### PR TITLE
Switch CI to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,9 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
-
-      - uses: astral-sh/setup-uv@v5
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Install dependencies
         run: uv sync
@@ -28,15 +22,9 @@ jobs:
         run: uv run ruff format --check .
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
-
-      - uses: astral-sh/setup-uv@v5
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary
- Switch CI jobs from `ubuntu-latest` to `self-hosted` runners
- Remove `setup-uv` and `setup-python` actions (pre-installed on host)
- 4 runners configured on deploy@2.56.122.47 as systemd services

## Test plan
- [ ] CI lint job passes on self-hosted runner
- [ ] CI type-check job passes on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)