### PR TITLE
Add state machine engine with DAG-based issue lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,14 @@ jobs:
 
       - name: Mypy
         run: uv run mypy src/
+
+  test:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,6 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
+        additional_dependencies:
+          - types-PyYAML>=6.0.12
+          - pytest>=9.0.2

--- a/docs/superpowers/plans/2026-03-22-state-machine-engine-test-scenarios.md
+++ b/docs/superpowers/plans/2026-03-22-state-machine-engine-test-scenarios.md
@@ -1,0 +1,1538 @@
+# State Machine Engine — Test Scenarios Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Comprehensive test coverage for the state machine engine, covering real-world workflows, edge cases, and error conditions beyond the basic happy-path tests in the implementation plan.
+
+**Architecture:** All tests exercise the public API (`reduce`, `parse_config`, `State`, events). Tests use deterministic ID generators and build state step-by-step through event sequences. No mocking — the reducer is pure.
+
+**Tech Stack:** Python 3.12, pytest
+
+**Spec:** `docs/superpowers/specs/2026-03-22-state-machine-engine-design.md`
+**Implementation Plan:** `docs/superpowers/plans/2026-03-22-state-machine-engine.md`
+
+**Prerequisite:** All tasks from the implementation plan must be completed first.
+
+---
+
+## File Structure
+
+```
+tests/engine/
+├── test_scenario_kanban.py           — classic kanban workflow
+├── test_scenario_pipeline.py         — CI/CD merge serialization
+├── test_scenario_decompose.py        — decomposition and unblock patterns
+├── test_scenario_queuing.py          — max_workers stress patterns
+├── test_scenario_edge_cases.py       — boundary and error conditions
+├── test_scenario_serialization.py    — state round-trip and persistence
+```
+
+---
+
+### Task 1: Classic Kanban Workflow
+
+**Files:**
+- Create: `tests/engine/test_scenario_kanban.py`
+
+Tests a typical `todo → implementing → review → done` pipeline with loops.
+
+- [ ] **Step 1: Write test — full happy path through 3 active states**
+
+An issue goes `todo → implementing → review → done` without any loops. Verify state, result_history, and effects at each step.
+
+```python
+# tests/engine/test_scenario_kanban.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerResultEvent,
+)
+
+KANBAN_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Description"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Implementation result"
+          values_description:
+            done: "Implementation complete"
+        summary:
+          type: string
+          description: "What was done"
+    on:
+      done: review
+
+  review:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [approved, rejected]
+          description: "Review result"
+          values_description:
+            approved: "Code approved"
+            rejected: "Changes requested"
+        feedback:
+          type: string
+          description: "Review feedback"
+    on:
+      approved: done
+      rejected: implementing
+
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+def test_full_happy_path() -> None:
+    config = parse_config(KANBAN_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # Create
+    state, effects = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature", "text": "Build it"}), gen)
+    assert state.issues["K-1"].state == "todo"
+    assert len(effects) == 0
+
+    # Advance to implementing
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+    assert state.issues["K-1"].state == "implementing"
+    assert state.issues["K-1"].worker_active is True
+
+    # Complete implementing
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": "Built it"}), gen)
+    assert state.issues["K-1"].state == "review"
+    assert state.issues["K-1"].worker_active is True
+    assert len(state.issues["K-1"].result_history) == 1
+
+    # Approve review
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "LGTM"}), gen)
+    assert state.issues["K-1"].state == "done"
+    assert state.issues["K-1"].worker_active is False
+    assert len(state.issues["K-1"].result_history) == 2
+```
+
+- [ ] **Step 2: Write test — review rejection loop (bounces 3 times)**
+
+Issue gets rejected at review, goes back to implementing, resubmits, rejected again, finally approved on third attempt. Verify result_history accumulates all attempts.
+
+```python
+def test_review_rejection_loop() -> None:
+    config = parse_config(KANBAN_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature", "text": "Build it"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+
+    for i in range(3):
+        # Implement
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": f"Attempt {i+1}"}), gen)
+        assert state.issues["K-1"].state == "review"
+
+        if i < 2:
+            # Reject
+            state, _ = reduce(config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "rejected", "feedback": f"Fix #{i+1}"}), gen)
+            assert state.issues["K-1"].state == "implementing"
+        else:
+            # Approve
+            state, _ = reduce(config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "Finally good"}), gen)
+            assert state.issues["K-1"].state == "done"
+
+    # 3 implementing results + 2 review rejections + 1 review approval = 6 history entries
+    assert len(state.issues["K-1"].result_history) == 6
+```
+
+- [ ] **Step 3: Write test — multiple issues in parallel**
+
+5 issues all in implementing simultaneously. All complete. Verify they don't interfere with each other.
+
+```python
+def test_parallel_issues() -> None:
+    config = parse_config(KANBAN_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    for i in range(5):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"K-{i}", fields={"title": f"Task {i}", "text": "..."}), gen)
+        state, _ = reduce(config, state, AdvanceEvent(issue_id=f"K-{i}", target_state="implementing"), gen)
+
+    # All should be in implementing with active workers
+    for i in range(5):
+        assert state.issues[f"K-{i}"].state == "implementing"
+        assert state.issues[f"K-{i}"].worker_active is True
+
+    # Complete them in reverse order
+    for i in range(4, -1, -1):
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=f"K-{i}", result={"outcome": "done", "summary": "ok"}), gen)
+        assert state.issues[f"K-{i}"].state == "review"
+
+    # Approve all
+    for i in range(5):
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=f"K-{i}", result={"outcome": "approved", "feedback": "ok"}), gen)
+        assert state.issues[f"K-{i}"].state == "done"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_kanban.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/engine/test_scenario_kanban.py
+git commit -m "test: add kanban workflow scenarios"
+```
+
+---
+
+### Task 2: CI/CD Pipeline with Merge Serialization
+
+**Files:**
+- Create: `tests/engine/test_scenario_pipeline.py`
+
+Tests the `implementing → qa → apply (max_workers:1) → done` pipeline with conflict handling.
+
+- [ ] **Step 1: Write test — 4 issues serialize through apply**
+
+4 issues pass through qa, enter apply one at a time, each merges successfully.
+
+```python
+# tests/engine/test_scenario_pipeline.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerResultEvent,
+)
+
+PIPELINE_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: qa
+
+  qa:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [passed, failed]
+          description: "QA result"
+          values_description:
+            passed: "Tests pass"
+            failed: "Tests fail"
+    on:
+      passed: apply
+      failed: implementing
+
+  apply:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [merged, conflict]
+          description: "Merge result"
+          values_description:
+            merged: "Merged"
+            conflict: "Conflict"
+    on:
+      merged: done
+      conflict: implementing
+
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+def _advance_to_apply(config: object, state: State, issue_id: str, gen: Callable[[], str]) -> tuple[State, list[object]]:
+    """Helper: advance issue through implementing and qa to apply."""
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state="implementing"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "done"}), gen)
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "passed"}), gen)
+    return state, effects
+
+
+def test_serialized_merge_4_issues() -> None:
+    config = parse_config(PIPELINE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # Create 4 issues
+    for i in range(4):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"P-{i}", fields={"title": f"Feature {i}"}), gen)
+
+    # All pass through implementing and qa
+    for i in range(4):
+        state, _ = _advance_to_apply(config, state, f"P-{i}", gen)
+
+    # Only P-0 should be active in apply, rest queued
+    assert state.issues["P-0"].worker_active is True
+    assert state.issues["P-0"].state == "apply"
+    for i in range(1, 4):
+        assert state.issues[f"P-{i}"].state == "apply"
+        assert state.issues[f"P-{i}"].worker_active is False
+
+    # Merge them one by one
+    for i in range(4):
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id=f"P-{i}", result={"outcome": "merged"}), gen)
+        assert state.issues[f"P-{i}"].state == "done"
+        if i < 3:
+            # Next issue should be dispatched
+            dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+            next_id = f"P-{i+1}"
+            assert any(e.issue_id == next_id for e in dispatch_effects)
+            assert state.issues[next_id].worker_active is True
+```
+
+- [ ] **Step 2: Write test — conflict sends issue back, queue advances**
+
+First issue in apply conflicts, goes back to implementing. Next issue in queue gets the slot.
+
+```python
+def test_conflict_frees_slot_for_next() -> None:
+    config = parse_config(PIPELINE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "A"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-2", fields={"title": "B"}), gen)
+
+    state, _ = _advance_to_apply(config, state, "P-1", gen)
+    state, _ = _advance_to_apply(config, state, "P-2", gen)
+
+    assert state.issues["P-1"].worker_active is True
+    assert state.issues["P-2"].worker_active is False
+
+    # P-1 conflicts — goes back to implementing, P-2 gets the slot
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+    assert state.issues["P-1"].state == "implementing"
+    assert state.issues["P-2"].worker_active is True
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert any(e.issue_id == "P-2" for e in dispatch_effects)
+```
+
+- [ ] **Step 3: Write test — issue re-enters apply queue after conflict and full cycle**
+
+Issue conflicts, goes through implementing → qa again, re-enters apply at the back of the queue.
+
+```python
+def test_conflict_reenter_at_back_of_queue() -> None:
+    config = parse_config(PIPELINE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "A"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-2", fields={"title": "B"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-3", fields={"title": "C"}), gen)
+
+    for pid in ["P-1", "P-2", "P-3"]:
+        state, _ = _advance_to_apply(config, state, pid, gen)
+
+    # P-1 active, P-2 and P-3 queued
+    assert state.issues["P-1"].worker_active is True
+
+    # P-1 conflicts
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+    assert state.issues["P-1"].state == "implementing"
+    assert state.issues["P-2"].worker_active is True
+
+    # P-1 goes back through implementing → qa → apply
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "done"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "passed"}), gen)
+    assert state.issues["P-1"].state == "apply"
+    assert state.issues["P-1"].worker_active is False  # P-2 still has the slot
+
+    # P-2 merges — P-3 should get slot (not P-1, which is behind P-3 in queue)
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-2", result={"outcome": "merged"}), gen)
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert any(e.issue_id == "P-3" for e in dispatch_effects)
+    assert state.issues["P-3"].worker_active is True
+    assert state.issues["P-1"].worker_active is False
+```
+
+- [ ] **Step 4: Write test — WorkerFailed retains slot, queue doesn't advance**
+
+```python
+def test_worker_failed_retains_slot() -> None:
+    config = parse_config(PIPELINE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "A"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-2", fields={"title": "B"}), gen)
+
+    state, _ = _advance_to_apply(config, state, "P-1", gen)
+    state, _ = _advance_to_apply(config, state, "P-2", gen)
+
+    from orca.engine.types import WorkerFailedEvent
+
+    # P-1 fails — slot retained
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="P-1", error="crash"), gen)
+    assert state.issues["P-1"].worker_active is True
+    assert state.issues["P-2"].worker_active is False
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert len(dispatch_effects) == 1
+    assert dispatch_effects[0].issue_id == "P-1"  # retry, not P-2
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_pipeline.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/engine/test_scenario_pipeline.py
+git commit -m "test: add CI/CD pipeline merge serialization scenarios"
+```
+
+---
+
+### Task 3: Decomposition and Unblock Patterns
+
+**Files:**
+- Create: `tests/engine/test_scenario_decompose.py`
+
+Tests decomposition at various depths, cascading unblock, and edge cases.
+
+- [ ] **Step 1: Write test — single-level decompose and unblock**
+
+Issue decomposes into 2 children. Both complete. Parent unblocks, worker re-runs, parent proceeds.
+
+```python
+# tests/engine/test_scenario_decompose.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerResultEvent,
+)
+
+DECOMPOSE_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Text"
+
+initial: todo
+
+states:
+  todo: {}
+
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "Scope result"
+          values_description:
+            ready: "Ready"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when: decompose
+          items: $issue
+          description: "Sub-issues"
+    on:
+      ready: implementing
+      decompose:
+        action: decompose
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+def _create_and_scope(config: object, state: State, issue_id: str, gen: Callable[[], str]) -> State:
+    state, _ = reduce(config, state, CreateEvent(issue_id=issue_id, fields={"title": "Root", "text": "Big task"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state="scoping"), gen)
+    return state
+
+
+def test_single_level_decompose_and_unblock() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "ROOT", gen)
+
+    # Decompose into 2 children
+    result = {
+        "outcome": "decompose",
+        "sub_issues": [
+            {"title": "Child A", "text": "First part"},
+            {"title": "Child B", "text": "Second part"},
+        ],
+    }
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result=result), gen)
+
+    root = state.issues["ROOT"]
+    assert root.blocked is True
+    assert len(root.children) == 2
+    child_a_id, child_b_id = root.children
+
+    # Children are in todo (initial, passive)
+    assert state.issues[child_a_id].state == "todo"
+    assert state.issues[child_a_id].parent == "ROOT"
+
+    # Process child A: todo → scoping → ready → implementing → done
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=child_a_id, target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_a_id, result={"outcome": "ready"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_a_id, result={"outcome": "done"}), gen)
+    assert state.issues[child_a_id].state == "done"
+    assert state.issues["ROOT"].blocked is True  # child B still not done
+
+    # Process child B
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=child_b_id, target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_b_id, result={"outcome": "ready"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_b_id, result={"outcome": "done"}), gen)
+
+    # Parent should be unblocked and re-dispatched
+    assert state.issues["ROOT"].blocked is False
+    assert state.issues["ROOT"].worker_active is True
+    assert state.issues["ROOT"].state == "scoping"  # still in scoping, re-running
+
+    # Scoping re-run: now returns ready
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}), gen)
+    assert state.issues["ROOT"].state == "implementing"
+```
+
+- [ ] **Step 2: Write test — 3-level deep cascading unblock**
+
+A → decomposes into B → decomposes into C. C finishes → B unblocks → B finishes → A unblocks.
+
+```python
+def test_three_level_cascading_unblock() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "L1", gen)
+
+    # L1 decomposes
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="L1", result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": "L2", "text": "Mid"}],
+    }), gen)
+    l2_id = state.issues["L1"].children[0]
+
+    # L2 enters scoping and decomposes
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=l2_id, target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": "L3", "text": "Leaf"}],
+    }), gen)
+    l3_id = state.issues[l2_id].children[0]
+
+    assert state.issues["L1"].blocked is True
+    assert state.issues[l2_id].blocked is True
+
+    # L3 completes
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=l3_id, target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=l3_id, result={"outcome": "ready"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=l3_id, result={"outcome": "done"}), gen)
+
+    # L2 should be unblocked, re-running scoping
+    assert state.issues[l2_id].blocked is False
+    assert state.issues[l2_id].worker_active is True
+    assert state.issues["L1"].blocked is True  # L2 not terminal yet
+
+    # L2 scoping re-run returns ready, then implementing completes
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "ready"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "done"}), gen)
+
+    # Now L1 should be unblocked
+    assert state.issues["L1"].blocked is False
+    assert state.issues["L1"].worker_active is True
+```
+
+- [ ] **Step 3: Write test — empty sub_issues list (edge case)**
+
+Worker returns decompose with empty list. Parent gets blocked with 0 children. All children terminal is vacuously true → instant unblock.
+
+```python
+def test_empty_decompose() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "ROOT", gen)
+
+    result = {"outcome": "decompose", "sub_issues": []}
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result=result), gen)
+
+    # With 0 children, "all children terminal" is vacuously true
+    # Parent should be unblocked immediately and re-dispatched
+    assert state.issues["ROOT"].children == []
+    assert state.issues["ROOT"].blocked is False
+    assert state.issues["ROOT"].worker_active is True
+```
+
+- [ ] **Step 4: Write test — massive fan-out (20 children)**
+
+```python
+def test_massive_fan_out() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "ROOT", gen)
+
+    sub_issues = [{"title": f"Sub {i}", "text": f"Part {i}"} for i in range(20)]
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={
+        "outcome": "decompose",
+        "sub_issues": sub_issues,
+    }), gen)
+
+    assert len(state.issues["ROOT"].children) == 20
+    assert state.issues["ROOT"].blocked is True
+
+    # Complete all children
+    for child_id in state.issues["ROOT"].children:
+        state, _ = reduce(config, state, AdvanceEvent(issue_id=child_id, target_state="scoping"), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen)
+
+    assert state.issues["ROOT"].blocked is False
+    assert state.issues["ROOT"].worker_active is True
+```
+
+- [ ] **Step 5: Write test — blocked issue rejects WorkerResult**
+
+```python
+def test_blocked_issue_rejects_worker_result() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "ROOT", gen)
+
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": "Child", "text": "..."}],
+    }), gen)
+
+    # Try to send WorkerResult to blocked parent
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert "blocked" in error_effects[0].message
+```
+
+- [ ] **Step 6: Write test — blocked issue rejects Advance**
+
+```python
+def test_blocked_issue_rejects_advance() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root", "text": "..."}), gen)
+    state.issues["ROOT"].blocked = True
+
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="ROOT", target_state="scoping"), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert "blocked" in error_effects[0].message
+```
+
+- [ ] **Step 7: Write test — dispatch context includes resolved children**
+
+After unblock, the DispatchWorker effect should include children with their result histories.
+
+```python
+def test_dispatch_includes_children_context() -> None:
+    config = parse_config(DECOMPOSE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state = _create_and_scope(config, state, "ROOT", gen)
+
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": "Child", "text": "Do it"}],
+    }), gen)
+    child_id = state.issues["ROOT"].children[0]
+
+    # Complete child
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=child_id, target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen)
+
+    # Find the dispatch for ROOT (re-run after unblock)
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect) and e.issue_id == "ROOT"]
+    assert len(dispatch_effects) == 1
+    children_data = dispatch_effects[0].issue["children"]
+    assert len(children_data) == 1
+    assert children_data[0]["issue_id"] == child_id
+    assert children_data[0]["state"] == "done"
+    assert len(children_data[0]["result_history"]) == 2
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_decompose.py -v`
+Expected: all PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/engine/test_scenario_decompose.py
+git commit -m "test: add decomposition and unblock scenarios"
+```
+
+---
+
+### Task 4: Max Workers and Queuing Stress
+
+**Files:**
+- Create: `tests/engine/test_scenario_queuing.py`
+
+Tests max_workers capacity limits, queue ordering, and interactions with other features.
+
+- [ ] **Step 1: Write test — 20 issues through max_workers:1 gate**
+
+```python
+# tests/engine/test_scenario_queuing.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+QUEUE_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: work
+
+states:
+  work:
+    max_workers: 3
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+def test_max_workers_respected() -> None:
+    config = parse_config(QUEUE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # Create 10 issues — initial state is active with max_workers: 3
+    for i in range(10):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"Q-{i}", fields={"title": f"Task {i}"}), gen)
+
+    # First 3 should be active, rest queued
+    active = [k for k, v in state.issues.items() if v.worker_active]
+    queued = [k for k, v in state.issues.items() if not v.worker_active]
+    assert len(active) == 3
+    assert len(queued) == 7
+
+    # Complete one — next in queue should activate
+    first_active = active[0]
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id=first_active, result={"outcome": "done"}), gen)
+    new_active = [k for k, v in state.issues.items() if v.worker_active and v.state == "work"]
+    assert len(new_active) == 3  # still 3 active
+```
+
+- [ ] **Step 2: Write test — worker failure doesn't affect queue**
+
+```python
+def test_worker_failure_retains_slot_in_capped_state() -> None:
+    config = parse_config(QUEUE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    for i in range(5):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"Q-{i}", fields={"title": f"Task {i}"}), gen)
+
+    active_before = sum(1 for v in state.issues.values() if v.worker_active)
+    assert active_before == 3
+
+    # Fail the first active worker 3 times
+    active_ids = [k for k, v in state.issues.items() if v.worker_active]
+    for _ in range(3):
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id=active_ids[0], error="crash"), gen)
+        assert state.issues[active_ids[0]].worker_active is True
+        active_now = sum(1 for v in state.issues.values() if v.worker_active)
+        assert active_now == 3  # unchanged
+```
+
+- [ ] **Step 3: Write test — sequential drain of entire queue**
+
+```python
+def test_sequential_drain() -> None:
+    """All 10 issues complete one by one as slots free up."""
+    config = parse_config(QUEUE_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    for i in range(10):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"Q-{i}", fields={"title": f"Task {i}"}), gen)
+
+    completed = 0
+    while completed < 10:
+        active_ids = [k for k, v in state.issues.items() if v.worker_active and v.state == "work"]
+        if not active_ids:
+            break
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=active_ids[0], result={"outcome": "done"}), gen)
+        completed += 1
+
+    assert completed == 10
+    assert all(v.state == "done" for v in state.issues.values())
+```
+
+- [ ] **Step 4: Write test — decompose fan-out respects max_workers on initial state**
+
+```python
+FANOUT_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Text"
+
+initial: work
+
+states:
+  work:
+    max_workers: 2
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done, decompose]
+          description: "Result"
+          values_description:
+            done: "Complete"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when: decompose
+          items: $issue
+          description: "Sub-issues"
+    on:
+      done: done
+      decompose:
+        action: decompose
+
+  done:
+    terminal: true
+"""
+
+
+def test_decompose_fanout_respects_max_workers() -> None:
+    config = parse_config(FANOUT_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root", "text": "Big"}), gen)
+    assert state.issues["ROOT"].worker_active is True
+
+    # Decompose into 5 children — initial state has max_workers: 2
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": f"Sub {i}", "text": f"Part {i}"} for i in range(5)],
+    }), gen)
+
+    active_children = [cid for cid in state.issues["ROOT"].children if state.issues[cid].worker_active]
+    queued_children = [cid for cid in state.issues["ROOT"].children if not state.issues[cid].worker_active]
+    assert len(active_children) == 2
+    assert len(queued_children) == 3
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_queuing.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/engine/test_scenario_queuing.py
+git commit -m "test: add max_workers and queuing stress scenarios"
+```
+
+---
+
+### Task 5: Edge Cases and Error Conditions
+
+**Files:**
+- Create: `tests/engine/test_scenario_edge_cases.py`
+
+Tests boundary conditions, invalid inputs, and unusual but valid configurations.
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/engine/test_scenario_edge_cases.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+# --- Minimal configs ---
+
+MINIMAL_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: work
+
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+PASSIVE_ONLY_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: backlog
+
+states:
+  backlog: {}
+  ready: {}
+  done:
+    terminal: true
+"""
+
+
+def test_minimal_single_state_machine() -> None:
+    """Simplest possible: work → done."""
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, effects = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Simple"}), gen)
+    assert state.issues["I-1"].state == "work"
+    assert state.issues["I-1"].worker_active is True
+
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    assert state.issues["I-1"].state == "done"
+
+
+def test_passive_to_passive_advance() -> None:
+    """Advance from one passive state to another."""
+    config = parse_config(PASSIVE_ONLY_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    assert state.issues["I-1"].state == "backlog"
+
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="ready"), gen)
+    assert state.issues["I-1"].state == "ready"
+    assert len(effects) == 0  # no worker to dispatch
+
+
+def test_advance_to_terminal() -> None:
+    """Advance from passive directly to terminal state."""
+    config = parse_config(PASSIVE_ONLY_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="done"), gen)
+    assert state.issues["I-1"].state == "done"
+
+
+def test_advance_to_same_state() -> None:
+    """Advance from passive state to itself — valid but no-op."""
+    config = parse_config(PASSIVE_ONLY_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="backlog"), gen)
+    assert state.issues["I-1"].state == "backlog"
+    assert len(effects) == 0
+
+
+def test_self_loop_state() -> None:
+    """State that transitions back to itself (iterative refinement)."""
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+initial: refine
+states:
+  refine:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [again, done]
+          description: "Result"
+          values_description:
+            again: "Needs more work"
+            done: "Finished"
+    on:
+      again: refine
+      done: done
+  done:
+    terminal: true
+"""
+    config = parse_config(yaml_str)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Iterate"}), gen)
+
+    # Loop 3 times
+    for i in range(3):
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "again"}), gen)
+        assert state.issues["I-1"].state == "refine"
+        assert state.issues["I-1"].worker_active is True
+
+    # Finish
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    assert state.issues["I-1"].state == "done"
+    assert len(state.issues["I-1"].result_history) == 4  # 3 agains + 1 done
+
+
+def test_duplicate_create_errors() -> None:
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "First"}), gen)
+    state, effects = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Duplicate"}), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert state.issues["I-1"].fields["title"] == "First"  # unchanged
+
+
+def test_worker_result_on_terminal_errors() -> None:
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    assert state.issues["I-1"].state == "done"
+
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_worker_result_unknown_outcome_errors() -> None:
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "invalid"}), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    # State should be unchanged
+    assert state.issues["I-1"].state == "work"
+    assert state.issues["I-1"].worker_active is True  # not freed since validation failed before mutation
+
+
+def test_double_worker_result_race_condition() -> None:
+    """Two WorkerResults for same issue — second should error because worker_active is False."""
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+
+    # First result succeeds
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+
+    # Second result should error (worker_active is False after first result)
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_events_on_nonexistent_issue() -> None:
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # All event types on nonexistent issue should error
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="NOPE", target_state="done"), gen)
+    assert any(isinstance(e, ErrorEffect) for e in effects)
+
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="NOPE", result={"outcome": "done"}), gen)
+    assert any(isinstance(e, ErrorEffect) for e in effects)
+
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="NOPE", error="x"), gen)
+    assert any(isinstance(e, ErrorEffect) for e in effects)
+
+
+def test_worker_failed_when_not_active_errors() -> None:
+    config = parse_config(MINIMAL_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task"}), gen)
+    state.issues["I-1"].worker_active = False  # simulate
+
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="I-1", error="crash"), gen)
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_edge_cases.py -v`
+Expected: all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/engine/test_scenario_edge_cases.py
+git commit -m "test: add edge case and error condition scenarios"
+```
+
+---
+
+### Task 6: Serialization Round-Trips
+
+**Files:**
+- Create: `tests/engine/test_scenario_serialization.py`
+
+Tests that state survives JSON serialization at various points in a workflow — simulating system restarts.
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/engine/test_scenario_serialization.py
+import json
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    State,
+    WorkerResultEvent,
+)
+
+KANBAN_CONFIG = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Description"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+
+def _counter(start: int = 0) -> Callable[[], str]:
+    n = start
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+def _roundtrip(state: State) -> State:
+    """Serialize to JSON and back."""
+    return State.from_dict(json.loads(json.dumps(state.to_dict())))
+
+
+def test_empty_state_roundtrip() -> None:
+    state = State(issues={}, worker_queues={})
+    restored = _roundtrip(state)
+    assert restored.issues == {}
+    assert restored.worker_queues == {}
+
+
+def test_mid_workflow_roundtrip() -> None:
+    """State survives serialization mid-workflow."""
+    config = parse_config(KANBAN_CONFIG)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Task", "text": "Do it"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), gen)
+
+    # Serialize and restore (simulating system restart)
+    state = _roundtrip(state)
+
+    # Continue processing on restored state
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    assert state.issues["I-1"].state == "done"
+    assert len(state.issues["I-1"].result_history) == 1
+
+
+def test_blocked_state_roundtrip() -> None:
+    """Blocked parent with children survives serialization."""
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Text"
+
+initial: todo
+
+states:
+  todo: {}
+
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "Result"
+          values_description:
+            ready: "Ready"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when: decompose
+          items: $issue
+          description: "Sub-issues"
+    on:
+      ready: done
+      decompose:
+        action: decompose
+
+  done:
+    terminal: true
+"""
+    config = parse_config(yaml_str)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "Parent", "text": "Big"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="P-1", target_state="scoping"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={
+        "outcome": "decompose",
+        "sub_issues": [{"title": "Child", "text": "Small"}],
+    }), gen)
+
+    # Serialize with blocked parent and child
+    state = _roundtrip(state)
+
+    child_id = state.issues["P-1"].children[0]
+    assert state.issues["P-1"].blocked is True
+    assert state.issues[child_id].parent == "P-1"
+    assert state.issues[child_id].state == "todo"
+
+
+def test_queue_order_survives_roundtrip() -> None:
+    """Worker queue FIFO order preserved across serialization."""
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: gate
+
+states:
+  gate:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+    config = parse_config(yaml_str)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # Create 5 issues — 1 active, 4 queued
+    for i in range(5):
+        state, _ = reduce(config, state, CreateEvent(issue_id=f"Q-{i}", fields={"title": f"Task {i}"}), gen)
+
+    assert state.issues["Q-0"].worker_active is True
+    queue_before = list(state.worker_queues.get("gate", []))
+
+    # Roundtrip
+    state = _roundtrip(state)
+
+    queue_after = list(state.worker_queues.get("gate", []))
+    assert queue_before == queue_after
+
+    # Complete Q-0 on restored state — next in queue should activate
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="Q-0", result={"outcome": "done"}), gen)
+    assert state.issues["Q-0"].state == "done"
+    assert state.issues[queue_before[0]].worker_active is True
+
+
+def test_deep_result_history_roundtrip() -> None:
+    """Issue with 10 result_history entries survives roundtrip."""
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+initial: loop
+states:
+  loop:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [again, done]
+          description: "Result"
+          values_description:
+            again: "Repeat"
+            done: "Complete"
+    on:
+      again: loop
+      done: done
+  done:
+    terminal: true
+"""
+    config = parse_config(yaml_str)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "Loop"}), gen)
+    for _ in range(10):
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "again"}), gen)
+
+    state = _roundtrip(state)
+
+    assert len(state.issues["I-1"].result_history) == 10
+    assert all(e.result["outcome"] == "again" for e in state.issues["I-1"].result_history)
+
+    # Can still finish after roundtrip
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    assert state.issues["I-1"].state == "done"
+    assert len(state.issues["I-1"].result_history) == 11
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/engine/test_scenario_serialization.py -v`
+Expected: all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/engine/test_scenario_serialization.py
+git commit -m "test: add state serialization round-trip scenarios"
+```
+
+---
+
+### Task 7: Full Suite Verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: all PASS
+
+- [ ] **Step 2: Run ruff and mypy**
+
+Run: `uv run ruff check . && uv run ruff format --check . && uv run mypy src/`
+Expected: all PASS
+
+- [ ] **Step 3: Commit any fixes if needed**

--- a/docs/superpowers/plans/2026-03-22-state-machine-engine.md
+++ b/docs/superpowers/plans/2026-03-22-state-machine-engine.md
@@ -1,0 +1,2399 @@
+# State Machine Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a pure reducer function that drives issue lifecycle through a user-defined state machine configured via `orca.yml`.
+
+**Architecture:** The engine is a pure function `reduce(config, state, event, generate_id) -> (new_state, effects)`. Config is parsed from YAML into typed dataclasses. State and events are typed dataclasses serializable to/from JSON. The reducer has no I/O — all side effects are returned as data objects.
+
+**Tech Stack:** Python 3.12, dataclasses, PyYAML, pytest
+
+**Spec:** `docs/superpowers/specs/2026-03-22-state-machine-engine-design.md`
+
+---
+
+## File Structure
+
+```
+src/orca/
+├── __init__.py                  (existing)
+├── py.typed                     (existing)
+├── engine/
+│   ├── __init__.py              — public API re-exports
+│   ├── types.py                 — all dataclasses: Config, State, Event, Effect, Issue
+│   ├── config.py                — YAML parsing + validation
+│   ├── reducer.py               — pure reduce() function
+│   └── dispatch.py              — dispatch protocol (max_workers, queuing)
+tests/
+├── __init__.py
+├── engine/
+│   ├── __init__.py
+│   ├── test_types.py            — serialization round-trips
+│   ├── test_config.py           — YAML parsing + validation rules
+│   ├── test_reducer_create.py   — Create event handling
+│   ├── test_reducer_advance.py  — Advance event handling
+│   ├── test_reducer_worker_result.py — WorkerResult: transitions, decompose, unblock
+│   ├── test_reducer_worker_failed.py — WorkerFailed event handling
+│   ├── test_dispatch.py         — max_workers, queuing, slot backfill
+│   └── conftest.py              — shared fixtures: sample configs, states, helper functions
+```
+
+---
+
+### Task 1: Project Setup — Add pytest and pyyaml Dependencies
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add dependencies**
+
+```bash
+uv add --dev pytest
+uv add pyyaml
+```
+
+- [ ] **Step 2: Verify pytest runs**
+
+Run: `uv run pytest --co -q`
+Expected: "no tests ran" (no test files yet)
+
+- [ ] **Step 3: Create directory structure**
+
+```bash
+mkdir -p src/orca/engine tests/engine
+touch src/orca/engine/__init__.py tests/__init__.py tests/engine/__init__.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/orca/engine/__init__.py tests/__init__.py tests/engine/__init__.py
+git commit -m "chore: add pytest, pyyaml, create engine and tests directories"
+```
+
+---
+
+### Task 2: Core Types — Dataclasses for Config, State, Events, Effects
+
+**Files:**
+- Create: `src/orca/engine/types.py`
+- Create: `tests/engine/test_types.py`
+
+- [ ] **Step 1: Write the failing test for type construction and serialization**
+
+```python
+# tests/engine/test_types.py
+import json
+from orca.engine.types import (
+    Issue,
+    State,
+    CreateEvent,
+    AdvanceEvent,
+    WorkerResultEvent,
+    WorkerFailedEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    FieldDef,
+    EnumFieldDef,
+    StringFieldDef,
+    ListFieldDef,
+    StateDef,
+    WorkerDef,
+    OnTransition,
+    OnDecompose,
+    StateMachineConfig,
+    ResultHistoryEntry,
+)
+
+
+def test_issue_construction() -> None:
+    issue = Issue(
+        fields={"title": "Test", "text": "Description"},
+        state="todo",
+        blocked=False,
+        worker_active=False,
+        parent=None,
+        children=[],
+        result_history=[],
+    )
+    assert issue.state == "todo"
+    assert issue.blocked is False
+    assert issue.worker_active is False
+
+
+def test_state_serialization_roundtrip() -> None:
+    state = State(
+        issues={
+            "ISSUE-1": Issue(
+                fields={"title": "Test"},
+                state="todo",
+                blocked=False,
+                worker_active=False,
+                parent=None,
+                children=[],
+                result_history=[],
+            )
+        },
+        worker_queues={},
+    )
+    data = state.to_dict()
+    json_str = json.dumps(data)
+    restored = State.from_dict(json.loads(json_str))
+    assert restored.issues["ISSUE-1"].fields == {"title": "Test"}
+    assert restored.issues["ISSUE-1"].state == "todo"
+    assert restored.worker_queues == {}
+
+
+def test_state_with_result_history_roundtrip() -> None:
+    entry = ResultHistoryEntry(state="implementing", result={"outcome": "done", "summary": "Built it"})
+    issue = Issue(
+        fields={"title": "Test"},
+        state="done",
+        blocked=False,
+        worker_active=False,
+        parent="PARENT-1",
+        children=[],
+        result_history=[entry],
+    )
+    state = State(issues={"ISSUE-1": issue}, worker_queues={})
+    data = state.to_dict()
+    restored = State.from_dict(data)
+    assert len(restored.issues["ISSUE-1"].result_history) == 1
+    assert restored.issues["ISSUE-1"].result_history[0].state == "implementing"
+    assert restored.issues["ISSUE-1"].result_history[0].result["outcome"] == "done"
+
+
+def test_state_with_worker_queues_roundtrip() -> None:
+    state = State(
+        issues={},
+        worker_queues={"apply": ["ISSUE-2", "ISSUE-3"]},
+    )
+    data = state.to_dict()
+    restored = State.from_dict(data)
+    assert restored.worker_queues == {"apply": ["ISSUE-2", "ISSUE-3"]}
+
+
+def test_create_event() -> None:
+    event = CreateEvent(issue_id="ISSUE-1", fields={"title": "Test"})
+    assert event.issue_id == "ISSUE-1"
+
+
+def test_advance_event() -> None:
+    event = AdvanceEvent(issue_id="ISSUE-1", target_state="implementing")
+    assert event.target_state == "implementing"
+
+
+def test_worker_result_event() -> None:
+    event = WorkerResultEvent(issue_id="ISSUE-1", result={"outcome": "done"})
+    assert event.result["outcome"] == "done"
+
+
+def test_worker_failed_event() -> None:
+    event = WorkerFailedEvent(issue_id="ISSUE-1", error="timeout")
+    assert event.error == "timeout"
+
+
+def test_dispatch_worker_effect() -> None:
+    effect = DispatchWorkerEffect(
+        issue_id="ISSUE-1",
+        state="implementing",
+        result_format={"outcome": {"type": "enum", "values": ["done"]}},
+        issue={"fields": {"title": "Test"}, "result_history": [], "parent": None, "children": []},
+    )
+    assert effect.state == "implementing"
+
+
+def test_error_effect() -> None:
+    effect = ErrorEffect(issue_id="ISSUE-1", message="blocked")
+    assert effect.message == "blocked"
+
+
+def test_config_types() -> None:
+    enum_field = EnumFieldDef(
+        values=["ready", "decompose"],
+        description="outcome",
+        values_description={"ready": "ready", "decompose": "split"},
+    )
+    assert enum_field.values == ["ready", "decompose"]
+
+    string_field = StringFieldDef(description="summary")
+    assert string_field.description == "summary"
+
+    list_field = ListFieldDef(description="sub-issues", items="$issue", required_when=["decompose"])
+    assert list_field.items == "$issue"
+
+    worker = WorkerDef(result_format={"outcome": enum_field, "summary": string_field})
+    assert "outcome" in worker.result_format
+
+    on_transition = OnTransition(target="implementing")
+    assert on_transition.target == "implementing"
+
+    on_decompose = OnDecompose()
+    assert isinstance(on_decompose, OnDecompose)
+
+    state_def = StateDef(worker=worker, on={"ready": on_transition, "decompose": on_decompose})
+    assert state_def.worker is not None
+
+    passive_def = StateDef()
+    assert passive_def.worker is None
+    assert passive_def.terminal is False
+
+    terminal_def = StateDef(terminal=True)
+    assert terminal_def.terminal is True
+
+    field_def = FieldDef(type="string", description="title")
+    config = StateMachineConfig(
+        issue_fields={"title": field_def},
+        initial="todo",
+        states={"todo": passive_def, "implementing": state_def, "done": terminal_def},
+    )
+    assert config.initial == "todo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_types.py -v`
+Expected: FAIL with ImportError
+
+- [ ] **Step 3: Implement types**
+
+```python
+# src/orca/engine/types.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# --- Config types ---
+
+
+@dataclass(frozen=True)
+class FieldDef:
+    type: str
+    description: str
+
+
+@dataclass(frozen=True)
+class EnumFieldDef:
+    values: list[str]
+    description: str
+    values_description: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StringFieldDef:
+    description: str
+    required_when: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ListFieldDef:
+    description: str
+    items: str
+    required_when: list[str] = field(default_factory=list)
+
+
+ResultFormatField = EnumFieldDef | StringFieldDef | ListFieldDef
+
+
+@dataclass(frozen=True)
+class WorkerDef:
+    result_format: dict[str, ResultFormatField]
+
+
+@dataclass(frozen=True)
+class OnTransition:
+    target: str
+
+
+@dataclass(frozen=True)
+class OnDecompose:
+    pass
+
+
+OnRule = OnTransition | OnDecompose
+
+
+@dataclass(frozen=True)
+class StateDef:
+    worker: WorkerDef | None = None
+    on: dict[str, OnRule] = field(default_factory=dict)
+    terminal: bool = False
+    max_workers: int | None = None
+
+
+@dataclass(frozen=True)
+class StateMachineConfig:
+    issue_fields: dict[str, FieldDef]
+    initial: str
+    states: dict[str, StateDef]
+
+
+# --- Runtime state types ---
+
+
+@dataclass
+class ResultHistoryEntry:
+    state: str
+    result: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"state": self.state, "result": self.result}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResultHistoryEntry:
+        return cls(state=data["state"], result=data["result"])
+
+
+@dataclass
+class Issue:
+    fields: dict[str, Any]
+    state: str
+    blocked: bool
+    worker_active: bool
+    parent: str | None
+    children: list[str]
+    result_history: list[ResultHistoryEntry]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fields": self.fields,
+            "state": self.state,
+            "blocked": self.blocked,
+            "worker_active": self.worker_active,
+            "parent": self.parent,
+            "children": self.children,
+            "result_history": [e.to_dict() for e in self.result_history],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Issue:
+        return cls(
+            fields=data["fields"],
+            state=data["state"],
+            blocked=data["blocked"],
+            worker_active=data["worker_active"],
+            parent=data["parent"],
+            children=data["children"],
+            result_history=[ResultHistoryEntry.from_dict(e) for e in data["result_history"]],
+        )
+
+
+@dataclass
+class State:
+    issues: dict[str, Issue]
+    worker_queues: dict[str, list[str]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issues": {k: v.to_dict() for k, v in self.issues.items()},
+            "worker_queues": self.worker_queues,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> State:
+        return cls(
+            issues={k: Issue.from_dict(v) for k, v in data["issues"].items()},
+            worker_queues=data.get("worker_queues", {}),
+        )
+
+
+# --- Events ---
+
+
+@dataclass(frozen=True)
+class CreateEvent:
+    issue_id: str
+    fields: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AdvanceEvent:
+    issue_id: str
+    target_state: str
+
+
+@dataclass(frozen=True)
+class WorkerResultEvent:
+    issue_id: str
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WorkerFailedEvent:
+    issue_id: str
+    error: str
+
+
+Event = CreateEvent | AdvanceEvent | WorkerResultEvent | WorkerFailedEvent
+
+
+# --- Effects ---
+
+
+@dataclass(frozen=True)
+class DispatchWorkerEffect:
+    issue_id: str
+    state: str
+    result_format: dict[str, Any]
+    issue: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ErrorEffect:
+    issue_id: str
+    message: str
+
+
+Effect = DispatchWorkerEffect | ErrorEffect
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_types.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run ruff and mypy**
+
+Run: `uv run ruff check src/orca/engine/types.py tests/engine/test_types.py && uv run mypy src/orca/engine/types.py tests/engine/test_types.py`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/types.py tests/engine/test_types.py
+git commit -m "feat: add core type definitions for state machine engine"
+```
+
+---
+
+### Task 3: Config Parsing — YAML to StateMachineConfig
+
+**Files:**
+- Create: `src/orca/engine/config.py`
+- Create: `tests/engine/test_config.py`
+- Create: `tests/engine/conftest.py`
+
+- [ ] **Step 1: Write conftest with shared YAML fixtures**
+
+```python
+# tests/engine/conftest.py
+import pytest
+
+
+SIMPLE_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Short title"
+    text:
+      type: string
+      description: "Description"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+        summary:
+          type: string
+          description: "Summary"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+DECOMPOSE_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+    text:
+      type: string
+      description: "Text"
+
+initial: todo
+
+states:
+  todo: {}
+
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "Scope result"
+          values_description:
+            ready: "Ready"
+            decompose: "Needs split"
+        sub_issues:
+          type: list
+          required_when: decompose
+          items: $issue
+          description: "Sub-issues"
+    on:
+      ready: implementing
+      decompose:
+        action: decompose
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+
+  done:
+    terminal: true
+"""
+
+MAX_WORKERS_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "Title"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: apply
+
+  apply:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [merged, conflict]
+          description: "Merge result"
+          values_description:
+            merged: "Merged"
+            conflict: "Conflict"
+    on:
+      merged: done
+      conflict: implementing
+
+  done:
+    terminal: true
+"""
+
+
+@pytest.fixture
+def simple_config_yaml() -> str:
+    return SIMPLE_CONFIG_YAML
+
+
+@pytest.fixture
+def decompose_config_yaml() -> str:
+    return DECOMPOSE_CONFIG_YAML
+
+
+@pytest.fixture
+def max_workers_config_yaml() -> str:
+    return MAX_WORKERS_CONFIG_YAML
+```
+
+- [ ] **Step 2: Write failing tests for config parsing and validation**
+
+```python
+# tests/engine/test_config.py
+import pytest
+from orca.engine.config import parse_config, ConfigValidationError
+from orca.engine.types import OnTransition, OnDecompose, EnumFieldDef, StringFieldDef, ListFieldDef
+
+
+def test_parse_simple_config(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    assert config.initial == "todo"
+    assert "todo" in config.states
+    assert "implementing" in config.states
+    assert "done" in config.states
+    assert config.states["done"].terminal is True
+    assert config.states["todo"].worker is None
+    assert config.states["implementing"].worker is not None
+    worker = config.states["implementing"].worker
+    assert isinstance(worker.result_format["outcome"], EnumFieldDef)
+    assert isinstance(worker.result_format["summary"], StringFieldDef)
+    on = config.states["implementing"].on
+    assert isinstance(on["done"], OnTransition)
+    assert on["done"].target == "done"
+
+
+def test_parse_decompose_config(decompose_config_yaml: str) -> None:
+    config = parse_config(decompose_config_yaml)
+    scoping = config.states["scoping"]
+    assert scoping.worker is not None
+    assert isinstance(scoping.on["decompose"], OnDecompose)
+    assert isinstance(scoping.on["ready"], OnTransition)
+    sub_issues_field = scoping.worker.result_format["sub_issues"]
+    assert isinstance(sub_issues_field, ListFieldDef)
+    assert sub_issues_field.items == "$issue"
+    assert sub_issues_field.required_when == ["decompose"]
+
+
+def test_parse_max_workers_config(max_workers_config_yaml: str) -> None:
+    config = parse_config(max_workers_config_yaml)
+    assert config.states["apply"].max_workers == 1
+    assert config.states["implementing"].max_workers is None
+
+
+def test_issue_fields_parsed(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    assert "title" in config.issue_fields
+    assert config.issue_fields["title"].type == "string"
+
+
+def test_validation_initial_references_existing_state() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: nonexistent
+states:
+  todo: {}
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="initial.*nonexistent"):
+        parse_config(yaml_str)
+
+
+def test_validation_on_target_references_existing_state() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: todo
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "r"
+    on:
+      done: nonexistent
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="nonexistent"):
+        parse_config(yaml_str)
+
+
+def test_validation_on_key_matches_outcome_values() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "r"
+    on:
+      invalid_key: done
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="invalid_key"):
+        parse_config(yaml_str)
+
+
+def test_validation_active_state_requires_outcome() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        summary:
+          type: string
+          description: "s"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="outcome"):
+        parse_config(yaml_str)
+
+
+def test_validation_terminal_state_no_worker() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: todo
+states:
+  todo: {}
+  done:
+    terminal: true
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [x]
+          description: "r"
+    on:
+      x: todo
+"""
+    with pytest.raises(ConfigValidationError, match="terminal.*worker"):
+        parse_config(yaml_str)
+
+
+def test_validation_at_least_one_terminal() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: todo
+states:
+  todo: {}
+"""
+    with pytest.raises(ConfigValidationError, match="terminal"):
+        parse_config(yaml_str)
+
+
+def test_validation_decompose_requires_sub_issues() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "r"
+    on:
+      ready: done
+      decompose:
+        action: decompose
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="sub_issues"):
+        parse_config(yaml_str)
+
+
+def test_validation_max_workers_positive() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: work
+states:
+  work:
+    max_workers: 0
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "r"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+    with pytest.raises(ConfigValidationError, match="max_workers.*positive"):
+        parse_config(yaml_str)
+
+
+def test_validation_required_when_as_string(decompose_config_yaml: str) -> None:
+    """required_when should be normalized to a list even when given as a string."""
+    config = parse_config(decompose_config_yaml)
+    sub_issues = config.states["scoping"].worker.result_format["sub_issues"]
+    assert isinstance(sub_issues, ListFieldDef)
+    assert sub_issues.required_when == ["decompose"]
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_config.py -v`
+Expected: FAIL with ImportError
+
+- [ ] **Step 4: Implement config parsing**
+
+```python
+# src/orca/engine/config.py
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from orca.engine.types import (
+    EnumFieldDef,
+    FieldDef,
+    ListFieldDef,
+    OnDecompose,
+    OnRule,
+    OnTransition,
+    ResultFormatField,
+    StateDef,
+    StateMachineConfig,
+    StringFieldDef,
+    WorkerDef,
+)
+
+
+class ConfigValidationError(Exception):
+    pass
+
+
+def parse_config(yaml_str: str) -> StateMachineConfig:
+    raw = yaml.safe_load(yaml_str)
+    issue_fields = _parse_issue_fields(raw["issue"]["fields"])
+    initial = raw["initial"]
+    states = {name: _parse_state_def(name, data) for name, data in raw["states"].items()}
+    config = StateMachineConfig(issue_fields=issue_fields, initial=initial, states=states)
+    _validate(config)
+    return config
+
+
+def _parse_issue_fields(raw: dict[str, Any]) -> dict[str, FieldDef]:
+    return {name: FieldDef(type=data["type"], description=data["description"]) for name, data in raw.items()}
+
+
+def _parse_state_def(name: str, data: Any) -> StateDef:
+    if data is None:
+        data = {}
+    if isinstance(data, dict) and data.get("terminal"):
+        if "worker" in data or "on" in data:
+            raise ConfigValidationError(f"State '{name}': terminal state cannot have worker or on")
+        return StateDef(terminal=True)
+    if "worker" not in data:
+        return StateDef()
+    worker = _parse_worker_def(data["worker"])
+    on = _parse_on_rules(data.get("on", {}))
+    max_workers = data.get("max_workers")
+    return StateDef(worker=worker, on=on, max_workers=max_workers)
+
+
+def _parse_worker_def(raw: dict[str, Any]) -> WorkerDef:
+    result_format: dict[str, ResultFormatField] = {}
+    for field_name, field_data in raw["result_format"].items():
+        result_format[field_name] = _parse_result_format_field(field_data)
+    return WorkerDef(result_format=result_format)
+
+
+def _parse_result_format_field(data: dict[str, Any]) -> ResultFormatField:
+    field_type = data["type"]
+    required_when_raw = data.get("required_when")
+    required_when: list[str] = []
+    if isinstance(required_when_raw, str):
+        required_when = [required_when_raw]
+    elif isinstance(required_when_raw, list):
+        required_when = required_when_raw
+
+    if field_type == "enum":
+        return EnumFieldDef(
+            values=data["values"],
+            description=data["description"],
+            values_description=data.get("values_description", {}),
+        )
+    elif field_type == "string":
+        return StringFieldDef(description=data["description"], required_when=required_when)
+    elif field_type == "list":
+        return ListFieldDef(
+            description=data["description"],
+            items=data["items"],
+            required_when=required_when,
+        )
+    else:
+        raise ConfigValidationError(f"Unknown field type: {field_type}")
+
+
+def _parse_on_rules(raw: dict[str, Any]) -> dict[str, OnRule]:
+    rules: dict[str, OnRule] = {}
+    for key, value in raw.items():
+        if isinstance(value, str):
+            rules[key] = OnTransition(target=value)
+        elif isinstance(value, dict) and value.get("action") == "decompose":
+            rules[key] = OnDecompose()
+        else:
+            raise ConfigValidationError(f"Invalid on rule for '{key}': {value}")
+    return rules
+
+
+def _validate(config: StateMachineConfig) -> None:
+    # Rule 1: initial references existing state
+    if config.initial not in config.states:
+        raise ConfigValidationError(f"initial state '{config.initial}' does not exist in states")
+
+    # Rule 6: at least one terminal
+    terminal_states = [name for name, s in config.states.items() if s.terminal]
+    if not terminal_states:
+        raise ConfigValidationError("At least one terminal state must exist")
+
+    for name, state_def in config.states.items():
+        if state_def.terminal:
+            # Rule 5: terminal has no worker or on
+            if state_def.worker is not None or state_def.on:
+                raise ConfigValidationError(f"State '{name}': terminal state cannot have worker or on")
+            continue
+
+        if state_def.worker is None:
+            # Passive state
+            continue
+
+        # Rule 4: active state must have outcome enum
+        if "outcome" not in state_def.worker.result_format:
+            raise ConfigValidationError(f"State '{name}': active state must have 'outcome' in result_format")
+        outcome_field = state_def.worker.result_format["outcome"]
+        if not isinstance(outcome_field, EnumFieldDef):
+            raise ConfigValidationError(f"State '{name}': 'outcome' must be of type enum")
+
+        outcome_values = outcome_field.values
+
+        for on_key, on_rule in state_def.on.items():
+            # Rule 3: on key matches outcome values
+            if on_key not in outcome_values:
+                raise ConfigValidationError(
+                    f"State '{name}': on key '{on_key}' not in outcome values {outcome_values}"
+                )
+            # Rule 2: on target references existing state
+            if isinstance(on_rule, OnTransition) and on_rule.target not in config.states:
+                raise ConfigValidationError(
+                    f"State '{name}': on target '{on_rule.target}' does not exist in states"
+                )
+            # Rule 7: decompose requires sub_issues with items: $issue
+            if isinstance(on_rule, OnDecompose):
+                has_sub_issues = False
+                for rf_name, rf_field in state_def.worker.result_format.items():
+                    if rf_name == "sub_issues" and isinstance(rf_field, ListFieldDef) and rf_field.items == "$issue":
+                        has_sub_issues = True
+                        break
+                if not has_sub_issues:
+                    raise ConfigValidationError(
+                        f"State '{name}': action decompose requires 'sub_issues' field with items: $issue"
+                    )
+
+        # Rule 9: max_workers positive
+        if state_def.max_workers is not None and state_def.max_workers < 1:
+            raise ConfigValidationError(f"State '{name}': max_workers must be a positive integer")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_config.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Run ruff and mypy**
+
+Run: `uv run ruff check src/orca/engine/config.py tests/engine/test_config.py && uv run mypy src/orca/engine/config.py`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/orca/engine/config.py tests/engine/test_config.py tests/engine/conftest.py
+git commit -m "feat: add config parsing and validation for orca.yml"
+```
+
+---
+
+### Task 4: Dispatch Protocol — max_workers and Queuing Logic
+
+**Files:**
+- Create: `src/orca/engine/dispatch.py`
+- Create: `tests/engine/test_dispatch.py`
+
+- [ ] **Step 1: Write failing tests for dispatch protocol**
+
+```python
+# tests/engine/test_dispatch.py
+from orca.engine.types import (
+    Issue,
+    State,
+    StateDef,
+    WorkerDef,
+    EnumFieldDef,
+    StateMachineConfig,
+    FieldDef,
+    DispatchWorkerEffect,
+)
+from orca.engine.dispatch import try_dispatch, backfill_queue
+
+
+def _make_config(max_workers: int | None = None) -> StateMachineConfig:
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="t")},
+        initial="todo",
+        states={
+            "todo": StateDef(),
+            "work": StateDef(
+                max_workers=max_workers,
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["done"], description="r", values_description={"done": "d"})
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+def _make_issue(state: str, worker_active: bool = False) -> Issue:
+    return Issue(
+        fields={"title": "test"},
+        state=state,
+        blocked=False,
+        worker_active=worker_active,
+        parent=None,
+        children=[],
+        result_history=[],
+    )
+
+
+def test_dispatch_no_limit() -> None:
+    config = _make_config(max_workers=None)
+    state = State(issues={"I-1": _make_issue("work")}, worker_queues={})
+    effects: list[DispatchWorkerEffect] = []
+    try_dispatch(config, state, "I-1", effects)
+    assert len(effects) == 1
+    assert state.issues["I-1"].worker_active is True
+
+
+def test_dispatch_under_limit() -> None:
+    config = _make_config(max_workers=2)
+    state = State(issues={"I-1": _make_issue("work"), "I-2": _make_issue("work")}, worker_queues={})
+    effects: list[DispatchWorkerEffect] = []
+    try_dispatch(config, state, "I-1", effects)
+    assert len(effects) == 1
+    assert state.issues["I-1"].worker_active is True
+
+
+def test_dispatch_at_limit_queues() -> None:
+    config = _make_config(max_workers=1)
+    i1 = _make_issue("work", worker_active=True)
+    i2 = _make_issue("work")
+    state = State(issues={"I-1": i1, "I-2": i2}, worker_queues={})
+    effects: list[DispatchWorkerEffect] = []
+    try_dispatch(config, state, "I-2", effects)
+    assert len(effects) == 0
+    assert state.issues["I-2"].worker_active is False
+    assert state.worker_queues["work"] == ["I-2"]
+
+
+def test_backfill_dispatches_next_in_queue() -> None:
+    config = _make_config(max_workers=1)
+    i1 = _make_issue("work", worker_active=False)  # just finished
+    i2 = _make_issue("work")
+    i3 = _make_issue("work")
+    state = State(issues={"I-1": i1, "I-2": i2, "I-3": i3}, worker_queues={"work": ["I-2", "I-3"]})
+    effects: list[DispatchWorkerEffect] = []
+    backfill_queue(config, state, "work", effects)
+    assert len(effects) == 1
+    assert effects[0].issue_id == "I-2"
+    assert state.issues["I-2"].worker_active is True
+    assert state.worker_queues["work"] == ["I-3"]
+
+
+def test_backfill_skips_blocked() -> None:
+    config = _make_config(max_workers=1)
+    i1 = _make_issue("work")
+    i1.blocked = True
+    i2 = _make_issue("work")
+    state = State(issues={"I-1": i1, "I-2": i2}, worker_queues={"work": ["I-1", "I-2"]})
+    effects: list[DispatchWorkerEffect] = []
+    backfill_queue(config, state, "work", effects)
+    assert len(effects) == 1
+    assert effects[0].issue_id == "I-2"
+
+
+def test_dispatch_includes_resolved_children() -> None:
+    config = _make_config(max_workers=None)
+    parent = _make_issue("work")
+    parent.children = ["I-2"]
+    child = _make_issue("done")
+    child.parent = "I-1"
+    child.result_history = []
+    state = State(issues={"I-1": parent, "I-2": child}, worker_queues={})
+    effects: list[DispatchWorkerEffect] = []
+    try_dispatch(config, state, "I-1", effects)
+    assert len(effects) == 1
+    children_data = effects[0].issue["children"]
+    assert len(children_data) == 1
+    assert children_data[0]["issue_id"] == "I-2"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_dispatch.py -v`
+Expected: FAIL with ImportError
+
+- [ ] **Step 3: Implement dispatch protocol**
+
+```python
+# src/orca/engine/dispatch.py
+from __future__ import annotations
+
+from typing import Any
+
+from orca.engine.types import (
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    Issue,
+    ListFieldDef,
+    State,
+    StateMachineConfig,
+    StringFieldDef,
+)
+
+
+def build_issue_context(state: State, issue_id: str) -> dict[str, Any]:
+    issue = state.issues[issue_id]
+    children_data: list[dict[str, Any]] = []
+    for child_id in issue.children:
+        child = state.issues[child_id]
+        children_data.append(
+            {
+                "issue_id": child_id,
+                "fields": child.fields,
+                "state": child.state,
+                "result_history": [e.to_dict() for e in child.result_history],
+            }
+        )
+    return {
+        "fields": issue.fields,
+        "result_history": [e.to_dict() for e in issue.result_history],
+        "parent": issue.parent,
+        "children": children_data,
+    }
+
+
+def build_result_format(config: StateMachineConfig, state_name: str) -> dict[str, Any]:
+    state_def = config.states[state_name]
+    assert state_def.worker is not None
+    result: dict[str, Any] = {}
+    for name, field in state_def.worker.result_format.items():
+        if isinstance(field, EnumFieldDef):
+            entry: dict[str, Any] = {
+                "type": "enum",
+                "values": field.values,
+                "description": field.description,
+            }
+            if field.values_description:
+                entry["values_description"] = field.values_description
+            result[name] = entry
+        elif isinstance(field, ListFieldDef):
+            result[name] = {"type": "list", "description": field.description, "items": field.items}
+        elif isinstance(field, StringFieldDef):
+            result[name] = {"type": "string", "description": field.description}
+    return result
+
+
+def count_active_workers(state: State, state_name: str) -> int:
+    return sum(1 for issue in state.issues.values() if issue.state == state_name and issue.worker_active)
+
+
+def try_dispatch(
+    config: StateMachineConfig,
+    state: State,
+    issue_id: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    issue = state.issues[issue_id]
+    state_name = issue.state
+    state_def = config.states[state_name]
+
+    if state_def.worker is None:
+        return
+
+    max_w = state_def.max_workers
+    if max_w is not None and count_active_workers(state, state_name) >= max_w:
+        # Queue the issue
+        if state_name not in state.worker_queues:
+            state.worker_queues[state_name] = []
+        if issue_id not in state.worker_queues[state_name]:
+            state.worker_queues[state_name].append(issue_id)
+        return
+
+    issue.worker_active = True
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=issue_id,
+            state=state_name,
+            result_format=_build_result_format(config, state_name),
+            issue=_build_issue_context(state, issue_id),
+        )
+    )
+
+
+def backfill_queue(
+    config: StateMachineConfig,
+    state: State,
+    state_name: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    if state_name not in state.worker_queues:
+        return
+    queue = state.worker_queues[state_name]
+    while queue:
+        candidate_id = queue[0]
+        if candidate_id not in state.issues:
+            queue.pop(0)
+            continue
+        candidate = state.issues[candidate_id]
+        if candidate.blocked or candidate.state != state_name:
+            queue.pop(0)
+            continue
+        queue.pop(0)
+        try_dispatch(config, state, candidate_id, effects)
+        return
+    # Clean up empty queue
+    if not queue:
+        del state.worker_queues[state_name]
+
+
+def remove_from_queue(state: State, state_name: str, issue_id: str) -> None:
+    if state_name in state.worker_queues and issue_id in state.worker_queues[state_name]:
+        state.worker_queues[state_name].remove(issue_id)
+        if not state.worker_queues[state_name]:
+            del state.worker_queues[state_name]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_dispatch.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run ruff and mypy**
+
+Run: `uv run ruff check src/orca/engine/dispatch.py tests/engine/test_dispatch.py && uv run mypy src/orca/engine/dispatch.py`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/dispatch.py tests/engine/test_dispatch.py
+git commit -m "feat: add dispatch protocol with max_workers and queuing"
+```
+
+---
+
+### Task 5: Reducer — Create Event
+
+**Files:**
+- Create: `src/orca/engine/reducer.py`
+- Create: `tests/engine/test_reducer_create.py`
+
+- [ ] **Step 1: Write failing tests for Create event**
+
+```python
+# tests/engine/test_reducer_create.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+)
+from orca.engine.reducer import reduce
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def test_create_issue_in_passive_initial(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    event = CreateEvent(issue_id="I-1", fields={"title": "Test", "text": "Desc"})
+    new_state, effects = reduce(config, state, event, _counter())
+    assert "I-1" in new_state.issues
+    issue = new_state.issues["I-1"]
+    assert issue.state == "todo"
+    assert issue.blocked is False
+    assert issue.worker_active is False
+    assert issue.parent is None
+    assert issue.children == []
+    assert issue.result_history == []
+    assert issue.fields == {"title": "Test", "text": "Desc"}
+    # Passive initial state — no dispatch
+    assert len(effects) == 0
+
+
+def test_create_issue_in_active_initial() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "r"
+          values_description:
+            done: "d"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+    config = parse_config(yaml_str)
+    state = State(issues={}, worker_queues={})
+    event = CreateEvent(issue_id="I-1", fields={"title": "Test"})
+    new_state, effects = reduce(config, state, event, _counter())
+    assert new_state.issues["I-1"].worker_active is True
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert len(dispatch_effects) == 1
+    assert dispatch_effects[0].issue_id == "I-1"
+
+
+def test_create_duplicate_issue_id(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    event = CreateEvent(issue_id="I-1", fields={"title": "Test", "text": "Desc"})
+    state, _ = reduce(config, state, event, _counter())
+    # Try to create again with same ID
+    state2, effects = reduce(config, state, event, _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert "already exists" in error_effects[0].message
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_reducer_create.py -v`
+Expected: FAIL with ImportError
+
+- [ ] **Step 3: Implement reducer with Create event support**
+
+```python
+# src/orca/engine/reducer.py
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any
+
+from orca.engine.dispatch import backfill_queue, build_issue_context, build_result_format, remove_from_queue, try_dispatch
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    Effect,
+    ErrorEffect,
+    Event,
+    Issue,
+    OnDecompose,
+    OnTransition,
+    ResultHistoryEntry,
+    State,
+    StateMachineConfig,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+def reduce(
+    config: StateMachineConfig,
+    state: State,
+    event: Event,
+    generate_id: Callable[[], str],
+) -> tuple[State, list[Effect]]:
+    new_state = copy.deepcopy(state)
+    effects: list[Effect] = []
+
+    if isinstance(event, CreateEvent):
+        _handle_create(config, new_state, event, effects)
+    elif isinstance(event, AdvanceEvent):
+        _handle_advance(config, new_state, event, effects)
+    elif isinstance(event, WorkerResultEvent):
+        _handle_worker_result(config, new_state, event, effects, generate_id)
+    elif isinstance(event, WorkerFailedEvent):
+        _handle_worker_failed(config, new_state, event, effects)
+
+    return new_state, effects
+
+
+def _handle_create(
+    config: StateMachineConfig,
+    state: State,
+    event: CreateEvent,
+    effects: list[Effect],
+) -> None:
+    if event.issue_id in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' already exists"))
+        return
+
+    issue = Issue(
+        fields=event.fields,
+        state=config.initial,
+        blocked=False,
+        worker_active=False,
+        parent=None,
+        children=[],
+        result_history=[],
+    )
+    state.issues[event.issue_id] = issue
+
+    initial_def = config.states[config.initial]
+    if initial_def.worker is not None:
+        dispatch_effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, event.issue_id, dispatch_effects)
+        effects.extend(dispatch_effects)
+
+
+def _handle_advance(
+    config: StateMachineConfig,
+    state: State,
+    event: AdvanceEvent,
+    effects: list[Effect],
+) -> None:
+    pass  # Implemented in Task 6
+
+
+def _handle_worker_result(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerResultEvent,
+    effects: list[Effect],
+    generate_id: Callable[[], str],
+) -> None:
+    pass  # Implemented in Task 7
+
+
+def _handle_worker_failed(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerFailedEvent,
+    effects: list[Effect],
+) -> None:
+    pass  # Implemented in Task 8
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_reducer_create.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run ruff and mypy**
+
+Run: `uv run ruff check src/orca/engine/reducer.py && uv run mypy src/orca/engine/reducer.py`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/reducer.py tests/engine/test_reducer_create.py
+git commit -m "feat: add reducer with Create event handling"
+```
+
+---
+
+### Task 6: Reducer — Advance Event
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+- Create: `tests/engine/test_reducer_advance.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/engine/test_reducer_advance.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+)
+from orca.engine.reducer import reduce
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def test_advance_from_passive_to_active(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), _counter())
+    assert state.issues["I-1"].state == "todo"
+
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), _counter())
+    assert state.issues["I-1"].state == "implementing"
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert len(dispatch_effects) == 1
+
+
+def test_advance_from_active_state_errors(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), _counter())
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), _counter())
+    # Now in implementing (active) — advance should fail
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="done"), _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert "passive" in error_effects[0].message
+
+
+def test_advance_blocked_issue_errors(decompose_config_yaml: str) -> None:
+    config = parse_config(decompose_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), _counter())
+    state.issues["I-1"].blocked = True
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="scoping"), _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+    assert "blocked" in error_effects[0].message
+
+
+def test_advance_nonexistent_issue(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="NOPE", target_state="implementing"), _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_advance_to_nonexistent_state(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), _counter())
+    state, effects = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="nonexistent"), _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_reducer_advance.py -v`
+Expected: FAIL (advance handler is a pass stub)
+
+- [ ] **Step 3: Implement Advance handler in reducer.py**
+
+Replace the `_handle_advance` stub:
+
+```python
+def _handle_advance(
+    config: StateMachineConfig,
+    state: State,
+    event: AdvanceEvent,
+    effects: list[Effect],
+) -> None:
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    state_def = config.states.get(issue.state)
+
+    # Must be in a passive state
+    if state_def is not None and (state_def.worker is not None or state_def.terminal):
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is not in a passive state")
+        )
+        return
+
+    if issue.blocked:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is blocked"))
+        return
+
+    if event.target_state not in config.states:
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id, message=f"Target state '{event.target_state}' does not exist in config"
+            )
+        )
+        return
+
+    issue.state = event.target_state
+
+    target_def = config.states[event.target_state]
+    if target_def.worker is not None:
+        dispatch_effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, event.issue_id, dispatch_effects)
+        effects.extend(dispatch_effects)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_reducer_advance.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orca/engine/reducer.py tests/engine/test_reducer_advance.py
+git commit -m "feat: add Advance event handling to reducer"
+```
+
+---
+
+### Task 7: Reducer — WorkerResult Event (Transitions, Decompose, Unblock)
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+- Create: `tests/engine/test_reducer_worker_result.py`
+
+- [ ] **Step 1: Write failing tests for simple transitions**
+
+```python
+# tests/engine/test_reducer_worker_result.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    StateMachineConfig,
+    WorkerResultEvent,
+)
+from orca.engine.reducer import reduce
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _setup_issue_in_state(config_yaml: str, target_state: str) -> tuple[StateMachineConfig, State]:
+    """Create an issue and advance it to the target active state."""
+    from orca.engine.config import parse_config
+
+    config = parse_config(config_yaml)
+    state = State(issues={}, worker_queues={})
+    gen = _counter()
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), gen)
+    if state.issues["I-1"].state != target_state:
+        state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state=target_state), gen)
+    return config, state
+
+
+def test_simple_transition(simple_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(simple_config_yaml, "implementing")
+    gen = _counter()
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done", "summary": "Built it"}), gen
+    )
+    assert state.issues["I-1"].state == "done"
+    assert state.issues["I-1"].worker_active is False
+    assert len(state.issues["I-1"].result_history) == 1
+    assert state.issues["I-1"].result_history[0].state == "implementing"
+
+
+def test_transition_to_active_state_dispatches() -> None:
+    yaml_str = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: "t"
+    text:
+      type: string
+      description: "t"
+initial: todo
+states:
+  todo: {}
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "r"
+          values_description:
+            done: "d"
+        summary:
+          type: string
+          description: "s"
+    on:
+      done: testing
+  testing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [passed]
+          description: "r"
+          values_description:
+            passed: "p"
+    on:
+      passed: done
+  done:
+    terminal: true
+"""
+    config, state = _setup_issue_in_state(yaml_str, "implementing")
+    gen = _counter()
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done", "summary": "ok"}), gen
+    )
+    assert state.issues["I-1"].state == "testing"
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert len(dispatch_effects) == 1
+    assert dispatch_effects[0].state == "testing"
+
+
+def test_worker_result_on_blocked_issue_errors(simple_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(simple_config_yaml, "implementing")
+    state.issues["I-1"].blocked = True
+    gen = _counter()
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done", "summary": "x"}), gen
+    )
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_worker_result_on_terminal_errors(simple_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(simple_config_yaml, "implementing")
+    state.issues["I-1"].state = "done"
+    state.issues["I-1"].worker_active = False
+    gen = _counter()
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen
+    )
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_worker_result_when_not_active_errors(simple_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(simple_config_yaml, "implementing")
+    state.issues["I-1"].worker_active = False
+    gen = _counter()
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done", "summary": "x"}), gen
+    )
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+
+
+def test_decompose_creates_children(decompose_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(decompose_config_yaml, "scoping")
+    gen = _counter()
+    result = {
+        "outcome": "decompose",
+        "sub_issues": [
+            {"title": "Sub 1", "text": "First"},
+            {"title": "Sub 2", "text": "Second"},
+        ],
+    }
+    state, effects = reduce(config, state, WorkerResultEvent(issue_id="I-1", result=result), gen)
+    parent = state.issues["I-1"]
+    assert parent.blocked is True
+    assert parent.state == "scoping"
+    assert len(parent.children) == 2
+
+    child_1_id = parent.children[0]
+    child_2_id = parent.children[1]
+    assert state.issues[child_1_id].fields["title"] == "Sub 1"
+    assert state.issues[child_1_id].parent == "I-1"
+    assert state.issues[child_1_id].state == "todo"
+    assert state.issues[child_2_id].fields["title"] == "Sub 2"
+
+
+def test_cascading_unblock(decompose_config_yaml: str) -> None:
+    config, state = _setup_issue_in_state(decompose_config_yaml, "scoping")
+    gen = _counter()
+
+    # Decompose
+    result = {
+        "outcome": "decompose",
+        "sub_issues": [{"title": "Sub 1", "text": "First"}],
+    }
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result=result), gen)
+    child_id = state.issues["I-1"].children[0]
+
+    # Advance child to scoping, then implementing, then done
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=child_id, target_state="scoping"), gen)
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen
+    )
+    assert state.issues[child_id].state == "implementing"
+
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen
+    )
+    assert state.issues[child_id].state == "done"
+
+    # Parent should be unblocked and re-dispatched
+    assert state.issues["I-1"].blocked is False
+    assert state.issues["I-1"].worker_active is True
+
+
+def test_slot_backfill_on_worker_result(max_workers_config_yaml: str) -> None:
+    config = parse_config(max_workers_config_yaml)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    # Create two issues, advance both to implementing
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "A"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-2", fields={"title": "B"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-2", target_state="implementing"), gen)
+
+    # Both complete implementing, move to apply
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen
+    )
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id="I-2", result={"outcome": "done"}), gen
+    )
+
+    # I-1 should be active in apply, I-2 queued (max_workers: 1)
+    assert state.issues["I-1"].state == "apply"
+    assert state.issues["I-2"].state == "apply"
+    assert state.issues["I-1"].worker_active is True
+    assert state.issues["I-2"].worker_active is False
+
+    # I-1 merges — should backfill I-2
+    state, effects = reduce(
+        config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "merged"}), gen
+    )
+    assert state.issues["I-1"].state == "done"
+    assert state.issues["I-2"].worker_active is True
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert any(e.issue_id == "I-2" for e in dispatch_effects)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_reducer_worker_result.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement WorkerResult handler**
+
+Replace the `_handle_worker_result` stub in `src/orca/engine/reducer.py`:
+
+```python
+def _handle_worker_result(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerResultEvent,
+    effects: list[Effect],
+    generate_id: Callable[[], str],
+) -> None:
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    state_def = config.states.get(issue.state)
+
+    if state_def is None or state_def.terminal:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is in a terminal state")
+        )
+        return
+
+    if issue.blocked:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is blocked"))
+        return
+
+    if not issue.worker_active:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' has no active worker")
+        )
+        return
+
+    if state_def.worker is None:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is in a passive state")
+        )
+        return
+
+    # Step 2: validate outcome before mutating state
+    outcome = event.result.get("outcome")
+    if outcome is None or outcome not in state_def.on:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"No routing rule for outcome '{outcome}'")
+        )
+        return
+
+    # Step 3: free slot (after validation passes)
+    old_state_name = issue.state
+    issue.worker_active = False
+
+    # Step 4: append to result_history
+    issue.result_history.append(ResultHistoryEntry(state=issue.state, result=event.result))
+
+    on_rule = state_def.on[outcome]
+
+    if isinstance(on_rule, OnTransition):
+        # Step 5: simple transition
+        remove_from_queue(state, old_state_name, event.issue_id)
+        issue.state = on_rule.target
+
+        target_def = config.states[on_rule.target]
+        if target_def.terminal:
+            _check_cascading_unblock(config, state, event.issue_id, effects)
+        elif target_def.worker is not None:
+            dispatch_effects: list[DispatchWorkerEffect] = []
+            try_dispatch(config, state, event.issue_id, dispatch_effects)
+            effects.extend(dispatch_effects)
+
+    elif isinstance(on_rule, OnDecompose):
+        # Step 6: decompose
+        sub_issues_data = event.result.get("sub_issues", [])
+        child_ids: list[str] = []
+        for sub in sub_issues_data:
+            child_id = generate_id()
+            child = Issue(
+                fields=sub,
+                state=config.initial,
+                blocked=False,
+                worker_active=False,
+                parent=event.issue_id,
+                children=[],
+                result_history=[],
+            )
+            state.issues[child_id] = child
+            child_ids.append(child_id)
+
+            initial_def = config.states[config.initial]
+            if initial_def.worker is not None:
+                child_dispatch: list[DispatchWorkerEffect] = []
+                try_dispatch(config, state, child_id, child_dispatch)
+                effects.extend(child_dispatch)
+
+        issue.children = child_ids
+        issue.blocked = True
+
+    # Backfill queue for old state
+    backfill_dispatch: list[DispatchWorkerEffect] = []
+    backfill_queue(config, state, old_state_name, backfill_dispatch)
+    effects.extend(backfill_dispatch)
+
+
+def _check_cascading_unblock(
+    config: StateMachineConfig,
+    state: State,
+    issue_id: str,
+    effects: list[Effect],
+) -> None:
+    issue = state.issues[issue_id]
+    if issue.parent is None:
+        return
+
+    parent = state.issues[issue.parent]
+    if not parent.blocked:
+        return
+
+    # Check if all children of parent are terminal
+    all_terminal = all(
+        config.states[state.issues[child_id].state].terminal for child_id in parent.children
+    )
+    if not all_terminal:
+        return
+
+    parent.blocked = False
+    dispatch_effects: list[DispatchWorkerEffect] = []
+    try_dispatch(config, state, issue.parent, dispatch_effects)
+    effects.extend(dispatch_effects)
+
+    # Recursive: if parent just got unblocked and its state is terminal, check its parent
+    parent_state_def = config.states[parent.state]
+    if parent_state_def.terminal:
+        _check_cascading_unblock(config, state, issue.parent, effects)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_reducer_worker_result.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/reducer.py tests/engine/test_reducer_worker_result.py
+git commit -m "feat: add WorkerResult handling with transitions, decompose, and cascading unblock"
+```
+
+---
+
+### Task 8: Reducer — WorkerFailed Event
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+- Create: `tests/engine/test_reducer_worker_failed.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/engine/test_reducer_worker_failed.py
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+from orca.engine.reducer import reduce
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def test_worker_failed_retries(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "T", "text": "D"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), gen)
+    assert state.issues["I-1"].worker_active is True
+
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="I-1", error="timeout"), gen)
+    # worker_active stays True (slot retained)
+    assert state.issues["I-1"].worker_active is True
+    assert state.issues["I-1"].state == "implementing"
+    dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+    assert len(dispatch_effects) == 1
+    assert dispatch_effects[0].issue_id == "I-1"
+
+
+def test_worker_failed_does_not_free_slot(max_workers_config_yaml: str) -> None:
+    config = parse_config(max_workers_config_yaml)
+    gen = _counter()
+    state = State(issues={}, worker_queues={})
+
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-1", fields={"title": "A"}), gen)
+    state, _ = reduce(config, state, CreateEvent(issue_id="I-2", fields={"title": "B"}), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-1", target_state="implementing"), gen)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id="I-2", target_state="implementing"), gen)
+
+    # Both to apply
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-1", result={"outcome": "done"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id="I-2", result={"outcome": "done"}), gen)
+
+    # I-1 active in apply, I-2 queued
+    assert state.issues["I-1"].worker_active is True
+    assert state.issues["I-2"].worker_active is False
+
+    # I-1 fails — slot should NOT free, I-2 should stay queued
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="I-1", error="crash"), gen)
+    assert state.issues["I-1"].worker_active is True
+    assert state.issues["I-2"].worker_active is False
+
+
+def test_worker_failed_nonexistent_issue(simple_config_yaml: str) -> None:
+    config = parse_config(simple_config_yaml)
+    state = State(issues={}, worker_queues={})
+    state, effects = reduce(config, state, WorkerFailedEvent(issue_id="NOPE", error="x"), _counter())
+    error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+    assert len(error_effects) == 1
+```
+
+We need to add the missing import at the top:
+
+```python
+from orca.engine.types import WorkerResultEvent
+```
+
+(Add this to the imports in the test file since `test_worker_failed_does_not_free_slot` uses it.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/engine/test_reducer_worker_failed.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement WorkerFailed handler**
+
+Replace the `_handle_worker_failed` stub in `src/orca/engine/reducer.py`:
+
+```python
+def _handle_worker_failed(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerFailedEvent,
+    effects: list[Effect],
+) -> None:
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+
+    if not issue.worker_active:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' has no active worker")
+        )
+        return
+
+    state_def = config.states[issue.state]
+    if state_def.worker is None:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is in a state without a worker")
+        )
+        return
+
+    # Unconditional retry — slot retained, bypass dispatch protocol
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=event.issue_id,
+            state=issue.state,
+            result_format=build_result_format(config, issue.state),
+            issue=build_issue_context(state, event.issue_id),
+        )
+    )
+```
+
+Note: This bypasses the dispatch protocol intentionally — per spec, the failed issue retains its slot (`worker_active` stays `True`) and the retry is unconditional. `build_issue_context` and `build_result_format` are public functions from `dispatch.py` (imported at the top of `reducer.py`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/engine/test_reducer_worker_failed.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/reducer.py tests/engine/test_reducer_worker_failed.py
+git commit -m "feat: add WorkerFailed event handling with slot retention and retry"
+```
+
+---
+
+### Task 9: Public API and Module Exports
+
+**Files:**
+- Modify: `src/orca/engine/__init__.py`
+
+- [ ] **Step 1: Write failing test for public API**
+
+```python
+# Add to tests/engine/test_types.py at the end:
+
+def test_public_api_imports() -> None:
+    from orca.engine import (
+        reduce,
+        parse_config,
+        ConfigValidationError,
+        State,
+        Issue,
+        CreateEvent,
+        AdvanceEvent,
+        WorkerResultEvent,
+        WorkerFailedEvent,
+        DispatchWorkerEffect,
+        ErrorEffect,
+        StateMachineConfig,
+    )
+    assert callable(reduce)
+    assert callable(parse_config)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_types.py::test_public_api_imports -v`
+Expected: FAIL with ImportError
+
+- [ ] **Step 3: Implement exports**
+
+```python
+# src/orca/engine/__init__.py
+"""Orca state machine engine."""
+
+from orca.engine.config import ConfigValidationError, parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    Issue,
+    State,
+    StateMachineConfig,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+__all__ = [
+    "ConfigValidationError",
+    "parse_config",
+    "reduce",
+    "AdvanceEvent",
+    "CreateEvent",
+    "DispatchWorkerEffect",
+    "ErrorEffect",
+    "Issue",
+    "State",
+    "StateMachineConfig",
+    "WorkerFailedEvent",
+    "WorkerResultEvent",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_types.py::test_public_api_imports -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite + ruff + mypy**
+
+Run: `uv run pytest -v && uv run ruff check . && uv run mypy src/`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/engine/__init__.py tests/engine/test_types.py
+git commit -m "feat: add public API exports for engine module"
+```
+
+---
+
+### Task 10: Final Verification — Full Test Suite, Lint, Type Check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: all tests PASS
+
+- [ ] **Step 2: Run ruff**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: PASS
+
+- [ ] **Step 3: Run mypy**
+
+Run: `uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 4: Verify CI config includes tests**
+
+Check `.github/workflows/ci.yml` — if tests aren't in CI yet, add a `test` job:
+
+```yaml
+  test:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: uv sync
+      - name: Run tests
+        run: uv run pytest -v
+```
+
+- [ ] **Step 5: Commit CI update if needed**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add test job to CI pipeline"
+```

--- a/docs/superpowers/specs/2026-03-22-state-machine-engine-design.md
+++ b/docs/superpowers/specs/2026-03-22-state-machine-engine-design.md
@@ -1,0 +1,570 @@
+# State Machine Engine Design
+
+## Goal
+
+A pure reducer function that drives issue lifecycle through a user-defined state machine. The state machine is configured via `orca.yml`. The reducer takes the current state and an event, returns the next state plus a list of side effects.
+
+## Signature
+
+```python
+def reduce(
+    config: StateMachineConfig,
+    state: State,
+    event: Event,
+    generate_id: Callable[[], str],
+) -> tuple[State, list[Effect]]
+```
+
+- `config` — parsed `orca.yml`, immutable
+- `state` — full serializable system state (all issues + their relationships)
+- `event` — something that happened
+- `generate_id` — injected function for assigning IDs to sub-issues during decomposition. The one impurity in the interface; in tests, use a deterministic generator.
+- Returns new state + effects for the orchestrator to execute
+
+The reducer is **pure** — no I/O, no side effects. Effects are data objects the orchestrator interprets.
+
+## orca.yml Format
+
+### Top-Level Structure
+
+```yaml
+issue:
+  fields:
+    <field_name>:
+      type: string
+      description: "..."
+
+initial: <state_name>
+
+states:
+  <state_name>:
+    max_workers: <int>              # optional, default unlimited
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [...]
+          description: "..."
+          values_description:
+            <value>: "..."
+        <extra_field>:
+          type: string | list
+          description: "..."
+          required_when: <outcome_value>  # optional, supports single value or list
+          items: $issue                   # for type: list referencing issue schema
+    on:
+      <outcome_value>: <target_state>           # simple transition
+      <outcome_value>:                           # transition with directive
+        action: decompose
+
+  <terminal_state_name>:
+    terminal: true
+```
+
+### Sections
+
+#### `issue`
+
+Defines the user-facing fields of an issue.
+
+```yaml
+issue:
+  fields:
+    title:
+      type: string
+      description: "Short title of the issue"
+    text:
+      type: string
+      description: "Detailed description"
+```
+
+Supported field types: `string`. More types can be added later.
+
+#### `initial`
+
+The state an issue enters when created.
+
+```yaml
+initial: todo
+```
+
+Must reference a state defined in `states`.
+
+#### `states`
+
+Each state is one of:
+
+- **Passive** — no `worker`, no `on`, no `terminal`. A waiting state (e.g., `todo`). Issues sit here until an `Advance` event moves them to a specified target state.
+- **Active** — has `worker` and `on`. A worker processes the issue and the result determines the next transition.
+- **Terminal** — has `terminal: true`. The issue lifecycle is complete.
+
+##### Active State Fields
+
+**`max_workers`** — optional integer. Limits how many issues can have workers dispatched concurrently in this state. When the limit is reached, additional issues entering this state are queued and dispatched as slots free up. Default: unlimited (omitted). The reducer tracks active worker counts per state; when emitting `DispatchWorker`, it checks capacity and queues excess issues instead.
+
+**`worker`** — defines the interface for the worker that processes issues in this state.
+
+**`worker.result_format`** — schema for the worker's output. Must contain an `outcome` field of type `enum`. The `on` routing rules bind to `outcome.values`. Additional fields provide context to downstream workers.
+
+Field types in `result_format`:
+- `enum` — one of a set of values. Has `values`, `description`, `values_description`.
+- `string` — free text. Has `description`.
+- `list` — a list of items. Has `description`, `items`. When `items: $issue`, each item follows the `issue.fields` schema.
+
+Optional field modifiers:
+- `required_when` — field is required when outcome matches. Supports a single value (`required_when: decompose`) or a list (`required_when: [decompose, split]`).
+
+**`on`** — routing rules keyed by `outcome` values. Two forms:
+
+Simple transition (string):
+```yaml
+on:
+  ready: implementing
+```
+
+Directive transition (object):
+```yaml
+on:
+  decompose:
+    action: decompose
+```
+
+The `action: decompose` directive tells the reducer to:
+1. Create sub-issues from the `sub_issues` field in the worker result
+2. Mark the parent issue as `blocked`
+3. Keep the parent in its current state
+4. When all sub-issues reach a terminal state, the parent is automatically unblocked and the worker re-runs
+
+Note: the decompose behavior is triggered by the `action: decompose` directive in the routing rule, **not** by the outcome value name. An outcome named `"split"` routing to `action: decompose` works identically.
+
+### Validation Rules
+
+At config load time, the orchestrator validates:
+
+1. `initial` references an existing state
+2. Every `on` target references an existing state
+3. Every `on` key matches a value in `outcome.values`
+4. Every active state has `outcome` of type `enum` in `result_format`
+5. Terminal states have no `worker` or `on`
+6. At least one terminal state exists
+7. `action: decompose` requires a `sub_issues` field with `items: $issue` in `result_format`
+8. Every non-initial, non-passive state is reachable (is a target of at least one `on` rule or is the `initial` state). Passive states are exempt as they are reached via `Advance` events.
+9. `max_workers` if present must be a positive integer
+
+## Reducer State
+
+The full system state, fully serializable as JSON:
+
+```json
+{
+  "issues": {
+    "ISSUE-1": {
+      "fields": {
+        "title": "Build auth",
+        "text": "Implement full auth system"
+      },
+      "state": "scoping",
+      "blocked": true,
+      "worker_active": false,
+      "parent": null,
+      "children": ["ISSUE-2", "ISSUE-3"],
+      "result_history": [
+        {
+          "state": "scoping",
+          "result": {
+            "outcome": "decompose",
+            "sub_issues": [...]
+          }
+        }
+      ]
+    },
+    "ISSUE-2": {
+      "fields": {
+        "title": "Add login endpoint",
+        "text": "..."
+      },
+      "state": "done",
+      "blocked": false,
+      "worker_active": false,
+      "parent": "ISSUE-1",
+      "children": [],
+      "result_history": [
+        {
+          "state": "implementing",
+          "result": {"outcome": "done", "summary": "Implemented login"}
+        },
+        {
+          "state": "ready-for-test",
+          "result": {"outcome": "passed", "report": "All tests pass"}
+        }
+      ]
+    }
+  },
+  "worker_queues": {}
+}
+```
+
+### Issue Fields
+
+User-defined (from `issue.fields` in config):
+- Stored under `fields` key
+- Shape matches the `issue.fields` schema
+
+System-managed:
+- `state` — current state name in the machine
+- `blocked` — `true` when waiting on sub-issues, `false` otherwise
+- `worker_active` — `true` when a worker has been dispatched and hasn't returned yet, `false` otherwise
+- `parent` — ID of the parent issue, or `null`
+- `children` — list of child issue IDs
+- `result_history` — ordered list of worker results. Each entry records the `state` and the worker's `result`. Appended on every `WorkerResult` event. Workers can use this to see prior outcomes (e.g., a scoping worker re-running after unblock can see its previous decompose result and the children's results via their own histories).
+
+### Dispatch Protocol
+
+All `DispatchWorker` emission goes through a single protocol. Every place in the spec that says "dispatch the issue" follows these rules:
+
+1. Check if the issue's state has `max_workers` set
+2. If yes, count issues in that state with `worker_active: true`
+3. If count < `max_workers` (or `max_workers` is not set): set `worker_active: true` on the issue, emit `DispatchWorker` effect
+4. If count >= `max_workers`: leave `worker_active: false`, do not emit `DispatchWorker`. The issue is queued.
+
+**Freeing slots:** when a `WorkerResult` or `WorkerFailed` is processed, the reducer sets `worker_active: false` on the issue (freeing a slot), then checks for queued issues in the same state (`worker_active: false`, not blocked) and dispatches the next one.
+
+**FIFO ordering:** to survive JSON serialization round-trips, the reducer state includes a `worker_queues` dict at the top level. When an issue is queued (step 4 above), its ID is appended to `worker_queues[state_name]`. When a slot frees up, the first ID is popped from the queue. When an issue transitions out of a state, it is removed from that state's queue if present.
+
+```json
+{
+  "issues": { "..." },
+  "worker_queues": {
+    "apply": ["ISSUE-3", "ISSUE-4"]
+  }
+}
+```
+
+**`WorkerFailed` and slots:** when a worker fails, the slot is NOT freed. `worker_active` stays `true`, and the retry `DispatchWorker` is emitted unconditionally. This ensures the failed issue retains its slot and isn't starved by queued issues.
+
+## Events
+
+Four event types:
+
+### `Create`
+
+A new issue enters the system.
+
+```json
+{
+  "type": "create",
+  "issue_id": "ISSUE-1",
+  "fields": {
+    "title": "Build auth",
+    "text": "..."
+  }
+}
+```
+
+**Reducer behavior:** adds the issue to state with `state` set to `initial`, `blocked: false`, `worker_active: false`, `parent: null`, `children: []`, `result_history: []`.
+
+**Effects:** if the initial state is active, dispatch the issue (see Dispatch Protocol).
+
+### `Advance`
+
+Moves an issue from a passive state to a specified target state. This is how issues leave states that have no worker (e.g., `todo` → `scoping`).
+
+```json
+{
+  "type": "advance",
+  "issue_id": "ISSUE-1",
+  "target_state": "scoping"
+}
+```
+
+**Reducer behavior:**
+1. Validate the issue is in a passive state
+2. Validate the issue is not blocked
+3. Validate `target_state` exists in the config
+4. Move issue to `target_state`
+
+**Effects:** if target state is active, dispatch the issue (see Dispatch Protocol).
+
+Note: `Advance` intentionally allows transition to any defined state (active or passive). Passive states exist outside the `on`-rule graph — the orchestrator or external caller decides when and where to advance them. This is by design: passive states are human/scheduler-controlled entry points, not automated transitions.
+
+### `WorkerResult`
+
+A worker completed processing an issue.
+
+```json
+{
+  "type": "worker_result",
+  "issue_id": "ISSUE-1",
+  "result": {
+    "outcome": "decompose",
+    "sub_issues": [
+      {"title": "Add login", "text": "..."},
+      {"title": "Add signup", "text": "..."}
+    ]
+  }
+}
+```
+
+**Reducer behavior:**
+1. Validate result against `result_format` of the current state
+2. Set `worker_active: false` on the issue (frees a slot — see Dispatch Protocol)
+3. Append `{state, result}` to issue's `result_history`
+4. Look up `on[outcome]` routing rule
+5. If simple transition: move issue to target state, remove from old state's worker queue if present
+6. If `action: decompose`: create child issues at `initial` state, set parent `blocked: true`, link `parent`/`children`
+
+**Cascading unblock check:** after any transition to a terminal state, the reducer checks whether the issue has a parent, and if so, whether all siblings (all children of the parent) are now terminal. If yes, the parent is unblocked (`blocked: false`) and dispatched (see Dispatch Protocol). This check is recursive — unblocking a parent may cause it to complete and unblock its own parent.
+
+**Slot backfill:** after step 2, if the old state has `max_workers` and there are queued issues, dispatch the next queued issue (see Dispatch Protocol).
+
+**Effects:**
+- Simple transition to active state → dispatch the issue (see Dispatch Protocol)
+- Simple transition to terminal state → check and cascade unblock (see above)
+- `action: decompose` → dispatch each child whose initial state is active (see Dispatch Protocol)
+
+**Error cases:**
+- Issue is blocked → reject event, return state unchanged, emit `Error` effect
+- Issue is in a terminal state → reject event, return state unchanged, emit `Error` effect
+- Issue has `worker_active: false` → reject event, return state unchanged, emit `Error` effect
+- Result fails validation → reject event, return state unchanged, emit `Error` effect
+
+### `WorkerFailed`
+
+A worker crashed, timed out, or returned an unparseable response.
+
+```json
+{
+  "type": "worker_failed",
+  "issue_id": "ISSUE-1",
+  "error": "Worker timed out after 300s"
+}
+```
+
+**Reducer behavior:** issue remains in its current state, `worker_active` stays `true` (slot is retained).
+
+**Effects:** emit `DispatchWorker` unconditionally for the same issue (retry). The slot is not freed — the failed issue retains its position and is not displaced by queued issues. The orchestrator is responsible for retry limits and backoff — the reducer always retries. When the orchestrator decides to stop retrying, it stops sending events; the reducer does not track retry counts.
+
+## Effects
+
+Effects are data objects returned by the reducer. The orchestrator executes them, which eventually produce new events.
+
+### `DispatchWorker`
+
+```json
+{
+  "type": "dispatch_worker",
+  "issue_id": "ISSUE-1",
+  "state": "implementing",
+  "result_format": { "..." },
+  "issue": {
+    "fields": { "..." },
+    "result_history": [ "..." ],
+    "parent": null,
+    "children": [
+      {
+        "issue_id": "ISSUE-2",
+        "fields": { "..." },
+        "state": "done",
+        "result_history": [ "..." ]
+      }
+    ]
+  }
+}
+```
+
+Tells the orchestrator to assign the issue to a worker for the given state. Includes:
+- `result_format` — the output schema the worker must follow
+- `issue` — full issue context including `fields`, `result_history`, and `parent`
+- `issue.children` — resolved child issue data (not just IDs), including each child's `fields`, `state`, and `result_history`. This allows workers re-running after unblock to inspect child outcomes without needing access to the full system state.
+
+### `Error`
+
+```json
+{
+  "type": "error",
+  "issue_id": "ISSUE-1",
+  "message": "Cannot process WorkerResult: issue is blocked"
+}
+```
+
+Signals an invalid event. The orchestrator decides how to handle (log, alert, discard).
+
+## Decomposition: Multi-Level
+
+Sub-issues can themselves decompose. The unblock mechanism works transitively:
+
+1. ISSUE-1 decomposes into ISSUE-2 and ISSUE-3 → ISSUE-1 is blocked
+2. ISSUE-2 decomposes into ISSUE-4 and ISSUE-5 → ISSUE-2 is blocked
+3. ISSUE-4 and ISSUE-5 reach terminal → ISSUE-2 is unblocked, worker re-runs
+4. ISSUE-2 reaches terminal → all children of ISSUE-1 are terminal → ISSUE-1 is unblocked
+
+Each level only checks its direct children. Transitivity emerges naturally: a blocked child is not terminal, so the parent stays blocked until the child is unblocked, re-runs, and eventually reaches terminal itself.
+
+## Sub-Issue Creation Path
+
+Sub-issues created via `action: decompose` are added directly to the reducer state (not via a `Create` event). This is intentional — the reducer handles the full decomposition atomically in a single step. The sub-issues enter at the `initial` state with `parent` set.
+
+## ID Generation
+
+The caller provides issue IDs in `Create` events. For sub-issues created via decomposition, the reducer uses the `generate_id` function from its signature. See the Signature section above.
+
+## Full orca.yml Example
+
+```yaml
+issue:
+  fields:
+    title:
+      type: string
+      description: "Short title of the issue"
+    text:
+      type: string
+      description: "Detailed description"
+
+initial: todo
+
+states:
+  todo: {}
+
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "Whether the issue is ready or needs decomposition"
+          values_description:
+            ready: "Issue is well-scoped and ready for implementation"
+            decompose: "Issue is too complex, split into sub-issues"
+        sub_issues:
+          type: list
+          required_when: decompose
+          items: $issue
+          description: "Sub-issues to create when decomposing"
+    on:
+      ready: implementing
+      decompose:
+        action: decompose
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "The result of the implementation"
+          values_description:
+            done: "Implementation is complete"
+        summary:
+          type: string
+          description: "Brief summary of what was done"
+    on:
+      done: ready-for-test
+
+  ready-for-test:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [passed, failed]
+          description: "The result of testing"
+          values_description:
+            passed: "All tests pass"
+            failed: "Tests failed"
+        report:
+          type: string
+          description: "Test report details"
+    on:
+      passed: done
+      failed: implementing
+
+  done:
+    terminal: true
+```
+
+## Example: Development Pipeline with Merge Serialization
+
+A common pattern where multiple issues implement features in parallel but must merge to main one at a time. The `apply` state uses `max_workers: 1` to serialize merges, avoiding cascade conflicts.
+
+```yaml
+issue:
+  fields:
+    title:
+      type: string
+      description: "Short title of the issue"
+    text:
+      type: string
+      description: "Detailed description"
+
+initial: todo
+
+states:
+  todo: {}
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Implementation result"
+          values_description:
+            done: "Implementation is complete"
+        summary:
+          type: string
+          description: "What was implemented"
+    on:
+      done: qa
+
+  qa:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [passed, failed]
+          description: "QA result"
+          values_description:
+            passed: "All tests pass, code meets requirements"
+            failed: "Tests failed or requirements not met"
+        report:
+          type: string
+          description: "Test report"
+    on:
+      passed: apply
+      failed: implementing
+
+  apply:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [merged, rebase_conflict]
+          description: "Merge result"
+          values_description:
+            merged: "Rebased onto latest main and merged"
+            rebase_conflict: "Rebase conflicts require implementation changes"
+    on:
+      merged: done
+      rebase_conflict: implementing
+
+  done:
+    terminal: true
+```
+
+**How it avoids the cascade problem:**
+
+Without `max_workers: 1`, if 4 issues reach `apply` simultaneously, one merges and the other 3 conflict — sending them all back through `implementing → qa → apply`, causing 10 full cycles worst case.
+
+With `max_workers: 1` on `apply`, issues are serialized:
+1. Issue A enters `apply`: rebase onto main (trivial) → merge → done
+2. Issue B enters `apply`: rebase onto main (includes A) → merge → done
+3. Issue C enters `apply`: rebase onto main (includes A+B) → merge → done
+4. Issue D enters `apply`: rebase onto main (includes A+B+C) → merge → done
+
+Each `apply` worker rebases onto the latest main before merging. Since only one issue merges at a time, the rebase is always against the current main — no conflicts between in-flight merges. Only genuine conflicts (overlapping file changes that can't auto-resolve) send an issue back to `implementing`.
+
+## Future Considerations
+
+- **Worker type/command** — `worker` currently only defines `result_format`. Eventually it will need to specify which CLI agent to invoke. Out of scope for the reducer.
+- **Additional field types** — `integer`, `boolean`, `object` in `result_format` and `issue.fields`.
+- **Conditional transitions** — routing based on multiple fields, not just `outcome`.

--- a/docs/superpowers/specs/2026-03-22-state-machine-engine-design.md
+++ b/docs/superpowers/specs/2026-03-22-state-machine-engine-design.md
@@ -130,10 +130,15 @@ on:
 ```
 
 The `action: decompose` directive tells the reducer to:
-1. Create sub-issues from the `sub_issues` field in the worker result
-2. Mark the parent issue as `blocked`
-3. Keep the parent in its current state
-4. When all sub-issues reach a terminal state, the parent is automatically unblocked and the worker re-runs
+1. Validate `sub_issues` is not empty
+2. Create sub-issues from the `sub_issues` field in the worker result, setting `decomposed_from` to the parent issue ID
+3. Resolve `key`/`depends_on` references between siblings to real issue IDs
+4. Keep the parent in its current state — it is now decomposition-blocked (has non-terminal children)
+5. When all children reach a terminal state, the parent is automatically unblocked and the worker re-runs
+
+Each sub-issue in the result may include:
+- `key` — temporary identifier for sibling references (not stored in state)
+- `depends_on` — list of sibling `key` values this sub-issue depends on (resolved to real IDs)
 
 Note: the decompose behavior is triggered by the `action: decompose` directive in the routing rule, **not** by the outcome value name. An outcome named `"split"` routing to `action: decompose` works identically.
 
@@ -164,10 +169,9 @@ The full system state, fully serializable as JSON:
         "text": "Implement full auth system"
       },
       "state": "scoping",
-      "blocked": true,
       "worker_active": false,
-      "parent": null,
-      "children": ["ISSUE-2", "ISSUE-3"],
+      "decomposed_from": null,
+      "depends_on": [],
       "result_history": [
         {
           "state": "scoping",
@@ -184,10 +188,9 @@ The full system state, fully serializable as JSON:
         "text": "..."
       },
       "state": "done",
-      "blocked": false,
       "worker_active": false,
-      "parent": "ISSUE-1",
-      "children": [],
+      "decomposed_from": "ISSUE-1",
+      "depends_on": [],
       "result_history": [
         {
           "state": "implementing",
@@ -196,6 +199,33 @@ The full system state, fully serializable as JSON:
         {
           "state": "ready-for-test",
           "result": {"outcome": "passed", "report": "All tests pass"}
+        }
+      ]
+    },
+    "ISSUE-3": {
+      "fields": {
+        "title": "Add order endpoint",
+        "text": "..."
+      },
+      "state": "implementing",
+      "worker_active": true,
+      "decomposed_from": "ISSUE-1",
+      "depends_on": ["ISSUE-4"],
+      "result_history": []
+    },
+    "ISSUE-4": {
+      "fields": {
+        "title": "Set up database",
+        "text": "..."
+      },
+      "state": "done",
+      "worker_active": false,
+      "decomposed_from": "ISSUE-1",
+      "depends_on": [],
+      "result_history": [
+        {
+          "state": "implementing",
+          "result": {"outcome": "done", "summary": "DB setup complete"}
         }
       ]
     }
@@ -212,20 +242,30 @@ User-defined (from `issue.fields` in config):
 
 System-managed:
 - `state` — current state name in the machine
-- `blocked` — `true` when waiting on sub-issues, `false` otherwise
 - `worker_active` — `true` when a worker has been dispatched and hasn't returned yet, `false` otherwise
-- `parent` — ID of the parent issue, or `null`
-- `children` — list of child issue IDs
-- `result_history` — ordered list of worker results. Each entry records the `state` and the worker's `result`. Appended on every `WorkerResult` event. Workers can use this to see prior outcomes (e.g., a scoping worker re-running after unblock can see its previous decompose result and the children's results via their own histories).
+- `decomposed_from` — ID of the issue this was decomposed from, or `null`. Replaces the old `parent` field. An issue's "children" are computed: all issues where `decomposed_from == this_issue_id`.
+- `depends_on` — list of issue IDs that must reach a terminal state before this issue can be dispatched to a worker. Supports diamond dependencies (multiple issues depending on the same issue).
+- `result_history` — ordered list of worker results. Each entry records the `state` and the worker's `result`. Appended on every `WorkerResult` event.
+
+### Blocking
+
+The old `blocked` boolean is replaced by **computed blocking** from two sources:
+
+1. **Decomposition block:** an issue has children (issues with `decomposed_from == this_id`) that are not all in a terminal state. When blocked this way, the issue re-runs its worker once all children reach terminal (the "synthesize" pattern).
+
+2. **Dependency block:** an issue has entries in `depends_on` that are not all in a terminal state. When blocked this way, the issue simply waits — once all dependencies are terminal, the issue proceeds normally (dispatched for the first time or continues from where it was).
+
+An issue is considered **blocked** if either condition is true. The Dispatch Protocol checks both before dispatching.
 
 ### Dispatch Protocol
 
 All `DispatchWorker` emission goes through a single protocol. Every place in the spec that says "dispatch the issue" follows these rules:
 
-1. Check if the issue's state has `max_workers` set
-2. If yes, count issues in that state with `worker_active: true`
-3. If count < `max_workers` (or `max_workers` is not set): set `worker_active: true` on the issue, emit `DispatchWorker` effect
-4. If count >= `max_workers`: leave `worker_active: false`, do not emit `DispatchWorker`. The issue is queued.
+1. Check if the issue is blocked (has non-terminal children OR has non-terminal dependencies). If blocked, do not dispatch.
+2. Check if the issue's state has `max_workers` set
+3. If yes, count issues in that state with `worker_active: true`
+4. If count < `max_workers` (or `max_workers` is not set): set `worker_active: true` on the issue, emit `DispatchWorker` effect
+5. If count >= `max_workers`: leave `worker_active: false`, do not emit `DispatchWorker`. The issue is queued.
 
 **Freeing slots:** when a `WorkerResult` or `WorkerFailed` is processed, the reducer sets `worker_active: false` on the issue (freeing a slot), then checks for queued issues in the same state (`worker_active: false`, not blocked) and dispatches the next one.
 
@@ -261,7 +301,7 @@ A new issue enters the system.
 }
 ```
 
-**Reducer behavior:** adds the issue to state with `state` set to `initial`, `blocked: false`, `worker_active: false`, `parent: null`, `children: []`, `result_history: []`.
+**Reducer behavior:** adds the issue to state with `state` set to `initial`, `worker_active: false`, `decomposed_from: null`, `depends_on: []`, `result_history: []`.
 
 **Effects:** if the initial state is active, dispatch the issue (see Dispatch Protocol).
 
@@ -279,7 +319,7 @@ Moves an issue from a passive state to a specified target state. This is how iss
 
 **Reducer behavior:**
 1. Validate the issue is in a passive state
-2. Validate the issue is not blocked
+2. Validate the issue is not blocked (no non-terminal children, no non-terminal dependencies)
 3. Validate `target_state` exists in the config
 4. Move issue to `target_state`
 
@@ -298,12 +338,17 @@ A worker completed processing an issue.
   "result": {
     "outcome": "decompose",
     "sub_issues": [
-      {"title": "Add login", "text": "..."},
-      {"title": "Add signup", "text": "..."}
+      {"key": "db", "title": "Set up database", "text": "..."},
+      {"key": "users", "title": "Add user endpoint", "text": "...", "depends_on": ["db"]},
+      {"key": "orders", "title": "Add order endpoint", "text": "...", "depends_on": ["db"]}
     ]
   }
 }
 ```
+
+Sub-issues in the decompose result support:
+- `key` — a temporary identifier used to reference siblings within the same decompose result. Not stored in state — resolved to real IDs by the reducer.
+- `depends_on` — list of `key` values referencing other sub-issues in the same result. The reducer resolves these to real issue IDs and sets `depends_on` on the created issues. This enables diamond dependencies: both "users" and "orders" depend on "db."
 
 **Reducer behavior:**
 1. Validate result against `result_format` of the current state
@@ -311,22 +356,33 @@ A worker completed processing an issue.
 3. Append `{state, result}` to issue's `result_history`
 4. Look up `on[outcome]` routing rule
 5. If simple transition: move issue to target state, remove from old state's worker queue if present
-6. If `action: decompose`: create child issues at `initial` state, set parent `blocked: true`, link `parent`/`children`
+6. If `action: decompose`:
+   a. Validate `sub_issues` is not empty — empty decompose is an error
+   b. Generate IDs for each sub-issue, build a `key → real_id` mapping
+   c. Create child issues at `initial` state with `decomposed_from` set to the parent issue ID
+   d. Resolve `depends_on` keys to real IDs for each child
+   e. The parent is now decomposition-blocked (it has non-terminal children)
 
-**Cascading unblock check:** after any transition to a terminal state, the reducer checks whether the issue has a parent, and if so, whether all siblings (all children of the parent) are now terminal. If yes, the parent is unblocked (`blocked: false`) and dispatched (see Dispatch Protocol). This check is recursive — unblocking a parent may cause it to complete and unblock its own parent.
+**Cascading unblock check:** after any transition to a terminal state, the reducer checks:
+1. **Decomposition unblock:** find all issues where `decomposed_from == this_issue's decomposed_from` (siblings). If all siblings are terminal, the parent (the issue they were decomposed from) is no longer decomposition-blocked. If the parent was waiting (decomposition-blocked), dispatch it (see Dispatch Protocol) — the worker re-runs.
+2. **Dependency unblock:** find all issues that have this issue in their `depends_on`. For each, check if all their dependencies are now terminal. If yes and the issue is in an active state, dispatch it (see Dispatch Protocol).
+
+Both checks are recursive — unblocking a parent may cause it to complete and trigger further unblocks up the chain.
 
 **Slot backfill:** after step 2, if the old state has `max_workers` and there are queued issues, dispatch the next queued issue (see Dispatch Protocol).
 
 **Effects:**
 - Simple transition to active state → dispatch the issue (see Dispatch Protocol)
 - Simple transition to terminal state → check and cascade unblock (see above)
-- `action: decompose` → dispatch each child whose initial state is active (see Dispatch Protocol)
+- `action: decompose` → dispatch each child that is not dependency-blocked and whose initial state is active (see Dispatch Protocol)
 
 **Error cases:**
 - Issue is blocked → reject event, return state unchanged, emit `Error` effect
 - Issue is in a terminal state → reject event, return state unchanged, emit `Error` effect
 - Issue has `worker_active: false` → reject event, return state unchanged, emit `Error` effect
 - Result fails validation → reject event, return state unchanged, emit `Error` effect
+- `action: decompose` with empty `sub_issues` → reject event, return state unchanged, emit `Error` effect
+- `depends_on` references a `key` that doesn't exist in the same decompose result → reject, emit `Error` effect
 
 ### `WorkerFailed`
 
@@ -354,12 +410,13 @@ Effects are data objects returned by the reducer. The orchestrator executes them
 {
   "type": "dispatch_worker",
   "issue_id": "ISSUE-1",
-  "state": "implementing",
+  "state": "scoping",
   "result_format": { "..." },
   "issue": {
     "fields": { "..." },
     "result_history": [ "..." ],
-    "parent": null,
+    "decomposed_from": null,
+    "depends_on": [],
     "children": [
       {
         "issue_id": "ISSUE-2",
@@ -374,8 +431,8 @@ Effects are data objects returned by the reducer. The orchestrator executes them
 
 Tells the orchestrator to assign the issue to a worker for the given state. Includes:
 - `result_format` — the output schema the worker must follow
-- `issue` — full issue context including `fields`, `result_history`, and `parent`
-- `issue.children` — resolved child issue data (not just IDs), including each child's `fields`, `state`, and `result_history`. This allows workers re-running after unblock to inspect child outcomes without needing access to the full system state.
+- `issue` — full issue context including `fields`, `result_history`, `decomposed_from`, and `depends_on`
+- `issue.children` — resolved child issue data (computed from all issues where `decomposed_from == this_issue_id`), including each child's `fields`, `state`, and `result_history`. This allows workers re-running after decomposition unblock to inspect child outcomes.
 
 ### `Error`
 
@@ -389,20 +446,53 @@ Tells the orchestrator to assign the issue to a worker for the given state. Incl
 
 Signals an invalid event. The orchestrator decides how to handle (log, alert, discard).
 
-## Decomposition: Multi-Level
+## Dependency Graph (DAG)
 
-Sub-issues can themselves decompose. The unblock mechanism works transitively:
+Issues form a directed acyclic graph through two edge types:
 
-1. ISSUE-1 decomposes into ISSUE-2 and ISSUE-3 → ISSUE-1 is blocked
-2. ISSUE-2 decomposes into ISSUE-4 and ISSUE-5 → ISSUE-2 is blocked
-3. ISSUE-4 and ISSUE-5 reach terminal → ISSUE-2 is unblocked, worker re-runs
-4. ISSUE-2 reaches terminal → all children of ISSUE-1 are terminal → ISSUE-1 is unblocked
+### Decomposition edges (`decomposed_from`)
 
-Each level only checks its direct children. Transitivity emerges naturally: a blocked child is not terminal, so the parent stays blocked until the child is unblocked, re-runs, and eventually reaches terminal itself.
+Express "I was created by splitting this parent issue." When all children reach terminal, the parent re-runs its worker to synthesize results.
+
+**Multi-level decomposition** works transitively:
+1. ISSUE-1 decomposes into ISSUE-2 and ISSUE-3 → ISSUE-1 is decomposition-blocked
+2. ISSUE-2 decomposes into ISSUE-4 and ISSUE-5 → ISSUE-2 is decomposition-blocked
+3. ISSUE-4 and ISSUE-5 reach terminal → ISSUE-2 unblocks, worker re-runs
+4. ISSUE-2 reaches terminal → all children of ISSUE-1 are terminal → ISSUE-1 unblocks
+
+### Dependency edges (`depends_on`)
+
+Express "I need these issues done before I can start." When all dependencies reach terminal, the issue proceeds normally.
+
+**Diamond dependencies** are supported:
+```
+A decomposes into:
+  db (no dependencies)
+  users (depends_on: [db])
+  orders (depends_on: [db])
+```
+
+Both `users` and `orders` wait for `db`. This is not possible in a tree model where each issue has a single parent.
+
+### Cycle prevention
+
+The reducer validates that `depends_on` references only exist between siblings (issues in the same decompose result). This prevents cycles by construction — you can't depend on an issue outside your decompose group, and you can't depend on yourself.
+
+### Blocking summary
+
+An issue is **blocked** if:
+- It has children (`decomposed_from == this_id`) that are not all terminal, OR
+- It has `depends_on` entries that are not all terminal
+
+Both are computed — there is no `blocked` boolean in the state.
 
 ## Sub-Issue Creation Path
 
-Sub-issues created via `action: decompose` are added directly to the reducer state (not via a `Create` event). This is intentional — the reducer handles the full decomposition atomically in a single step. The sub-issues enter at the `initial` state with `parent` set.
+Sub-issues created via `action: decompose` are added directly to the reducer state (not via a `Create` event). This is intentional — the reducer handles the full decomposition atomically in a single step. The sub-issues enter at the `initial` state with `decomposed_from` set. Dependencies between siblings are resolved from `key` references to real IDs during creation.
+
+## Empty Decompose
+
+Returning `action: decompose` with an empty `sub_issues` list is an **error**. The reducer rejects the event, returns state unchanged, and emits an `Error` effect. Rationale: empty decompose would cause immediate vacuous unblock (zero children are trivially "all terminal"), leading to infinite loops if the worker keeps returning decompose with no children.
 
 ## ID Generation
 
@@ -439,7 +529,7 @@ states:
           type: list
           required_when: decompose
           items: $issue
-          description: "Sub-issues to create when decomposing"
+          description: "Sub-issues to create. Each item may include 'key' (sibling ref) and 'depends_on' (list of sibling keys)."
     on:
       ready: implementing
       decompose:
@@ -568,3 +658,5 @@ Each `apply` worker rebases onto the latest main before merging. Since only one 
 - **Worker type/command** — `worker` currently only defines `result_format`. Eventually it will need to specify which CLI agent to invoke. Out of scope for the reducer.
 - **Additional field types** — `integer`, `boolean`, `object` in `result_format` and `issue.fields`.
 - **Conditional transitions** — routing based on multiple fields, not just `outcome`.
+- **Cross-group dependencies** — currently `depends_on` only supports siblings within the same decompose result. A future `AddDependency` event could link any two existing issues, enabling cross-group dependency graphs.
+- **Dependency cycle detection** — currently prevented by construction (sibling-only). If cross-group dependencies are added, explicit cycle detection will be needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ dependencies = [
     "pyyaml>=6.0.3",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ name = "orca"
 version = "0.1.0"
 description = ""
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0.3",
+]
 
 [tool.ruff]
 target-version = "py312"
@@ -22,5 +24,6 @@ warn_unused_configs = true
 dev = [
     "mypy>=1.19.1",
     "pre-commit>=4.5.1",
+    "pytest>=9.0.2",
     "ruff>=0.15.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,5 @@ dev = [
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "ruff>=0.15.7",
+    "types-pyyaml>=6.0.12.20250915",
 ]

--- a/src/orca/engine/__init__.py
+++ b/src/orca/engine/__init__.py
@@ -1,0 +1,34 @@
+"""Orca state machine engine."""
+
+from orca.engine.config import ConfigValidationError, parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    Effect,
+    ErrorEffect,
+    Event,
+    Issue,
+    State,
+    StateMachineConfig,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+__all__ = [
+    "ConfigValidationError",
+    "parse_config",
+    "reduce",
+    "AdvanceEvent",
+    "CreateEvent",
+    "DispatchWorkerEffect",
+    "Effect",
+    "ErrorEffect",
+    "Event",
+    "Issue",
+    "State",
+    "StateMachineConfig",
+    "WorkerFailedEvent",
+    "WorkerResultEvent",
+]

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from orca.engine.types import (
+    EnumFieldDef,
+    FieldDef,
+    ListFieldDef,
+    OnDecompose,
+    OnRule,
+    OnTransition,
+    ResultFormatField,
+    StateDef,
+    StateMachineConfig,
+    StringFieldDef,
+    WorkerDef,
+)
+
+
+class ConfigValidationError(Exception):
+    pass
+
+
+def _parse_required_when(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [str(v) for v in raw]
+    msg = f"required_when must be a string or list, got {type(raw)}"
+    raise ConfigValidationError(msg)
+
+
+def _parse_result_format_field(name: str, data: dict[str, Any]) -> ResultFormatField:
+    field_type = data.get("type")
+    description = data.get("description", "")
+
+    if field_type == "enum":
+        return EnumFieldDef(
+            values=data.get("values", []),
+            description=description,
+            values_description=data.get("values_description", {}),
+        )
+    elif field_type == "string":
+        return StringFieldDef(
+            description=description,
+            required_when=_parse_required_when(data.get("required_when")),
+        )
+    elif field_type == "list":
+        return ListFieldDef(
+            description=description,
+            items=data.get("items", ""),
+            required_when=_parse_required_when(data.get("required_when")),
+        )
+    else:
+        msg = f"Unknown result_format field type '{field_type}' for field '{name}'"
+        raise ConfigValidationError(msg)
+
+
+def _parse_on_rule(key: str, value: Any) -> OnRule:
+    if isinstance(value, str):
+        return OnTransition(target=value)
+    if isinstance(value, dict):
+        action = value.get("action")
+        if action == "decompose":
+            return OnDecompose()
+        msg = f"Unknown action '{action}' in on.{key}"
+        raise ConfigValidationError(msg)
+    msg = f"Invalid on rule for key '{key}': expected string or dict"
+    raise ConfigValidationError(msg)
+
+
+def _parse_state(name: str, raw_data: dict[str, Any] | None) -> StateDef:
+    if raw_data is None:
+        raw_data = {}
+    # YAML parses bare `on` as boolean True key; normalize to string key
+    data: dict[str, Any] = {}
+    for k, v in raw_data.items():
+        data[str(k)] = v
+
+    terminal = data.get("terminal", False)
+    max_workers = data.get("max_workers")
+
+    worker: WorkerDef | None = None
+    worker_data = data.get("worker")
+    if worker_data is not None:
+        rf_data: dict[str, Any] = worker_data.get("result_format", {})
+        result_format: dict[str, ResultFormatField] = {}
+        for field_name, field_data in rf_data.items():
+            result_format[field_name] = _parse_result_format_field(field_name, field_data)
+        worker = WorkerDef(result_format=result_format)
+
+    on: dict[str, OnRule] = {}
+    on_data = data.get("True") or data.get("on")
+    if on_data is not None:
+        for key, value in on_data.items():
+            on[key] = _parse_on_rule(key, value)
+
+    return StateDef(
+        worker=worker,
+        on=on,
+        terminal=terminal,
+        max_workers=max_workers,
+    )
+
+
+def _parse_issue_fields(data: dict[str, Any] | None) -> dict[str, FieldDef]:
+    if not data:
+        return {}
+    result: dict[str, FieldDef] = {}
+    for name, field_data in data.items():
+        result[name] = FieldDef(
+            type=field_data.get("type", ""),
+            description=field_data.get("description", ""),
+        )
+    return result
+
+
+def _validate(config: StateMachineConfig) -> None:
+    state_names = set(config.states.keys())
+
+    # Rule 1: initial references an existing state
+    if config.initial not in state_names:
+        msg = f"initial state '{config.initial}' does not reference an existing state"
+        raise ConfigValidationError(msg)
+
+    # Rule 6: at least one terminal state
+    terminal_states = {name for name, s in config.states.items() if s.terminal}
+    if not terminal_states:
+        msg = "At least one terminal state is required"
+        raise ConfigValidationError(msg)
+
+    # Collect reachable targets for rule 8
+    reachable: set[str] = {config.initial}
+
+    for name, state in config.states.items():
+        # Rule 9: max_workers must be positive integer
+        if state.max_workers is not None and (not isinstance(state.max_workers, int) or state.max_workers < 1):
+            msg = f"max_workers for state '{name}' must be a positive integer, got {state.max_workers}"
+            raise ConfigValidationError(msg)
+
+        # Rule 5: terminal states have no worker or on
+        if state.terminal:
+            if state.worker is not None or state.on:
+                msg = f"Terminal state '{name}' must not have worker or on rules"
+                raise ConfigValidationError(msg)
+            continue
+
+        # Rule 4: active states (with worker+on) must have outcome enum in result_format
+        if state.worker is not None and state.on:
+            outcome = state.worker.result_format.get("outcome")
+            if not isinstance(outcome, EnumFieldDef):
+                msg = f"Active state '{name}' must have 'outcome' of type enum in result_format"
+                raise ConfigValidationError(msg)
+
+            # Rule 3: every on key matches a value in outcome.values
+            for key in state.on:
+                if key not in outcome.values:
+                    msg = f"on key '{key}' in state '{name}' does not match any outcome value ({outcome.values})"
+                    raise ConfigValidationError(msg)
+
+        # Rule 2: every on target references an existing state
+        for key, rule in state.on.items():
+            if isinstance(rule, OnTransition):
+                if rule.target not in state_names:
+                    msg = f"on.{key} target '{rule.target}' in state '{name}' does not reference an existing state"
+                    raise ConfigValidationError(msg)
+                reachable.add(rule.target)
+
+        # Rule 7: action decompose requires sub_issues with items=$issue
+        for _key, rule in state.on.items():
+            if isinstance(rule, OnDecompose):
+                if state.worker is None:
+                    msg = f"State '{name}' has decompose action but no worker"
+                    raise ConfigValidationError(msg)
+                sub = state.worker.result_format.get("sub_issues")
+                if not isinstance(sub, ListFieldDef) or sub.items != "$issue":
+                    msg = (
+                        f"State '{name}' has action: decompose but result_format is missing "
+                        f"'sub_issues' field with items: $issue"
+                    )
+                    raise ConfigValidationError(msg)
+
+    # Rule 8: every non-initial, non-passive state must be reachable
+    for name, state in config.states.items():
+        if name in reachable:
+            continue
+        # Passive states (no worker, no on, not terminal) are exempt
+        is_passive = state.worker is None and not state.on and not state.terminal
+        if is_passive:
+            continue
+        msg = f"State '{name}' is not reachable from any on rule"
+        raise ConfigValidationError(msg)
+
+
+def parse_config(yaml_str: str) -> StateMachineConfig:
+    """Parse a YAML string into a StateMachineConfig."""
+    raw: Any = yaml.safe_load(yaml_str)
+    if not isinstance(raw, dict):
+        msg = "Config must be a YAML mapping"
+        raise ConfigValidationError(msg)
+
+    # Parse issue fields
+    issue_data = raw.get("issue", {})
+    fields_data = issue_data.get("fields") if isinstance(issue_data, dict) else None
+    issue_fields = _parse_issue_fields(fields_data)
+
+    # Parse states
+    states_data: dict[str, Any] = raw.get("states", {})
+    states: dict[str, StateDef] = {}
+    for name, state_data in states_data.items():
+        states[name] = _parse_state(name, state_data)
+
+    initial: str = raw.get("initial", "")
+
+    config = StateMachineConfig(
+        issue_fields=issue_fields,
+        initial=initial,
+        states=states,
+    )
+
+    _validate(config)
+
+    return config

--- a/src/orca/engine/dispatch.py
+++ b/src/orca/engine/dispatch.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+from orca.engine.types import (
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    ListFieldDef,
+    State,
+    StateMachineConfig,
+    StringFieldDef,
+)
+
+
+def get_children(state: State, issue_id: str) -> list[str]:
+    """Returns list of issue IDs where decomposed_from == issue_id."""
+    return [iid for iid, issue in state.issues.items() if issue.decomposed_from == issue_id]
+
+
+def is_blocked(state: State, config: StateMachineConfig, issue_id: str) -> bool:
+    """Returns True if the issue is decomposition-blocked or dependency-blocked."""
+    issue = state.issues[issue_id]
+
+    # Decomposition-blocked: has children not all in terminal states
+    children = get_children(state, issue_id)
+    if children:
+        for child_id in children:
+            child = state.issues[child_id]
+            child_state_def = config.states[child.state]
+            if not child_state_def.terminal:
+                return True
+
+    # Dependency-blocked: has depends_on entries not all in terminal states
+    for dep_id in issue.depends_on:
+        dep = state.issues[dep_id]
+        dep_state_def = config.states[dep.state]
+        if not dep_state_def.terminal:
+            return True
+
+    return False
+
+
+def build_issue_context(state: State, issue_id: str) -> dict[str, Any]:
+    """Builds the issue context dict for DispatchWorkerEffect."""
+    issue = state.issues[issue_id]
+    children_ids = get_children(state, issue_id)
+    children: list[dict[str, Any]] = []
+    for child_id in children_ids:
+        child = state.issues[child_id]
+        children.append(
+            {
+                "issue_id": child_id,
+                "fields": child.fields,
+                "state": child.state,
+                "result_history": [entry.to_dict() for entry in child.result_history],
+            }
+        )
+    return {
+        "fields": issue.fields,
+        "result_history": [entry.to_dict() for entry in issue.result_history],
+        "decomposed_from": issue.decomposed_from,
+        "depends_on": issue.depends_on,
+        "children": children,
+    }
+
+
+def build_result_format(config: StateMachineConfig, state_name: str) -> dict[str, Any]:
+    """Serializes the result_format from config into a plain dict."""
+    state_def = config.states[state_name]
+    if state_def.worker is None:
+        return {}
+    result: dict[str, Any] = {}
+    for name, field_def in state_def.worker.result_format.items():
+        if isinstance(field_def, EnumFieldDef):
+            result[name] = {
+                "type": "enum",
+                "values": field_def.values,
+                "description": field_def.description,
+                "values_description": field_def.values_description,
+            }
+        elif isinstance(field_def, StringFieldDef):
+            result[name] = {
+                "type": "string",
+                "description": field_def.description,
+                "required_when": field_def.required_when,
+            }
+        elif isinstance(field_def, ListFieldDef):
+            result[name] = {
+                "type": "list",
+                "description": field_def.description,
+                "items": field_def.items,
+                "required_when": field_def.required_when,
+            }
+    return result
+
+
+def try_dispatch(
+    config: StateMachineConfig,
+    state: State,
+    issue_id: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    """Core dispatch protocol."""
+    issue = state.issues[issue_id]
+    state_name = issue.state
+    state_def = config.states[state_name]
+
+    # 1. If issue is blocked, don't dispatch
+    if is_blocked(state, config, issue_id):
+        return
+
+    # 2. If state has no worker, don't dispatch
+    if state_def.worker is None:
+        return
+
+    # 3. If state has max_workers and active count >= limit, queue the issue
+    if state_def.max_workers is not None:
+        active_count = sum(1 for iid, iss in state.issues.items() if iss.state == state_name and iss.worker_active)
+        if active_count >= state_def.max_workers:
+            queue = state.worker_queues.setdefault(state_name, [])
+            queue.append(issue_id)
+            return
+
+    # 4. Dispatch
+    issue.worker_active = True
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=issue_id,
+            state=state_name,
+            result_format=build_result_format(config, state_name),
+            issue=build_issue_context(state, issue_id),
+        )
+    )
+
+
+def backfill_queue(
+    config: StateMachineConfig,
+    state: State,
+    state_name: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    """When a slot frees up in a capped state, pop next non-blocked issue from queue and dispatch."""
+    queue = state.worker_queues.get(state_name)
+    if not queue:
+        return
+
+    # Find next non-blocked issue in queue
+    for i, issue_id in enumerate(queue):
+        if not is_blocked(state, config, issue_id):
+            queue.pop(i)
+            try_dispatch(config, state, issue_id, effects)
+            return
+
+
+def remove_from_queue(state: State, state_name: str, issue_id: str) -> None:
+    """Remove an issue from a state's queue."""
+    queue = state.worker_queues.get(state_name)
+    if queue is None:
+        return
+    with contextlib.suppress(ValueError):
+        queue.remove(issue_id)

--- a/src/orca/engine/dispatch.py
+++ b/src/orca/engine/dispatch.py
@@ -116,7 +116,7 @@ def try_dispatch(
 
     # 3. If state has max_workers and active count >= limit, queue the issue
     if state_def.max_workers is not None:
-        active_count = sum(1 for iid, iss in state.issues.items() if iss.state == state_name and iss.worker_active)
+        active_count = sum(1 for iss in state.issues.values() if iss.state == state_name and iss.worker_active)
         if active_count >= state_def.max_workers:
             queue = state.worker_queues.setdefault(state_name, [])
             queue.append(issue_id)

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import copy
 from collections.abc import Callable
 
-from orca.engine.dispatch import is_blocked, try_dispatch
+from orca.engine.dispatch import (
+    backfill_queue,
+    get_children,
+    is_blocked,
+    remove_from_queue,
+    try_dispatch,
+)
 from orca.engine.types import (
     AdvanceEvent,
     CreateEvent,
@@ -12,6 +18,9 @@ from orca.engine.types import (
     ErrorEffect,
     Event,
     Issue,
+    OnDecompose,
+    OnTransition,
+    ResultHistoryEntry,
     State,
     StateMachineConfig,
     WorkerFailedEvent,
@@ -33,7 +42,9 @@ def reduce(
         _handle_create(config, new_state, event, effects)
     elif isinstance(event, AdvanceEvent):
         _handle_advance(config, new_state, event, effects)
-    elif isinstance(event, WorkerResultEvent | WorkerFailedEvent):
+    elif isinstance(event, WorkerResultEvent):
+        _handle_worker_result(config, new_state, event, effects, generate_id)
+    elif isinstance(event, WorkerFailedEvent):
         pass
 
     return new_state, effects
@@ -120,3 +131,198 @@ def _handle_advance(
         dispatch_effects: list[DispatchWorkerEffect] = []
         try_dispatch(config, state, event.issue_id, dispatch_effects)
         effects.extend(dispatch_effects)
+
+
+def _handle_worker_result(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerResultEvent,
+    effects: list[Effect],
+    generate_id: Callable[[], str],
+) -> None:
+    # --- Validation (before any mutation) ---
+
+    # Issue must exist
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    state_def = config.states[issue.state]
+
+    # Issue must not be in terminal state
+    if state_def.terminal:
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"Issue '{event.issue_id}' is in terminal state '{issue.state}'",
+            )
+        )
+        return
+
+    # Issue must have worker_active == True
+    if not issue.worker_active:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' has worker_active=False")
+        )
+        return
+
+    # Issue must not be blocked
+    if is_blocked(state, config, event.issue_id):
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is blocked"))
+        return
+
+    # State must have a worker
+    if state_def.worker is None:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"State '{issue.state}' has no worker"))
+        return
+
+    # outcome must exist in result and be in state_def.on
+    outcome = event.result.get("outcome")
+    if outcome is None or outcome not in state_def.on:
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"Outcome '{outcome}' is not valid for state '{issue.state}'",
+            )
+        )
+        return
+
+    rule = state_def.on[outcome]
+
+    # If decompose, validate sub_issues is not empty (before mutation)
+    if isinstance(rule, OnDecompose):
+        sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
+        if not sub_issues:
+            effects.append(ErrorEffect(issue_id=event.issue_id, message="Decompose requires non-empty sub_issues"))
+            return
+
+    # --- Mutation ---
+
+    old_state_name = issue.state
+
+    # 1. Set worker_active = False (frees slot)
+    issue.worker_active = False
+
+    # 2. Append ResultHistoryEntry
+    issue.result_history.append(ResultHistoryEntry(state=issue.state, result=event.result))
+
+    # Slot backfill: if old state has max_workers, backfill
+    dispatch_effects: list[DispatchWorkerEffect] = []
+    if state_def.max_workers is not None:
+        backfill_queue(config, state, old_state_name, dispatch_effects)
+
+    # 3. Route based on rule type
+    if isinstance(rule, OnTransition):
+        _apply_transition(config, state, event.issue_id, issue, old_state_name, rule.target, dispatch_effects)
+    elif isinstance(rule, OnDecompose):
+        _apply_decompose(config, state, event, issue, generate_id, dispatch_effects)
+
+    effects.extend(dispatch_effects)
+
+
+def _apply_transition(
+    config: StateMachineConfig,
+    state: State,
+    issue_id: str,
+    issue: Issue,
+    old_state_name: str,
+    target_state: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    # Remove issue from old state's worker queue
+    remove_from_queue(state, old_state_name, issue_id)
+
+    # Move issue to target state
+    issue.state = target_state
+    target_def = config.states[target_state]
+
+    if target_def.terminal:
+        # Run cascading unblock check
+        _cascading_unblock(config, state, issue_id, effects)
+    elif target_def.worker is not None:
+        # Target is active -> dispatch
+        try_dispatch(config, state, issue_id, effects)
+
+
+def _apply_decompose(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerResultEvent,
+    _parent_issue: Issue,
+    generate_id: Callable[[], str],
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
+
+    # Generate IDs and build key -> real_id mapping
+    key_to_id: dict[str, str] = {}
+    for sub in sub_issues:
+        key = str(sub.get("key", ""))
+        real_id = generate_id()
+        key_to_id[key] = real_id
+
+    # Create child issues
+    for sub in sub_issues:
+        key = str(sub.get("key", ""))
+        real_id = key_to_id[key]
+        fields: dict[str, object] = sub.get("fields", {})  # type: ignore[assignment]
+
+        # Resolve depends_on keys to real IDs
+        raw_depends: list[str] = sub.get("depends_on", [])  # type: ignore[assignment]
+        resolved_depends: list[str] = []
+        for dep_key in raw_depends:
+            if dep_key not in key_to_id:
+                # This shouldn't happen if spec is followed, but handle it
+                pass
+            else:
+                resolved_depends.append(key_to_id[dep_key])
+
+        child = Issue(
+            fields=dict(fields),
+            state=config.initial,
+            worker_active=False,
+            decomposed_from=event.issue_id,
+            depends_on=resolved_depends,
+            result_history=[],
+        )
+        state.issues[real_id] = child
+
+    # Dispatch each child that is not blocked and whose initial state is active
+    initial_def = config.states[config.initial]
+    if initial_def.worker is not None:
+        for _key, real_id in key_to_id.items():
+            if not is_blocked(state, config, real_id):
+                try_dispatch(config, state, real_id, effects)
+
+
+def _cascading_unblock(
+    config: StateMachineConfig,
+    state: State,
+    terminal_issue_id: str,
+    effects: list[DispatchWorkerEffect],
+) -> None:
+    terminal_issue = state.issues[terminal_issue_id]
+
+    # 1. Decomposition unblock: if this issue has a parent, check if all siblings are terminal
+    if terminal_issue.decomposed_from is not None:
+        parent_id = terminal_issue.decomposed_from
+        parent = state.issues[parent_id]
+        children = get_children(state, parent_id)
+        all_terminal = all(config.states[state.issues[cid].state].terminal for cid in children)
+        if all_terminal and not parent.worker_active:
+            # Parent is no longer decomposition-blocked -> dispatch
+            try_dispatch(config, state, parent_id, effects)
+
+    # 2. Dependency unblock: find all issues that depend on the terminal issue
+    for iid, iss in state.issues.items():
+        if terminal_issue_id in iss.depends_on:
+            # Check if all depends_on are now terminal
+            all_deps_terminal = all(config.states[state.issues[dep_id].state].terminal for dep_id in iss.depends_on)
+            if (
+                all_deps_terminal
+                and not is_blocked(state, config, iid)
+                and not iss.worker_active
+                and config.states[iss.state].worker is not None
+            ):
+                try_dispatch(config, state, iid, effects)

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 
 from orca.engine.dispatch import (
     backfill_queue,
+    build_issue_context,
+    build_result_format,
     get_children,
     is_blocked,
     remove_from_queue,
@@ -45,7 +47,7 @@ def reduce(
     elif isinstance(event, WorkerResultEvent):
         _handle_worker_result(config, new_state, event, effects, generate_id)
     elif isinstance(event, WorkerFailedEvent):
-        pass
+        _handle_worker_failed(config, new_state, event, effects)
 
     return new_state, effects
 
@@ -219,6 +221,44 @@ def _handle_worker_result(
         _apply_decompose(config, state, event, issue, generate_id, dispatch_effects)
 
     effects.extend(dispatch_effects)
+
+
+def _handle_worker_failed(
+    config: StateMachineConfig,
+    state: State,
+    event: WorkerFailedEvent,
+    effects: list[Effect],
+) -> None:
+    # Issue must exist
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    state_def = config.states[issue.state]
+
+    # Issue must have worker_active == True
+    if not issue.worker_active:
+        effects.append(
+            ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' has worker_active=False")
+        )
+        return
+
+    # State must have a worker
+    if state_def.worker is None:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"State '{issue.state}' has no worker"))
+        return
+
+    # worker_active stays True — slot is RETAINED (not freed)
+    # Emit DispatchWorkerEffect unconditionally (retry), bypassing dispatch protocol
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=event.issue_id,
+            state=issue.state,
+            result_format=build_result_format(config, issue.state),
+            issue=build_issue_context(state, event.issue_id),
+        )
+    )
 
 
 def _apply_transition(

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+
+from orca.engine.dispatch import is_blocked, try_dispatch
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    Effect,
+    ErrorEffect,
+    Event,
+    Issue,
+    State,
+    StateMachineConfig,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+def reduce(
+    config: StateMachineConfig,
+    state: State,
+    event: Event,
+    generate_id: Callable[[], str],
+) -> tuple[State, list[Effect]]:
+    """Dispatch event to the appropriate handler and return (new_state, effects)."""
+    new_state = copy.deepcopy(state)
+    effects: list[Effect] = []
+
+    if isinstance(event, CreateEvent):
+        _handle_create(config, new_state, event, effects)
+    elif isinstance(event, AdvanceEvent):
+        _handle_advance(config, new_state, event, effects)
+    elif isinstance(event, WorkerResultEvent | WorkerFailedEvent):
+        pass
+
+    return new_state, effects
+
+
+def _handle_create(
+    config: StateMachineConfig,
+    state: State,
+    event: CreateEvent,
+    effects: list[Effect],
+) -> None:
+    if event.issue_id in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' already exists"))
+        return
+
+    issue = Issue(
+        fields=event.fields,
+        state=config.initial,
+        worker_active=False,
+        decomposed_from=None,
+        depends_on=[],
+        result_history=[],
+    )
+    state.issues[event.issue_id] = issue
+
+    # If initial state is active (has a worker), dispatch
+    state_def = config.states[config.initial]
+    if state_def.worker is not None:
+        dispatch_effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, event.issue_id, dispatch_effects)
+        effects.extend(dispatch_effects)
+
+
+def _handle_advance(
+    config: StateMachineConfig,
+    state: State,
+    event: AdvanceEvent,
+    effects: list[Effect],
+) -> None:
+    # Issue must exist
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    current_state_def = config.states[issue.state]
+
+    # Must be in a passive state (no worker and not terminal)
+    if current_state_def.worker is not None or current_state_def.terminal:
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"Issue '{event.issue_id}' is not in a passive state (current: '{issue.state}')",
+            )
+        )
+        return
+
+    # Must not be blocked
+    if is_blocked(state, config, event.issue_id):
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"Issue '{event.issue_id}' is blocked",
+            )
+        )
+        return
+
+    # Target state must exist
+    if event.target_state not in config.states:
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"State '{event.target_state}' does not exist in config",
+            )
+        )
+        return
+
+    # Move to target state
+    issue.state = event.target_state
+
+    # If target state is active, dispatch
+    target_state_def = config.states[event.target_state]
+    if target_state_def.worker is not None:
+        dispatch_effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, event.issue_id, dispatch_effects)
+        effects.extend(dispatch_effects)

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# --- Config types (frozen) ---
+
+
+@dataclass(frozen=True)
+class FieldDef:
+    type: str
+    description: str
+
+
+@dataclass(frozen=True)
+class EnumFieldDef:
+    values: list[str]
+    description: str
+    values_description: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StringFieldDef:
+    description: str
+    required_when: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ListFieldDef:
+    description: str
+    items: str
+    required_when: list[str] = field(default_factory=list)
+
+
+ResultFormatField = EnumFieldDef | StringFieldDef | ListFieldDef
+
+
+@dataclass(frozen=True)
+class WorkerDef:
+    result_format: dict[str, ResultFormatField]
+
+
+@dataclass(frozen=True)
+class OnTransition:
+    target: str
+
+
+@dataclass(frozen=True)
+class OnDecompose:
+    pass
+
+
+OnRule = OnTransition | OnDecompose
+
+
+@dataclass(frozen=True)
+class StateDef:
+    worker: WorkerDef | None = None
+    on: dict[str, OnRule] = field(default_factory=dict)
+    terminal: bool = False
+    max_workers: int | None = None
+
+
+@dataclass(frozen=True)
+class StateMachineConfig:
+    issue_fields: dict[str, FieldDef]
+    initial: str
+    states: dict[str, StateDef]
+
+
+# --- Runtime state types (mutable, with serialization) ---
+
+
+@dataclass
+class ResultHistoryEntry:
+    state: str
+    result: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"state": self.state, "result": self.result}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResultHistoryEntry:
+        return cls(state=data["state"], result=data["result"])
+
+
+@dataclass
+class Issue:
+    fields: dict[str, Any]
+    state: str
+    worker_active: bool
+    decomposed_from: str | None
+    depends_on: list[str]
+    result_history: list[ResultHistoryEntry]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fields": self.fields,
+            "state": self.state,
+            "worker_active": self.worker_active,
+            "decomposed_from": self.decomposed_from,
+            "depends_on": self.depends_on,
+            "result_history": [entry.to_dict() for entry in self.result_history],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Issue:
+        return cls(
+            fields=data["fields"],
+            state=data["state"],
+            worker_active=data["worker_active"],
+            decomposed_from=data["decomposed_from"],
+            depends_on=data["depends_on"],
+            result_history=[ResultHistoryEntry.from_dict(e) for e in data["result_history"]],
+        )
+
+
+@dataclass
+class State:
+    issues: dict[str, Issue]
+    worker_queues: dict[str, list[str]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issues": {k: v.to_dict() for k, v in self.issues.items()},
+            "worker_queues": self.worker_queues,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> State:
+        return cls(
+            issues={k: Issue.from_dict(v) for k, v in data["issues"].items()},
+            worker_queues=data["worker_queues"],
+        )
+
+
+# --- Events (frozen) ---
+
+
+@dataclass(frozen=True)
+class CreateEvent:
+    issue_id: str
+    fields: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AdvanceEvent:
+    issue_id: str
+    target_state: str
+
+
+@dataclass(frozen=True)
+class WorkerResultEvent:
+    issue_id: str
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WorkerFailedEvent:
+    issue_id: str
+    error: str
+
+
+Event = CreateEvent | AdvanceEvent | WorkerResultEvent | WorkerFailedEvent
+
+
+# --- Effects (frozen) ---
+
+
+@dataclass(frozen=True)
+class DispatchWorkerEffect:
+    issue_id: str
+    state: str
+    result_format: dict[str, Any]
+    issue: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ErrorEffect:
+    issue_id: str
+    message: str
+
+
+Effect = DispatchWorkerEffect | ErrorEffect

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def simple_config_yaml() -> str:
+    return """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Issue title
+    priority:
+      type: enum
+      description: Priority level
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision to start work
+    on:
+      start: implementing
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+            - reject
+          description: Implementation outcome
+        reason:
+          type: string
+          description: Explanation
+          required_when: reject
+    on:
+      complete: done
+      reject: todo
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+
+@pytest.fixture()
+def decompose_config_yaml() -> str:
+    return """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Issue title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - scope
+          description: Decision
+    on:
+      scope: scoping
+
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - decompose
+            - implement
+          description: Scoping decision
+        sub_issues:
+          type: list
+          items: "$issue"
+          description: Sub-issues to create
+          required_when:
+            - decompose
+    on:
+      decompose:
+        action: decompose
+      implement: implementing
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+          description: Implementation outcome
+    on:
+      complete: done
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+
+@pytest.fixture()
+def max_workers_config_yaml() -> str:
+    return """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Issue title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - ready
+          description: Outcome
+    on:
+      ready: apply
+
+  apply:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - applied
+          description: Apply result
+    on:
+      applied: done
+
+  done:
+    terminal: true
+
+initial: todo
+"""

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import pytest
+
+from orca.engine.config import ConfigValidationError, parse_config
+from orca.engine.types import (
+    EnumFieldDef,
+    ListFieldDef,
+    OnDecompose,
+    OnTransition,
+    StringFieldDef,
+)
+
+
+class TestParseSimpleConfig:
+    def test_states_exist(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert set(cfg.states.keys()) == {"todo", "implementing", "done"}
+
+    def test_initial_state(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.initial == "todo"
+
+    def test_terminal_state(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.states["done"].terminal is True
+        assert cfg.states["done"].worker is None
+        assert cfg.states["done"].on == {}
+
+    def test_active_state_worker(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        state = cfg.states["todo"]
+        assert state.worker is not None
+        assert "outcome" in state.worker.result_format
+        outcome = state.worker.result_format["outcome"]
+        assert isinstance(outcome, EnumFieldDef)
+        assert outcome.values == ["start"]
+
+    def test_on_rules(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.states["todo"].on == {"start": OnTransition(target="implementing")}
+        assert cfg.states["implementing"].on == {
+            "complete": OnTransition(target="done"),
+            "reject": OnTransition(target="todo"),
+        }
+
+    def test_string_result_format_field(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        rf = cfg.states["implementing"].worker
+        assert rf is not None
+        reason = rf.result_format["reason"]
+        assert isinstance(reason, StringFieldDef)
+        assert reason.description == "Explanation"
+
+    def test_required_when_normalization(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        rf = cfg.states["implementing"].worker
+        assert rf is not None
+        reason = rf.result_format["reason"]
+        assert isinstance(reason, StringFieldDef)
+        assert reason.required_when == ["reject"]
+
+
+class TestParseDecomposeConfig:
+    def test_on_decompose_rule(self, decompose_config_yaml: str) -> None:
+        cfg = parse_config(decompose_config_yaml)
+        assert isinstance(cfg.states["scoping"].on["decompose"], OnDecompose)
+
+    def test_on_transition_rule(self, decompose_config_yaml: str) -> None:
+        cfg = parse_config(decompose_config_yaml)
+        assert cfg.states["scoping"].on["implement"] == OnTransition(target="implementing")
+
+    def test_list_field_def_with_issue_items(self, decompose_config_yaml: str) -> None:
+        cfg = parse_config(decompose_config_yaml)
+        worker = cfg.states["scoping"].worker
+        assert worker is not None
+        sub = worker.result_format["sub_issues"]
+        assert isinstance(sub, ListFieldDef)
+        assert sub.items == "$issue"
+        assert sub.required_when == ["decompose"]
+
+
+class TestParseMaxWorkersConfig:
+    def test_max_workers(self, max_workers_config_yaml: str) -> None:
+        cfg = parse_config(max_workers_config_yaml)
+        assert cfg.states["apply"].max_workers == 1
+
+    def test_no_max_workers_default(self, max_workers_config_yaml: str) -> None:
+        cfg = parse_config(max_workers_config_yaml)
+        assert cfg.states["todo"].max_workers is None
+
+
+class TestParseIssueFields:
+    def test_issue_fields(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert "title" in cfg.issue_fields
+        assert cfg.issue_fields["title"].type == "string"
+        assert cfg.issue_fields["title"].description == "Issue title"
+        assert "priority" in cfg.issue_fields
+        assert cfg.issue_fields["priority"].type == "enum"
+
+
+class TestValidationErrors:
+    def test_initial_references_existing_state(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    terminal: true
+initial: nonexistent
+"""
+        with pytest.raises(ConfigValidationError, match="initial.*nonexistent"):
+            parse_config(yaml_str)
+
+    def test_on_target_references_existing_state(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [start]
+          description: d
+    on:
+      start: ghost
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="ghost"):
+            parse_config(yaml_str)
+
+    def test_on_key_matches_outcome_values(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [start]
+          description: d
+    on:
+      bogus: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="bogus"):
+            parse_config(yaml_str)
+
+    def test_active_state_requires_outcome_enum(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        reason:
+          type: string
+          description: d
+    on:
+      x: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="outcome"):
+            parse_config(yaml_str)
+
+    def test_terminal_state_no_worker_or_on(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [x]
+          description: d
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="[Tt]erminal"):
+            parse_config(yaml_str)
+
+    def test_at_least_one_terminal_state(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: todo
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="[Tt]erminal"):
+            parse_config(yaml_str)
+
+    def test_decompose_requires_sub_issues_field(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [decompose]
+          description: d
+    on:
+      decompose:
+        action: decompose
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="sub_issues"):
+            parse_config(yaml_str)
+
+    def test_unreachable_state(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  orphan:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [x]
+          description: d
+    on:
+      x: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="orphan"):
+            parse_config(yaml_str)
+
+    def test_max_workers_must_be_positive_integer(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    max_workers: 0
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="max_workers"):
+            parse_config(yaml_str)
+
+    def test_max_workers_negative(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    max_workers: -1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="max_workers"):
+            parse_config(yaml_str)

--- a/tests/engine/test_dispatch.py
+++ b/tests/engine/test_dispatch.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from orca.engine.dispatch import (
+    backfill_queue,
+    build_issue_context,
+    build_result_format,
+    get_children,
+    is_blocked,
+    remove_from_queue,
+    try_dispatch,
+)
+from orca.engine.types import (
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    FieldDef,
+    Issue,
+    ListFieldDef,
+    ResultHistoryEntry,
+    State,
+    StateDef,
+    StateMachineConfig,
+    StringFieldDef,
+    WorkerDef,
+)
+
+
+def _make_config(
+    states: dict[str, StateDef] | None = None,
+    initial: str = "todo",
+) -> StateMachineConfig:
+    if states is None:
+        states = {
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                    }
+                ),
+                on={},
+            ),
+            "implementing": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["complete"], description="Outcome"),
+                    }
+                ),
+                on={},
+            ),
+            "apply": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["applied"], description="Apply result"),
+                    }
+                ),
+                on={},
+                max_workers=1,
+            ),
+            "done": StateDef(terminal=True),
+        }
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial=initial,
+        states=states,
+    )
+
+
+def _make_issue(
+    state: str = "todo",
+    worker_active: bool = False,
+    decomposed_from: str | None = None,
+    depends_on: list[str] | None = None,
+    fields: dict[str, object] | None = None,
+    result_history: list[ResultHistoryEntry] | None = None,
+) -> Issue:
+    return Issue(
+        fields=fields or {"title": "Test"},
+        state=state,
+        worker_active=worker_active,
+        decomposed_from=decomposed_from,
+        depends_on=depends_on or [],
+        result_history=result_history or [],
+    )
+
+
+class TestIsBlocked:
+    def test_not_blocked_no_children_no_deps(self) -> None:
+        config = _make_config()
+        state = State(issues={"A": _make_issue()}, worker_queues={})
+        assert is_blocked(state, config, "A") is False
+
+    def test_blocked_non_terminal_children(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="todo"),
+                "B": _make_issue(state="implementing", decomposed_from="A"),
+            },
+            worker_queues={},
+        )
+        assert is_blocked(state, config, "A") is True
+
+    def test_not_blocked_all_children_terminal(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="todo"),
+                "B": _make_issue(state="done", decomposed_from="A"),
+            },
+            worker_queues={},
+        )
+        assert is_blocked(state, config, "A") is False
+
+    def test_blocked_non_terminal_depends_on(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="todo", depends_on=["B"]),
+                "B": _make_issue(state="implementing"),
+            },
+            worker_queues={},
+        )
+        assert is_blocked(state, config, "A") is True
+
+    def test_not_blocked_all_deps_terminal(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="todo", depends_on=["B"]),
+                "B": _make_issue(state="done"),
+            },
+            worker_queues={},
+        )
+        assert is_blocked(state, config, "A") is False
+
+
+class TestGetChildren:
+    def test_returns_children(self) -> None:
+        state = State(
+            issues={
+                "A": _make_issue(),
+                "B": _make_issue(decomposed_from="A"),
+                "C": _make_issue(decomposed_from="A"),
+                "D": _make_issue(decomposed_from="B"),
+            },
+            worker_queues={},
+        )
+        children = get_children(state, "A")
+        assert sorted(children) == ["B", "C"]
+
+    def test_no_children(self) -> None:
+        state = State(issues={"A": _make_issue()}, worker_queues={})
+        assert get_children(state, "A") == []
+
+
+class TestBuildIssueContext:
+    def test_includes_resolved_children(self) -> None:
+        state = State(
+            issues={
+                "A": _make_issue(state="todo", fields={"title": "Parent"}),
+                "B": _make_issue(
+                    state="done",
+                    decomposed_from="A",
+                    fields={"title": "Child1"},
+                    result_history=[ResultHistoryEntry(state="done", result={"outcome": "complete"})],
+                ),
+            },
+            worker_queues={},
+        )
+        ctx = build_issue_context(state, "A")
+        assert ctx["fields"] == {"title": "Parent"}
+        assert ctx["result_history"] == []
+        assert ctx["decomposed_from"] is None
+        assert ctx["depends_on"] == []
+        assert len(ctx["children"]) == 1
+        child = ctx["children"][0]
+        assert child["issue_id"] == "B"
+        assert child["fields"] == {"title": "Child1"}
+        assert child["state"] == "done"
+        assert child["result_history"] == [{"state": "done", "result": {"outcome": "complete"}}]
+
+
+class TestBuildResultFormat:
+    def test_enum_field(self) -> None:
+        config = _make_config()
+        result = build_result_format(config, "todo")
+        assert result["outcome"] == {
+            "type": "enum",
+            "values": ["start"],
+            "description": "Decision",
+            "values_description": {},
+        }
+
+    def test_string_field(self) -> None:
+        states = {
+            "review": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["approve"], description="Decision"),
+                        "reason": StringFieldDef(description="Explanation", required_when=["reject"]),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        }
+        config = _make_config(states=states, initial="review")
+        result = build_result_format(config, "review")
+        assert result["reason"] == {
+            "type": "string",
+            "description": "Explanation",
+            "required_when": ["reject"],
+        }
+
+    def test_list_field(self) -> None:
+        states = {
+            "scoping": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["decompose"], description="Decision"),
+                        "sub_issues": ListFieldDef(
+                            description="Sub-issues", items="$issue", required_when=["decompose"]
+                        ),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        }
+        config = _make_config(states=states, initial="scoping")
+        result = build_result_format(config, "scoping")
+        assert result["sub_issues"] == {
+            "type": "list",
+            "description": "Sub-issues",
+            "items": "$issue",
+            "required_when": ["decompose"],
+        }
+
+
+class TestTryDispatch:
+    def test_dispatch_no_limit(self) -> None:
+        config = _make_config()
+        state = State(issues={"A": _make_issue(state="todo")}, worker_queues={})
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "A", effects)
+        assert len(effects) == 1
+        assert effects[0].issue_id == "A"
+        assert effects[0].state == "todo"
+        assert state.issues["A"].worker_active is True
+
+    def test_dispatch_under_limit(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="apply"),
+            },
+            worker_queues={},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "A", effects)
+        assert len(effects) == 1
+        assert state.issues["A"].worker_active is True
+
+    def test_dispatch_at_limit_queues(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="apply", worker_active=True),
+                "B": _make_issue(state="apply"),
+            },
+            worker_queues={},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "B", effects)
+        assert len(effects) == 0
+        assert state.issues["B"].worker_active is False
+        assert state.worker_queues["apply"] == ["B"]
+
+    def test_blocked_issue_not_dispatched(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="todo"),
+                "B": _make_issue(state="implementing", decomposed_from="A"),
+            },
+            worker_queues={},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "A", effects)
+        assert len(effects) == 0
+        assert state.issues["A"].worker_active is False
+
+    def test_no_worker_not_dispatched(self) -> None:
+        config = _make_config()
+        state = State(issues={"A": _make_issue(state="done")}, worker_queues={})
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "A", effects)
+        assert len(effects) == 0
+
+
+class TestBackfillQueue:
+    def test_backfill_pops_next(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="apply"),
+                "B": _make_issue(state="apply"),
+            },
+            worker_queues={"apply": ["A", "B"]},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        backfill_queue(config, state, "apply", effects)
+        assert len(effects) == 1
+        assert effects[0].issue_id == "A"
+        assert state.issues["A"].worker_active is True
+        assert state.worker_queues["apply"] == ["B"]
+
+    def test_backfill_skips_blocked_decomposition(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="apply"),
+                "B": _make_issue(state="apply"),
+                "C": _make_issue(state="implementing", decomposed_from="A"),
+            },
+            worker_queues={"apply": ["A", "B"]},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        backfill_queue(config, state, "apply", effects)
+        assert len(effects) == 1
+        assert effects[0].issue_id == "B"
+        assert state.worker_queues["apply"] == ["A"]
+
+    def test_backfill_skips_blocked_dependency(self) -> None:
+        config = _make_config()
+        state = State(
+            issues={
+                "A": _make_issue(state="apply", depends_on=["C"]),
+                "B": _make_issue(state="apply"),
+                "C": _make_issue(state="implementing"),
+            },
+            worker_queues={"apply": ["A", "B"]},
+        )
+        effects: list[DispatchWorkerEffect] = []
+        backfill_queue(config, state, "apply", effects)
+        assert len(effects) == 1
+        assert effects[0].issue_id == "B"
+        assert state.worker_queues["apply"] == ["A"]
+
+
+class TestRemoveFromQueue:
+    def test_remove_existing(self) -> None:
+        state = State(issues={}, worker_queues={"apply": ["A", "B", "C"]})
+        remove_from_queue(state, "apply", "B")
+        assert state.worker_queues["apply"] == ["A", "C"]
+
+    def test_remove_nonexistent_no_error(self) -> None:
+        state = State(issues={}, worker_queues={"apply": ["A"]})
+        remove_from_queue(state, "apply", "Z")
+        assert state.worker_queues["apply"] == ["A"]
+
+    def test_remove_from_missing_queue_no_error(self) -> None:
+        state = State(issues={}, worker_queues={})
+        remove_from_queue(state, "apply", "A")  # should not raise

--- a/tests/engine/test_reducer_advance.py
+++ b/tests/engine/test_reducer_advance.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    ErrorEffect,
+    FieldDef,
+    Issue,
+    State,
+    StateDef,
+    StateMachineConfig,
+    WorkerDef,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def next_id() -> str:
+        nonlocal n
+        n += 1
+        return f"id-{n}"
+
+    return next_id
+
+
+def _make_issue(
+    state: str = "backlog",
+    worker_active: bool = False,
+    decomposed_from: str | None = None,
+    depends_on: list[str] | None = None,
+) -> Issue:
+    return Issue(
+        fields={"title": "Test"},
+        state=state,
+        worker_active=worker_active,
+        decomposed_from=decomposed_from,
+        depends_on=depends_on or [],
+        result_history=[],
+    )
+
+
+def _config() -> StateMachineConfig:
+    """Config with passive 'backlog', active 'todo' and 'implementing', terminal 'done'."""
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial="backlog",
+        states={
+            "backlog": StateDef(),
+            "review": StateDef(),
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                    }
+                ),
+                on={},
+            ),
+            "implementing": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["complete"], description="Outcome"),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+class TestAdvancePassiveToActive:
+    def test_state_changes_and_dispatch(self) -> None:
+        config = _config()
+        state = State(
+            issues={"A": _make_issue(state="backlog")},
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="todo")
+
+        new_state, effects = reduce(config, state, event, _counter())
+
+        assert new_state.issues["A"].state == "todo"
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+        assert effects[0].issue_id == "A"
+        assert effects[0].state == "todo"
+
+
+class TestAdvanceFromActive:
+    def test_error_when_in_active_state(self) -> None:
+        config = _config()
+        state = State(
+            issues={"A": _make_issue(state="todo")},
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="implementing")
+
+        _new_state, effects = reduce(config, state, event, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert effects[0].issue_id == "A"
+
+
+class TestAdvanceBlocked:
+    def test_error_when_blocked(self) -> None:
+        config = _config()
+        state = State(
+            issues={
+                "A": _make_issue(state="backlog"),
+                "B": _make_issue(state="implementing", decomposed_from="A"),
+            },
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="todo")
+
+        _new_state, effects = reduce(config, state, event, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert effects[0].issue_id == "A"
+
+
+class TestAdvanceNonexistent:
+    def test_error_for_missing_issue(self) -> None:
+        config = _config()
+        state = State(issues={}, worker_queues={})
+        event = AdvanceEvent(issue_id="Z", target_state="todo")
+
+        _new_state, effects = reduce(config, state, event, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert effects[0].issue_id == "Z"
+
+
+class TestAdvanceToNonexistentState:
+    def test_error_for_unknown_target(self) -> None:
+        config = _config()
+        state = State(
+            issues={"A": _make_issue(state="backlog")},
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="nonexistent")
+
+        _new_state, effects = reduce(config, state, event, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert effects[0].issue_id == "A"
+
+
+class TestAdvancePassiveToPassive:
+    def test_state_changes_no_dispatch(self) -> None:
+        config = _config()
+        state = State(
+            issues={"A": _make_issue(state="backlog")},
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="review")
+
+        new_state, effects = reduce(config, state, event, _counter())
+
+        assert new_state.issues["A"].state == "review"
+        assert effects == []
+
+
+class TestAdvanceToTerminal:
+    def test_state_changes_to_terminal(self) -> None:
+        config = _config()
+        state = State(
+            issues={"A": _make_issue(state="backlog")},
+            worker_queues={},
+        )
+        event = AdvanceEvent(issue_id="A", target_state="done")
+
+        new_state, effects = reduce(config, state, event, _counter())
+
+        assert new_state.issues["A"].state == "done"
+        # Terminal states have no worker, so no dispatch
+        assert effects == []

--- a/tests/engine/test_reducer_create.py
+++ b/tests/engine/test_reducer_create.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    ErrorEffect,
+    FieldDef,
+    State,
+    StateDef,
+    StateMachineConfig,
+    WorkerDef,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def next_id() -> str:
+        nonlocal n
+        n += 1
+        return f"id-{n}"
+
+    return next_id
+
+
+def _passive_initial_config() -> StateMachineConfig:
+    """Config where initial state 'backlog' is passive (no worker)."""
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial="backlog",
+        states={
+            "backlog": StateDef(),
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+def _active_initial_config() -> StateMachineConfig:
+    """Config where initial state 'todo' is active (has worker)."""
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial="todo",
+        states={
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+class TestCreatePassiveInitial:
+    def test_creates_issue_with_correct_fields(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+
+        new_state, effects = reduce(config, state, event, _counter())
+
+        assert "A" in new_state.issues
+        issue = new_state.issues["A"]
+        assert issue.fields == {"title": "My Issue"}
+        assert issue.state == "backlog"
+        assert issue.worker_active is False
+        assert issue.decomposed_from is None
+        assert issue.depends_on == []
+        assert issue.result_history == []
+
+    def test_no_effects_for_passive_initial(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+
+        _new_state, effects = reduce(config, state, event, _counter())
+
+        assert effects == []
+
+
+class TestCreateActiveInitial:
+    def test_dispatch_effect_emitted(self) -> None:
+        config = _active_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+
+        new_state, effects = reduce(config, state, event, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+        assert effects[0].issue_id == "A"
+        assert effects[0].state == "todo"
+        assert new_state.issues["A"].worker_active is True
+
+
+class TestCreateDuplicate:
+    def test_error_on_duplicate_id(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "First"})
+        state, _effects = reduce(config, state, event, _counter())
+
+        # Try creating again with the same ID
+        event2 = CreateEvent(issue_id="A", fields={"title": "Second"})
+        new_state, effects = reduce(config, state, event2, _counter())
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert effects[0].issue_id == "A"
+        # Original issue unchanged
+        assert new_state.issues["A"].fields == {"title": "First"}

--- a/tests/engine/test_reducer_worker_failed.py
+++ b/tests/engine/test_reducer_worker_failed.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def next_id() -> str:
+        nonlocal n
+        n += 1
+        return f"id-{n}"
+
+    return next_id
+
+
+class TestWorkerFailedRetries:
+    """Test 1: Worker failed retries — worker_active stays True, DispatchWorkerEffect emitted."""
+
+    def test_retry_on_failure(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create issue -> lands in todo (active), worker dispatched
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        assert state.issues["A"].worker_active is True
+        assert state.issues["A"].state == "todo"
+
+        # Worker fails
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="timeout"), gen)
+
+        # worker_active stays True (slot retained)
+        assert state.issues["A"].worker_active is True
+        # DispatchWorkerEffect emitted for retry
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 1
+        assert dispatch_effects[0].issue_id == "A"
+        assert dispatch_effects[0].state == "todo"
+        # No error effects
+        assert not any(isinstance(e, ErrorEffect) for e in effects)
+
+
+class TestWorkerFailedRetainsSlot:
+    """Test 2: In max_workers capped state, queued issue stays queued after failure."""
+
+    def test_queued_issue_stays_queued(self, max_workers_config_yaml: str) -> None:
+        config = parse_config(max_workers_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create A, advance to apply state (max_workers=1)
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "A"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "ready"}), gen)
+        assert state.issues["A"].state == "apply"
+        assert state.issues["A"].worker_active is True
+
+        # Create B, advance to apply state — should be queued
+        state, _ = reduce(config, state, CreateEvent(issue_id="B", fields={"title": "B"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "start"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "ready"}), gen)
+        assert state.issues["B"].state == "apply"
+        assert state.issues["B"].worker_active is False
+        assert "B" in state.worker_queues.get("apply", [])
+
+        # A's worker fails — slot is retained, B stays queued
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="crash"), gen)
+
+        # A still holds slot
+        assert state.issues["A"].worker_active is True
+        # B still queued, not dispatched
+        assert state.issues["B"].worker_active is False
+        assert "B" in state.worker_queues.get("apply", [])
+
+        # Only A gets a retry dispatch, not B
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 1
+        assert dispatch_effects[0].issue_id == "A"
+
+
+class TestWorkerFailedNonexistentIssue:
+    """Test 3: Worker failed on nonexistent issue -> ErrorEffect."""
+
+    def test_nonexistent_issue_error(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="NOPE", error="timeout"), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "NOPE" in effects[0].message
+
+
+class TestWorkerFailedNotActive:
+    """Test 4: Worker failed when worker_active is False -> ErrorEffect."""
+
+    def test_inactive_worker_error(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        # Manually deactivate worker
+        state.issues["A"].worker_active = False
+
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="timeout"), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+
+
+class TestWorkerFailedRepeated:
+    """Test 5: Worker failed 3 times in a row — slot retained each time, retry each time."""
+
+    def test_three_consecutive_failures(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        assert state.issues["A"].worker_active is True
+
+        for i in range(3):
+            state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error=f"failure-{i}"), gen)
+            # Slot retained every time
+            assert state.issues["A"].worker_active is True
+            # Retry dispatched every time
+            dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+            assert len(dispatch_effects) == 1
+            assert dispatch_effects[0].issue_id == "A"
+            assert dispatch_effects[0].state == "todo"
+            # No errors
+            assert not any(isinstance(e, ErrorEffect) for e in effects)

--- a/tests/engine/test_reducer_worker_result.py
+++ b/tests/engine/test_reducer_worker_result.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerResultEvent,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def next_id() -> str:
+        nonlocal n
+        n += 1
+        return f"id-{n}"
+
+    return next_id
+
+
+def _create_and_advance(
+    config: object,
+    state: State,
+    issue_id: str,
+    target_state: str,
+    gen: Callable[[], str],
+) -> State:
+    from orca.engine.types import StateMachineConfig
+
+    assert isinstance(config, StateMachineConfig)
+    state, _ = reduce(config, state, CreateEvent(issue_id=issue_id, fields={"title": "T", "text": "D"}), gen)
+    if state.issues[issue_id].state != target_state:
+        state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state=target_state), gen)
+    return state
+
+
+class TestSimpleTransition:
+    """Test 1: implementing -> done, verify state change, result_history, worker_active=False."""
+
+    def test_transition_to_terminal(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create issue -> lands in todo (active), worker dispatched
+        state, effects = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        assert state.issues["A"].worker_active is True
+
+        # Worker returns "start" -> transition to implementing
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        assert state.issues["A"].state == "implementing"
+        assert state.issues["A"].worker_active is True  # re-dispatched in implementing
+
+        # Worker returns "complete" -> transition to done (terminal)
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        assert state.issues["A"].state == "done"
+        assert state.issues["A"].worker_active is False
+        assert len(state.issues["A"].result_history) == 2
+        assert state.issues["A"].result_history[0].state == "todo"
+        assert state.issues["A"].result_history[0].result == {"outcome": "start"}
+        assert state.issues["A"].result_history[1].state == "implementing"
+        assert state.issues["A"].result_history[1].result == {"outcome": "complete"}
+        # No dispatch effects for terminal state
+        assert not any(isinstance(e, DispatchWorkerEffect) for e in effects)
+
+
+class TestTransitionToActiveState:
+    """Test 2: implementing -> testing equivalent, verify DispatchWorkerEffect."""
+
+    def test_dispatch_on_transition_to_active(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        # todo -> implementing via "start"
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        assert state.issues["A"].state == "implementing"
+        # Should get a DispatchWorkerEffect for the implementing state
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 1
+        assert dispatch_effects[0].issue_id == "A"
+        assert dispatch_effects[0].state == "implementing"
+
+
+class TestWorkerResultOnBlockedIssue:
+    """Test 3: WorkerResult on blocked issue -> ErrorEffect."""
+
+    def test_blocked_issue_error(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create parent, advance to scoping
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "T"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        assert state.issues["P"].state == "scoping"
+        assert state.issues["P"].worker_active is True
+
+        # Decompose: creates children, parent becomes blocked
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
+                },
+            ),
+            gen,
+        )
+        # Parent should be blocked (children not terminal)
+        # Trying to send WorkerResult to blocked parent should error
+        # First, the parent's worker_active is False after decompose result
+        # We need to set it True to test the blocked validation
+        state.issues["P"].worker_active = True
+
+        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "implement"}), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "blocked" in effects[0].message.lower()
+
+
+class TestWorkerResultOnTerminalIssue:
+    """Test 4: WorkerResult on terminal issue -> ErrorEffect."""
+
+    def test_terminal_issue_error(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        assert state.issues["A"].state == "done"
+
+        # Try sending result to terminal issue
+        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+
+
+class TestWorkerResultWhenInactive:
+    """Test 5: WorkerResult when worker_active=False -> ErrorEffect."""
+
+    def test_worker_inactive_error(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        # Manually set worker_active to False
+        state.issues["A"].worker_active = False
+
+        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "worker_active" in effects[0].message.lower() or "active" in effects[0].message.lower()
+
+
+class TestUnknownOutcome:
+    """Test 6: Unknown outcome -> ErrorEffect, state unchanged."""
+
+    def test_unknown_outcome_error(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        assert state.issues["A"].worker_active is True
+        assert state.issues["A"].state == "todo"
+
+        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "nonexistent"}), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        # worker_active stays True since validation is before mutation
+        assert state2.issues["A"].worker_active is True
+        assert state2.issues["A"].state == "todo"
+
+
+class TestDecomposeCreatesChildren:
+    """Test 7: Decompose creates children with decomposed_from, parent stays in same state."""
+
+    def test_children_created(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        assert state.issues["P"].state == "scoping"
+
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "Child 1"}},
+                        {"key": "c2", "fields": {"title": "Child 2"}},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Parent stays in scoping state
+        assert state.issues["P"].state == "scoping"
+        assert state.issues["P"].worker_active is False
+
+        # Children created
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "P"]
+        assert len(child_ids) == 2
+
+        for cid in child_ids:
+            child = state.issues[cid]
+            assert child.decomposed_from == "P"
+            assert child.state == config.initial  # "todo"
+
+
+class TestDecomposeWithDependsOn:
+    """Test 8: Decompose with key/depends_on, verify depends_on resolved to real IDs."""
+
+    def test_depends_on_resolved(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "C1"}},
+                        {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Find the child that depends on the other
+        children = {iid: iss for iid, iss in state.issues.items() if iss.decomposed_from == "P"}
+        assert len(children) == 2
+
+        # One child should have depends_on pointing to the real ID of c1
+        dependent = [iss for iss in children.values() if iss.depends_on]
+        assert len(dependent) == 1
+        # The depends_on should contain the real ID of c1 (not the key "c1")
+        dep_id = dependent[0].depends_on[0]
+        assert dep_id in children  # the ID it depends on is a real child ID
+        assert children[dep_id].depends_on == []  # c1 has no dependencies
+
+        # The dependent child should NOT be dispatched (blocked)
+        # The independent child should be dispatched
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        dispatched_ids = {e.issue_id for e in dispatch_effects}
+        assert dep_id in dispatched_ids  # c1 is dispatched
+        # The dependent child is blocked, not dispatched
+        dependent_id = [iid for iid, iss in children.items() if iss.depends_on][0]
+        assert dependent_id not in dispatched_ids
+
+
+class TestEmptyDecompose:
+    """Test 9: Empty decompose -> ErrorEffect."""
+
+    def test_empty_sub_issues_error(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+
+        state2, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={"outcome": "decompose", "sub_issues": []},
+            ),
+            gen,
+        )
+        assert any(isinstance(e, ErrorEffect) for e in effects)
+        # State should not be mutated (validation before mutation)
+        assert state2.issues["P"].worker_active is True
+
+
+class TestCascadingDecompositionUnblock:
+    """Test 10: Child reaches terminal, parent unblocked and re-dispatched."""
+
+    def test_parent_dispatched_when_all_children_done(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create parent, move to scoping
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+
+        # Decompose into one child
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
+                },
+            ),
+            gen,
+        )
+
+        # Find child ID
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "P"]
+        assert len(child_ids) == 1
+        child_id = child_ids[0]
+
+        # Child is in todo with worker active
+        assert state.issues[child_id].state == "todo"
+        assert state.issues[child_id].worker_active is True
+
+        # Child: todo -> scoping via "scope"
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
+        assert state.issues[child_id].state == "scoping"
+
+        # Child: scoping -> implementing via "implement"
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "implement"}), gen)
+        assert state.issues[child_id].state == "implementing"
+
+        # Child: implementing -> done via "complete"
+        state, effects = reduce(
+            config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}), gen
+        )
+        assert state.issues[child_id].state == "done"
+
+        # Parent should be re-dispatched (unblocked)
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        parent_dispatched = [e for e in dispatch_effects if e.issue_id == "P"]
+        assert len(parent_dispatched) == 1
+        assert state.issues["P"].worker_active is True
+
+
+class TestDependencyUnblock:
+    """Test 11: Issue in depends_on reaches terminal, dependent issue gets dispatched."""
+
+    def test_dependent_dispatched_when_dependency_done(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create parent, move to scoping, decompose with dependency
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "C1"}},
+                        {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Find children
+        children = {iid: iss for iid, iss in state.issues.items() if iss.decomposed_from == "P"}
+        c1_id = [iid for iid, iss in children.items() if not iss.depends_on][0]
+        c2_id = [iid for iid, iss in children.items() if iss.depends_on][0]
+
+        # c2 should not be dispatched (blocked by c1)
+        assert state.issues[c2_id].worker_active is False
+
+        # Complete c1: todo -> scoping -> implementing -> done
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}), gen)
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}), gen)
+        assert state.issues[c1_id].state == "done"
+
+        # c2 should now be dispatched
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        c2_dispatched = [e for e in dispatch_effects if e.issue_id == c2_id]
+        assert len(c2_dispatched) == 1
+        assert state.issues[c2_id].worker_active is True
+
+
+class TestSlotBackfillOnWorkerResult:
+    """Test 12: Issue completes in max_workers state, next in queue dispatched."""
+
+    def test_backfill_after_result(self, max_workers_config_yaml: str) -> None:
+        config = parse_config(max_workers_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create two issues, both reach "apply" state (max_workers=1)
+        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "A"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "ready"}), gen)
+        # A is now in apply, dispatched
+        assert state.issues["A"].state == "apply"
+        assert state.issues["A"].worker_active is True
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="B", fields={"title": "B"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "start"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "ready"}), gen)
+        # B is in apply but queued (max_workers=1, A is active)
+        assert state.issues["B"].state == "apply"
+        assert state.issues["B"].worker_active is False
+
+        # A completes apply -> done, B should be backfilled
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "applied"}), gen)
+        assert state.issues["A"].state == "done"
+
+        # B should now be dispatched
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        b_dispatched = [e for e in dispatch_effects if e.issue_id == "B"]
+        assert len(b_dispatched) == 1
+        assert state.issues["B"].worker_active is True
+
+
+class TestDiamondDependency:
+    """Test 13: Two issues depend on same issue, both unblock when it completes."""
+
+    def test_diamond_unblock(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create parent, decompose into 3 children: c1, c2 depends on c1, c3 depends on c1
+        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "C1"}},
+                        {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
+                        {"key": "c3", "fields": {"title": "C3"}, "depends_on": ["c1"]},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Find children
+        children = {iid: iss for iid, iss in state.issues.items() if iss.decomposed_from == "P"}
+        c1_id = [iid for iid, iss in children.items() if not iss.depends_on][0]
+        dependent_ids = [iid for iid, iss in children.items() if iss.depends_on]
+        assert len(dependent_ids) == 2
+
+        # Both dependents should be blocked
+        for did in dependent_ids:
+            assert state.issues[did].worker_active is False
+
+        # Complete c1
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}), gen)
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}), gen)
+
+        # Both c2 and c3 should now be dispatched
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        dispatched_ids = {e.issue_id for e in dispatch_effects}
+        for did in dependent_ids:
+            assert did in dispatched_ids
+            assert state.issues[did].worker_active is True

--- a/tests/engine/test_scenario_decompose.py
+++ b/tests/engine/test_scenario_decompose.py
@@ -1,0 +1,448 @@
+"""Decomposition scenario tests with DAG dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    Effect,
+    ErrorEffect,
+    State,
+    StateMachineConfig,
+    WorkerResultEvent,
+)
+
+DECOMPOSE_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+    text: {type: string, description: "Text"}
+initial: todo
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [scope]
+          description: "Decision"
+          values_description:
+            scope: "Begin scoping"
+    on:
+      scope: scoping
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, decompose]
+          description: "Scope"
+          values_description:
+            ready: "Ready"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when:
+            - decompose
+          items: "$issue"
+          description: "Sub-issues"
+    on:
+      ready: implementing
+      decompose:
+        action: decompose
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+def _advance_to_scoping(
+    config: StateMachineConfig, state: State, issue_id: str, gen: Callable[[], str]
+) -> tuple[State, list[Effect]]:
+    """Advance an issue from todo to scoping via worker result."""
+    result: tuple[State, list[Effect]] = reduce(
+        config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "scope"}), gen
+    )
+    return result
+
+
+def _complete_child(config: StateMachineConfig, state: State, child_id: str, gen: Callable[[], str]) -> State:
+    """Take a child through todo→scoping(ready)→implementing→done."""
+    # Child starts in todo (active, auto-dispatched). Move to scoping.
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
+    # Scoping says ready → implementing
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+    # Implementing done → done
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen)
+    return state
+
+
+class TestSingleLevelDecomposeAndUnblock:
+    """Root decomposes into 2 children. Both complete. Parent unblocks."""
+
+    def test_single_level_decompose_and_unblock(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create root and advance to scoping
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        # Decompose into 2 children
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "child-a", "fields": {"title": "Child A"}},
+                        {"key": "child-b", "fields": {"title": "Child B"}},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Children created with generated IDs
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"]
+        assert len(child_ids) == 2
+
+        # Children are in todo (active state), auto-dispatched
+        for cid in child_ids:
+            assert state.issues[cid].state == "todo"
+            assert state.issues[cid].worker_active is True
+
+        # Root is blocked (children not terminal)
+        assert state.issues["ROOT"].worker_active is False
+
+        # Complete both children
+        for cid in child_ids:
+            state = _complete_child(config, state, cid, gen)
+            assert state.issues[cid].state == "done"
+
+        # After last child completes, parent gets re-dispatched in scoping
+        assert state.issues["ROOT"].worker_active is True
+        assert state.issues["ROOT"].state == "scoping"
+
+        # Parent returns ready → implementing
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}), gen)
+        assert state.issues["ROOT"].state == "implementing"
+        assert state.issues["ROOT"].worker_active is True
+
+        # Implementing done
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "done"}), gen)
+        assert state.issues["ROOT"].state == "done"
+
+
+class TestThreeLevelCascadingUnblock:
+    """L1 decomposes → L2 decomposes → L3. Cascading unblock."""
+
+    def test_three_level_cascading_unblock(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # L1: create and decompose
+        state, _ = reduce(config, state, CreateEvent(issue_id="L1", fields={"title": "Level 1"}), gen)
+        state, _ = _advance_to_scoping(config, state, "L1", gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="L1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "l2", "fields": {"title": "Level 2"}}],
+                },
+            ),
+            gen,
+        )
+
+        l2_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "L1"]
+        assert len(l2_ids) == 1
+        l2_id = l2_ids[0]
+
+        # L2: in todo (active, auto-dispatched), move to scoping
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id=l2_id,
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "l3", "fields": {"title": "Level 3"}}],
+                },
+            ),
+            gen,
+        )
+
+        l3_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == l2_id]
+        assert len(l3_ids) == 1
+        l3_id = l3_ids[0]
+
+        # L3: complete
+        state = _complete_child(config, state, l3_id, gen)
+        assert state.issues[l3_id].state == "done"
+
+        # L2 should be unblocked and re-dispatched in scoping
+        assert state.issues[l2_id].worker_active is True
+        assert state.issues[l2_id].state == "scoping"
+
+        # L2: ready → implementing → done
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "ready"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "done"}), gen)
+        assert state.issues[l2_id].state == "done"
+
+        # L1 should be unblocked and re-dispatched in scoping
+        assert state.issues["L1"].worker_active is True
+        assert state.issues["L1"].state == "scoping"
+
+
+class TestEmptyDecomposeError:
+    """Worker returns decompose with empty sub_issues → ErrorEffect."""
+
+    def test_empty_decompose_error(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={"outcome": "decompose", "sub_issues": []},
+            ),
+            gen,
+        )
+
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "non-empty" in effects[0].message.lower() or "empty" in effects[0].message.lower()
+        # State should be unchanged
+        assert state.issues["ROOT"].state == "scoping"
+        assert state.issues["ROOT"].worker_active is True
+
+
+class TestMassiveFanOut:
+    """Decompose into 20 children. All complete. Parent unblocks."""
+
+    def test_massive_fan_out(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        sub_issues = [{"key": f"child-{i}", "fields": {"title": f"Child {i}"}} for i in range(20)]
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={"outcome": "decompose", "sub_issues": sub_issues},
+            ),
+            gen,
+        )
+
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"]
+        assert len(child_ids) == 20
+
+        # Complete all children
+        for cid in child_ids:
+            state = _complete_child(config, state, cid, gen)
+
+        # Parent should be unblocked
+        assert state.issues["ROOT"].worker_active is True
+        assert state.issues["ROOT"].state == "scoping"
+
+
+class TestDiamondDependency:
+    """Decompose with diamond: db(no deps), users(depends_on:[db]), orders(depends_on:[db])."""
+
+    def test_diamond_dependency(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "db", "fields": {"title": "DB Migration"}, "depends_on": []},
+                        {"key": "users", "fields": {"title": "Users Service"}, "depends_on": ["db"]},
+                        {"key": "orders", "fields": {"title": "Orders Service"}, "depends_on": ["db"]},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Find the real IDs
+        child_ids = {iss.fields["title"]: iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"}
+        db_id = child_ids["DB Migration"]
+        users_id = child_ids["Users Service"]
+        orders_id = child_ids["Orders Service"]
+
+        # db has no depends_on, users and orders depend on db
+        assert state.issues[db_id].depends_on == []
+        assert state.issues[users_id].depends_on == [db_id]
+        assert state.issues[orders_id].depends_on == [db_id]
+
+        # db should be auto-dispatched in todo (not blocked)
+        assert state.issues[db_id].worker_active is True
+        assert state.issues[db_id].state == "todo"
+
+        # users and orders should NOT be dispatched (blocked by db dependency)
+        assert state.issues[users_id].worker_active is False
+        assert state.issues[orders_id].worker_active is False
+
+        # Verify dispatch effects: only db should have been dispatched
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        dispatched_ids = {e.issue_id for e in dispatch_effects}
+        assert db_id in dispatched_ids
+        assert users_id not in dispatched_ids
+        assert orders_id not in dispatched_ids
+
+        # Complete db through todo→scoping→implementing→done
+        state = _complete_child(config, state, db_id, gen)
+        assert state.issues[db_id].state == "done"
+
+        # After db completes, users and orders should be auto-dispatched via cascading unblock
+        assert state.issues[users_id].worker_active is True
+        assert state.issues[orders_id].worker_active is True
+
+
+class TestDispatchIncludesChildrenContext:
+    """After unblock, DispatchWorkerEffect includes resolved children context."""
+
+    def test_dispatch_includes_children_context(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "Child 1"}},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"]
+        assert len(child_ids) == 1
+        child_id = child_ids[0]
+
+        # Complete the child (todo→scoping→implementing→done) — last step triggers parent re-dispatch
+        # Child is auto-dispatched in todo
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+        state, effects_from_last = reduce(
+            config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen
+        )
+
+        # The last step should produce a dispatch for the parent
+        parent_dispatches = [
+            e for e in effects_from_last if isinstance(e, DispatchWorkerEffect) and e.issue_id == "ROOT"
+        ]
+        assert len(parent_dispatches) == 1
+        dispatch = parent_dispatches[0]
+
+        # The issue context should include children
+        assert "children" in dispatch.issue
+        assert len(dispatch.issue["children"]) == 1
+        child_context = dispatch.issue["children"][0]
+        assert child_context["issue_id"] == child_id
+        assert child_context["state"] == "done"
+        assert len(child_context["result_history"]) > 0
+
+
+class TestBlockedIssueRejectsWorkerResult:
+    """Send WorkerResult to a decomposition-blocked parent → ErrorEffect."""
+
+    def test_blocked_issue_rejects_worker_result(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = _advance_to_scoping(config, state, "ROOT", gen)
+
+        # Decompose
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "Child 1"}}],
+                },
+            ),
+            gen,
+        )
+
+        # Parent is now blocked. Try to send a worker result to it.
+        # Parent's worker_active is False after decompose, so this should error
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)

--- a/tests/engine/test_scenario_edge_cases.py
+++ b/tests/engine/test_scenario_edge_cases.py
@@ -1,0 +1,405 @@
+"""Edge case and boundary condition scenario tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+MINIMAL_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+
+PASSIVE_CHAIN_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: triage
+states:
+  triage:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [ready, done]
+          description: "Result"
+          values_description:
+            ready: "Needs review"
+            done: "Complete"
+    on:
+      ready: review
+      done: done
+  review: {}
+  approved: {}
+  done:
+    terminal: true
+"""
+
+SELF_LOOP_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: refine
+states:
+  refine:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [again, done]
+          description: "Result"
+          values_description:
+            again: "Refine more"
+            done: "Complete"
+    on:
+      again: refine
+      done: done
+  done:
+    terminal: true
+"""
+
+
+def _counter(start: int = 0) -> Callable[[], str]:
+    n = start
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+class TestMinimalSingleStateMachine:
+    """Simplest possible: create issue, complete, done."""
+
+    def test_minimal_single_state_machine(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create — initial state is active, so dispatch happens
+        state, effects = reduce(config, state, CreateEvent(issue_id="M-1", fields={"title": "Minimal"}), gen)
+        assert state.issues["M-1"].state == "work"
+        assert state.issues["M-1"].worker_active is True
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+
+        # Complete
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="M-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["M-1"].state == "done"
+        assert state.issues["M-1"].worker_active is False
+        assert effects == []
+        assert len(state.issues["M-1"].result_history) == 1
+
+
+class TestPassiveToPassiveAdvance:
+    """Advance between passive states: review → approved."""
+
+    def test_passive_to_passive_advance(self) -> None:
+        config = parse_config(PASSIVE_CHAIN_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create issue (triage is active, dispatched immediately)
+        state, effects = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "Passive"}), gen)
+        assert state.issues["P-1"].state == "triage"
+        assert state.issues["P-1"].worker_active is True
+
+        # Complete triage with "ready" outcome → transitions to review (passive)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}),
+            gen,
+        )
+        assert state.issues["P-1"].state == "review"
+        assert state.issues["P-1"].worker_active is False
+        assert effects == []
+
+        # Advance review → approved (both passive)
+        state, effects = reduce(config, state, AdvanceEvent(issue_id="P-1", target_state="approved"), gen)
+        assert state.issues["P-1"].state == "approved"
+        assert state.issues["P-1"].worker_active is False
+        assert effects == []
+
+
+class TestAdvanceToTerminal:
+    """Advance from passive directly to terminal."""
+
+    def test_advance_to_terminal(self) -> None:
+        config = parse_config(PASSIVE_CHAIN_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create issue (triage is active)
+        state, _effects = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "Skip"}), gen)
+
+        # Complete triage → review (passive)
+        state, _effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}),
+            gen,
+        )
+        assert state.issues["P-1"].state == "review"
+
+        # Advance review → done (passive to terminal)
+        state, effects = reduce(config, state, AdvanceEvent(issue_id="P-1", target_state="done"), gen)
+        assert state.issues["P-1"].state == "done"
+        assert effects == []
+
+
+class TestSelfLoopState:
+    """Loop 3 times in refine, then done. Verify 4 result_history entries."""
+
+    def test_self_loop_state(self) -> None:
+        config = parse_config(SELF_LOOP_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create — refine is active, dispatched immediately
+        state, effects = reduce(config, state, CreateEvent(issue_id="L-1", fields={"title": "Loop"}), gen)
+        assert state.issues["L-1"].state == "refine"
+        assert state.issues["L-1"].worker_active is True
+
+        # Loop 3 times
+        for _i in range(3):
+            state, effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id="L-1", result={"outcome": "again"}),
+                gen,
+            )
+            assert state.issues["L-1"].state == "refine"
+            assert state.issues["L-1"].worker_active is True
+            assert len(effects) == 1
+            assert isinstance(effects[0], DispatchWorkerEffect)
+
+        # Final: done
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="L-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["L-1"].state == "done"
+        assert state.issues["L-1"].worker_active is False
+
+        # 3 "again" + 1 "done" = 4 entries
+        assert len(state.issues["L-1"].result_history) == 4
+        outcomes = [e.result["outcome"] for e in state.issues["L-1"].result_history]
+        assert outcomes == ["again", "again", "again", "done"]
+
+
+class TestDuplicateCreateErrors:
+    """Create same ID twice. ErrorEffect, original unchanged."""
+
+    def test_duplicate_create_errors(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _effects = reduce(config, state, CreateEvent(issue_id="D-1", fields={"title": "First"}), gen)
+        original_fields = state.issues["D-1"].fields.copy()
+
+        state, effects = reduce(config, state, CreateEvent(issue_id="D-1", fields={"title": "Duplicate"}), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "already exists" in effects[0].message
+
+        # Original unchanged
+        assert state.issues["D-1"].fields == original_fields
+
+
+class TestWorkerResultOnTerminalErrors:
+    """Send WorkerResult to done issue. ErrorEffect."""
+
+    def test_worker_result_on_terminal_errors(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create and complete
+        state, _effects = reduce(config, state, CreateEvent(issue_id="T-1", fields={"title": "Terminal"}), gen)
+        state, _effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["T-1"].state == "done"
+
+        # Try to send result to terminal issue
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "terminal" in effects[0].message
+
+
+class TestWorkerResultUnknownOutcomeErrors:
+    """Send result with invalid outcome. ErrorEffect, state unchanged."""
+
+    def test_worker_result_unknown_outcome_errors(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _effects = reduce(config, state, CreateEvent(issue_id="U-1", fields={"title": "Unknown"}), gen)
+        assert state.issues["U-1"].worker_active is True
+
+        # Send invalid outcome
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="U-1", result={"outcome": "invalid_value"}),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+
+        # worker_active stays True (validation is before mutation)
+        assert state.issues["U-1"].worker_active is True
+        assert state.issues["U-1"].state == "work"
+
+
+class TestDoubleWorkerResultRaceCondition:
+    """Two WorkerResults for same issue. Second errors because worker_active is False."""
+
+    def test_double_worker_result_race_condition(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        state, _effects = reduce(config, state, CreateEvent(issue_id="R-1", fields={"title": "Race"}), gen)
+        assert state.issues["R-1"].worker_active is True
+
+        # First result succeeds
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["R-1"].state == "done"
+        assert not any(isinstance(e, ErrorEffect) for e in effects)
+
+        # Second result errors (terminal state)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+
+
+class TestEventsOnNonexistentIssue:
+    """Advance, WorkerResult, WorkerFailed on nonexistent ID. All produce ErrorEffect."""
+
+    def test_events_on_nonexistent_issue(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # AdvanceEvent on nonexistent
+        state, effects = reduce(config, state, AdvanceEvent(issue_id="NOPE-1", target_state="done"), gen)
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "does not exist" in effects[0].message
+
+        # WorkerResultEvent on nonexistent
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="NOPE-2", result={"outcome": "done"}),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "does not exist" in effects[0].message
+
+        # WorkerFailedEvent on nonexistent
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="NOPE-3", error="boom"),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)
+        assert "does not exist" in effects[0].message
+
+
+class TestWorkerFailedWhenNotActiveErrors:
+    """WorkerFailed when worker_active=False. ErrorEffect."""
+
+    def test_worker_failed_when_not_active_errors(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create issue — active initial state, so dispatched
+        state, _effects = reduce(config, state, CreateEvent(issue_id="F-1", fields={"title": "Fail"}), gen)
+        assert state.issues["F-1"].worker_active is True
+
+        # Complete the worker so worker_active becomes False
+        state, _effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="F-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["F-1"].worker_active is False
+
+        # WorkerFailed on issue with worker_active=False (terminal state, but checked first)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="F-1", error="boom"),
+            gen,
+        )
+        assert len(effects) == 1
+        assert isinstance(effects[0], ErrorEffect)

--- a/tests/engine/test_scenario_kanban.py
+++ b/tests/engine/test_scenario_kanban.py
@@ -1,0 +1,227 @@
+"""Kanban workflow scenario tests: todo → implementing → review → done."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerResultEvent,
+)
+
+KANBAN_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+    text: {type: string, description: "Description"}
+initial: todo
+states:
+  todo: {}
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+        summary:
+          type: string
+          description: "What was done"
+    on:
+      done: review
+  review:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [approved, rejected]
+          description: "Review result"
+          values_description:
+            approved: "Approved"
+            rejected: "Rejected"
+        feedback:
+          type: string
+          description: "Feedback"
+    on:
+      approved: done
+      rejected: implementing
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+class TestFullHappyPath:
+    """Issue goes todo → implementing → review(approved) → done."""
+
+    def test_full_happy_path(self) -> None:
+        config = parse_config(KANBAN_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create issue in todo (passive state, no dispatch)
+        state, effects = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature A"}), gen)
+        assert state.issues["K-1"].state == "todo"
+        assert state.issues["K-1"].worker_active is False
+        assert effects == []
+
+        # Advance to implementing (active state, should dispatch)
+        state, effects = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+        assert state.issues["K-1"].state == "implementing"
+        assert state.issues["K-1"].worker_active is True
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+        assert effects[0].issue_id == "K-1"
+        assert effects[0].state == "implementing"
+
+        # Worker completes implementing → transitions to review
+        state, effects = reduce(
+            config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": "Built it"}), gen
+        )
+        assert state.issues["K-1"].state == "review"
+        assert state.issues["K-1"].worker_active is True
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+        assert effects[0].state == "review"
+        assert len(state.issues["K-1"].result_history) == 1
+
+        # Review approves → transitions to done (terminal)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "LGTM"}),
+            gen,
+        )
+        assert state.issues["K-1"].state == "done"
+        assert state.issues["K-1"].worker_active is False
+        assert effects == []
+        assert len(state.issues["K-1"].result_history) == 2
+
+
+class TestReviewRejectionLoop:
+    """Issue gets rejected 2 times, approved on 3rd attempt."""
+
+    def test_review_rejection_loop(self) -> None:
+        config = parse_config(KANBAN_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create and advance to implementing
+        state, _ = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature B"}), gen)
+        state, _ = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+
+        for attempt in range(1, 4):
+            # Implementing completes → review
+            state, effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": f"Attempt {attempt}"}),
+                gen,
+            )
+            assert state.issues["K-1"].state == "review"
+            assert len(effects) == 1
+            assert isinstance(effects[0], DispatchWorkerEffect)
+
+            if attempt < 3:
+                # Reject → back to implementing
+                state, effects = reduce(
+                    config,
+                    state,
+                    WorkerResultEvent(issue_id="K-1", result={"outcome": "rejected", "feedback": "Needs work"}),
+                    gen,
+                )
+                assert state.issues["K-1"].state == "implementing"
+                assert state.issues["K-1"].worker_active is True
+                assert len(effects) == 1
+                assert isinstance(effects[0], DispatchWorkerEffect)
+                assert effects[0].state == "implementing"
+            else:
+                # Approve → done
+                state, effects = reduce(
+                    config,
+                    state,
+                    WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "Ship it"}),
+                    gen,
+                )
+                assert state.issues["K-1"].state == "done"
+
+        # 3 implementing results + 2 rejected reviews + 1 approved review = 6
+        assert len(state.issues["K-1"].result_history) == 6
+        # Verify the pattern of states in result_history
+        states_in_history = [e.state for e in state.issues["K-1"].result_history]
+        assert states_in_history == [
+            "implementing",
+            "review",
+            "implementing",
+            "review",
+            "implementing",
+            "review",
+        ]
+
+
+class TestParallelIssues:
+    """5 issues all in implementing simultaneously, complete in reverse order."""
+
+    def test_parallel_issues(self) -> None:
+        config = parse_config(KANBAN_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        issue_ids = [f"K-{i}" for i in range(1, 6)]
+
+        # Create all issues and advance to implementing
+        for iid in issue_ids:
+            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+            state, effects = reduce(config, state, AdvanceEvent(issue_id=iid, target_state="implementing"), gen)
+            assert len(effects) == 1
+            assert isinstance(effects[0], DispatchWorkerEffect)
+
+        # All 5 should be implementing with worker_active
+        for iid in issue_ids:
+            assert state.issues[iid].state == "implementing"
+            assert state.issues[iid].worker_active is True
+
+        # Complete in reverse order, going through full pipeline
+        for iid in reversed(issue_ids):
+            # implementing → review
+            state, effects = reduce(
+                config, state, WorkerResultEvent(issue_id=iid, result={"outcome": "done", "summary": "Done"}), gen
+            )
+            assert state.issues[iid].state == "review"
+            assert len(effects) == 1
+
+            # review → done
+            state, effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id=iid, result={"outcome": "approved", "feedback": "OK"}),
+                gen,
+            )
+            assert state.issues[iid].state == "done"
+            assert state.issues[iid].worker_active is False
+
+        # Verify all done, no interference
+        for iid in issue_ids:
+            assert state.issues[iid].state == "done"
+            assert len(state.issues[iid].result_history) == 2

--- a/tests/engine/test_scenario_pipeline.py
+++ b/tests/engine/test_scenario_pipeline.py
@@ -1,0 +1,236 @@
+"""CI/CD pipeline scenario tests with merge serialization (max_workers: 1)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+PIPELINE_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: todo
+states:
+  todo: {}
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: qa
+  qa:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [passed, failed]
+          description: "QA"
+          values_description:
+            passed: "Pass"
+            failed: "Fail"
+    on:
+      passed: apply
+      failed: implementing
+  apply:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [merged, conflict]
+          description: "Merge"
+          values_description:
+            merged: "OK"
+            conflict: "Conflict"
+    on:
+      merged: done
+      conflict: implementing
+  done:
+    terminal: true
+"""
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+def _advance_to_apply(config: object, state: State, issue_id: str, gen: Callable[[], str]) -> State:
+    """Helper to advance an issue from todo through implementing and qa to apply."""
+    from orca.engine.types import StateMachineConfig
+
+    assert isinstance(config, StateMachineConfig)
+    state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state="implementing"), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "done"}), gen)
+    state, _ = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "passed"}), gen)
+    return state
+
+
+class TestSerializedMerge4Issues:
+    """4 issues pass qa, enter apply. Only first active, rest queued."""
+
+    def test_serialized_merge_4_issues(self) -> None:
+        config = parse_config(PIPELINE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        ids = [f"P-{i}" for i in range(1, 5)]
+
+        # Create all issues
+        for iid in ids:
+            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+
+        # Advance all to apply
+        for iid in ids:
+            state = _advance_to_apply(config, state, iid, gen)
+
+        # First issue should be active, rest queued
+        assert state.issues["P-1"].state == "apply"
+        assert state.issues["P-1"].worker_active is True
+        for iid in ids[1:]:
+            assert state.issues[iid].state == "apply"
+            assert state.issues[iid].worker_active is False
+
+        # Queue should contain P-2, P-3, P-4
+        assert state.worker_queues.get("apply") == ["P-2", "P-3", "P-4"]
+
+        # Merge them one by one
+        for i, iid in enumerate(ids):
+            state, effects = reduce(config, state, WorkerResultEvent(issue_id=iid, result={"outcome": "merged"}), gen)
+            assert state.issues[iid].state == "done"
+
+            if i < len(ids) - 1:
+                # Backfill: next issue should get dispatched
+                next_id = ids[i + 1]
+                dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+                assert len(dispatch_effects) == 1
+                assert dispatch_effects[0].issue_id == next_id
+                assert dispatch_effects[0].state == "apply"
+                assert state.issues[next_id].worker_active is True
+            else:
+                # Last one, no backfill
+                dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+                assert len(dispatch_effects) == 0
+
+        # All done
+        for iid in ids:
+            assert state.issues[iid].state == "done"
+
+
+class TestConflictFreesSlotForNext:
+    """2 issues in apply, first conflicts → second gets the slot."""
+
+    def test_conflict_frees_slot_for_next(self) -> None:
+        config = parse_config(PIPELINE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        for iid in ["P-1", "P-2"]:
+            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state = _advance_to_apply(config, state, iid, gen)
+
+        assert state.issues["P-1"].worker_active is True
+        assert state.issues["P-2"].worker_active is False
+        assert state.worker_queues.get("apply") == ["P-2"]
+
+        # P-1 conflicts → goes back to implementing, P-2 gets dispatched in apply
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+        assert state.issues["P-1"].state == "implementing"
+        assert state.issues["P-1"].worker_active is True  # implementing dispatches immediately
+
+        # P-2 should be dispatched in apply
+        apply_dispatches = [e for e in effects if isinstance(e, DispatchWorkerEffect) and e.state == "apply"]
+        assert len(apply_dispatches) == 1
+        assert apply_dispatches[0].issue_id == "P-2"
+        assert state.issues["P-2"].worker_active is True
+
+
+class TestConflictReenterAtBackOfQueue:
+    """3 issues. First conflicts, re-enters at back of queue."""
+
+    def test_conflict_reenter_at_back_of_queue(self) -> None:
+        config = parse_config(PIPELINE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        for iid in ["P-1", "P-2", "P-3"]:
+            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state = _advance_to_apply(config, state, iid, gen)
+
+        assert state.issues["P-1"].worker_active is True
+        assert state.worker_queues.get("apply") == ["P-2", "P-3"]
+
+        # P-1 conflicts → goes back to implementing
+        state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+        assert state.issues["P-1"].state == "implementing"
+
+        # P-2 should now be active in apply
+        assert state.issues["P-2"].worker_active is True
+        assert state.issues["P-2"].state == "apply"
+
+        # Queue should now be just P-3
+        assert state.worker_queues.get("apply") == ["P-3"]
+
+        # P-1 goes back through implementing→qa→apply, should end up queued behind P-3
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "done"}), gen)
+        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "passed"}), gen)
+
+        assert state.issues["P-1"].state == "apply"
+        assert state.issues["P-1"].worker_active is False
+        assert state.worker_queues.get("apply") == ["P-3", "P-1"]
+
+
+class TestWorkerFailedRetainsSlot:
+    """WorkerFailed on apply retains slot, queued issue stays queued."""
+
+    def test_worker_failed_retains_slot(self) -> None:
+        config = parse_config(PIPELINE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        for iid in ["P-1", "P-2"]:
+            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state = _advance_to_apply(config, state, iid, gen)
+
+        assert state.issues["P-1"].worker_active is True
+        assert state.worker_queues.get("apply") == ["P-2"]
+
+        # Worker fails on P-1 → slot retained, P-2 stays queued
+        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="P-1", error="timeout"), gen)
+        assert state.issues["P-1"].worker_active is True  # slot retained
+        assert state.issues["P-1"].state == "apply"
+
+        # Should get a re-dispatch effect for P-1
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+        assert effects[0].issue_id == "P-1"
+        assert effects[0].state == "apply"
+
+        # P-2 should still be queued
+        assert state.issues["P-2"].worker_active is False
+        assert state.worker_queues.get("apply") == ["P-2"]

--- a/tests/engine/test_scenario_queuing.py
+++ b/tests/engine/test_scenario_queuing.py
@@ -1,0 +1,255 @@
+"""Queuing stress and max_workers capacity scenario tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+CAPPED_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    max_workers: 3
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+
+CAPPED_DECOMPOSE_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    max_workers: 2
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done, decompose]
+          description: "Result"
+          values_description:
+            done: "Complete"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when:
+            - decompose
+          items: "$issue"
+          description: "Sub-issues"
+    on:
+      done: done
+      decompose:
+        action: decompose
+  done:
+    terminal: true
+"""
+
+
+def _counter(start: int = 0) -> Callable[[], str]:
+    n = start
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+class TestMaxWorkersRespected:
+    """Create 10 issues. First 3 active, 7 queued. Complete one, verify new one activates."""
+
+    def test_max_workers_respected(self) -> None:
+        config = parse_config(CAPPED_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create 10 issues
+        all_ids = [f"Q-{i}" for i in range(1, 11)]
+        for iid in all_ids:
+            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+
+        # First 3 should be active, remaining 7 queued
+        active = [iid for iid in all_ids if state.issues[iid].worker_active]
+        queued = [iid for iid in all_ids if not state.issues[iid].worker_active]
+        assert len(active) == 3
+        assert len(queued) == 7
+        assert active == ["Q-1", "Q-2", "Q-3"]
+
+        # Complete Q-1 -> a queued issue should activate
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["Q-1"].state == "done"
+
+        # Should have dispatched one new worker
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 1
+
+        # Still 3 active workers total
+        active_after = [iid for iid in all_ids if state.issues[iid].worker_active and state.issues[iid].state == "work"]
+        assert len(active_after) == 3
+
+
+class TestWorkerFailureRetainsSlotInCappedState:
+    """5 issues, 3 active. Fail first active 3 times. Slot retained each time."""
+
+    def test_worker_failure_retains_slot_in_capped_state(self) -> None:
+        config = parse_config(CAPPED_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        all_ids = [f"Q-{i}" for i in range(1, 6)]
+        for iid in all_ids:
+            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+
+        # 3 active, 2 queued
+        active = [iid for iid in all_ids if state.issues[iid].worker_active]
+        assert len(active) == 3
+
+        # Fail Q-1 three times
+        for _ in range(3):
+            state, effects = reduce(
+                config,
+                state,
+                WorkerFailedEvent(issue_id="Q-1", error="boom"),
+                gen,
+            )
+            # Worker should be retried (DispatchWorkerEffect emitted)
+            assert len(effects) == 1
+            assert isinstance(effects[0], DispatchWorkerEffect)
+            assert effects[0].issue_id == "Q-1"
+
+            # worker_active stays True for Q-1 (slot retained)
+            assert state.issues["Q-1"].worker_active is True
+
+            # Still exactly 3 active total
+            active_now = [iid for iid in all_ids if state.issues[iid].worker_active]
+            assert len(active_now) == 3
+
+            # Queued issues should NOT have been promoted
+            assert state.issues["Q-4"].worker_active is False
+            assert state.issues["Q-5"].worker_active is False
+
+
+class TestSequentialDrain:
+    """10 issues through max_workers:3. Complete them one by one until all done."""
+
+    def test_sequential_drain(self) -> None:
+        config = parse_config(CAPPED_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        all_ids = [f"Q-{i}" for i in range(1, 11)]
+        for iid in all_ids:
+            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+
+        completed: list[str] = []
+        while True:
+            # Find an active issue to complete
+            active_id = next(
+                (iid for iid in all_ids if state.issues[iid].worker_active and state.issues[iid].state == "work"),
+                None,
+            )
+            if active_id is None:
+                break
+
+            state, _effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id=active_id, result={"outcome": "done"}),
+                gen,
+            )
+            completed.append(active_id)
+
+            # Invariant: at most 3 active at any time
+            active_count = sum(
+                1 for iid in all_ids if state.issues[iid].worker_active and state.issues[iid].state == "work"
+            )
+            assert active_count <= 3
+
+        # All 10 should be done
+        assert len(completed) == 10
+        for iid in all_ids:
+            assert state.issues[iid].state == "done"
+
+
+class TestDecomposeFanoutRespectsMaxWorkers:
+    """Create root, decompose into 5 children. Only 2 children active (max_workers:2)."""
+
+    def test_decompose_fanout_respects_max_workers(self) -> None:
+        config = parse_config(CAPPED_DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create root issue — initial state is "work" (active, max_workers:2), so dispatched
+        state, effects = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}),
+            gen,
+        )
+        assert state.issues["ROOT-1"].worker_active is True
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+
+        # Decompose into 5 children
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": f"child-{i}", "fields": {"title": f"Child {i}"}} for i in range(1, 6)],
+                },
+            ),
+            gen,
+        )
+
+        # Root should no longer be active (it's decomposition-blocked)
+        assert state.issues["ROOT-1"].worker_active is False
+
+        # 5 children should have been created
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT-1"]
+        assert len(child_ids) == 5
+
+        # Only 2 children should be active (max_workers:2)
+        active_children = [iid for iid in child_ids if state.issues[iid].worker_active]
+        queued_children = [iid for iid in child_ids if not state.issues[iid].worker_active]
+        assert len(active_children) == 2
+        assert len(queued_children) == 3
+
+        # Dispatch effects should be exactly 2
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 2

--- a/tests/engine/test_scenario_serialization.py
+++ b/tests/engine/test_scenario_serialization.py
@@ -1,0 +1,308 @@
+"""Serialization round-trip scenario tests simulating system restarts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerResultEvent,
+)
+
+MINIMAL_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+
+CAPPED_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    max_workers: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done]
+          description: "Result"
+          values_description:
+            done: "Complete"
+    on:
+      done: done
+  done:
+    terminal: true
+"""
+
+SELF_LOOP_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: refine
+states:
+  refine:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [again, done]
+          description: "Result"
+          values_description:
+            again: "Refine more"
+            done: "Complete"
+    on:
+      again: refine
+      done: done
+  done:
+    terminal: true
+"""
+
+DECOMPOSE_CONFIG_YAML = """\
+issue:
+  fields:
+    title: {type: string, description: "Title"}
+initial: work
+states:
+  work:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [done, decompose]
+          description: "Result"
+          values_description:
+            done: "Complete"
+            decompose: "Split"
+        sub_issues:
+          type: list
+          required_when:
+            - decompose
+          items: "$issue"
+          description: "Sub-issues"
+    on:
+      done: done
+      decompose:
+        action: decompose
+  done:
+    terminal: true
+"""
+
+
+def _counter(start: int = 0) -> Callable[[], str]:
+    n = start
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _empty_state() -> State:
+    return State(issues={}, worker_queues={})
+
+
+def _roundtrip(state: State) -> State:
+    return State.from_dict(json.loads(json.dumps(state.to_dict())))
+
+
+class TestEmptyStateRoundtrip:
+    """Empty state serializes and deserializes correctly."""
+
+    def test_empty_state_roundtrip(self) -> None:
+        state = _empty_state()
+        restored = _roundtrip(state)
+        assert restored.issues == {}
+        assert restored.worker_queues == {}
+
+
+class TestMidWorkflowRoundtrip:
+    """Create issue, advance to active. Serialize, restore. Continue to completion."""
+
+    def test_mid_workflow_roundtrip(self) -> None:
+        config = parse_config(MINIMAL_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create issue — dispatched immediately (active initial state)
+        state, effects = reduce(config, state, CreateEvent(issue_id="S-1", fields={"title": "Serialize"}), gen)
+        assert state.issues["S-1"].worker_active is True
+
+        # Serialize and restore (simulating restart)
+        state = _roundtrip(state)
+
+        # Verify state survived
+        assert state.issues["S-1"].state == "work"
+        assert state.issues["S-1"].worker_active is True
+        assert state.issues["S-1"].fields == {"title": "Serialize"}
+
+        # Continue processing on restored state — complete the issue
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="S-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["S-1"].state == "done"
+        assert state.issues["S-1"].worker_active is False
+        assert len(state.issues["S-1"].result_history) == 1
+
+
+class TestBlockedStateRoundtrip:
+    """Decompose parent with children. Serialize. Verify relationships survive."""
+
+    def test_blocked_state_roundtrip(self) -> None:
+        config = parse_config(DECOMPOSE_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create root
+        state, _effects = reduce(config, state, CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}), gen)
+
+        # Decompose into 2 children
+        state, _effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="ROOT-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "Child 1"}},
+                        {"key": "c2", "fields": {"title": "Child 2"}},
+                    ],
+                },
+            ),
+            gen,
+        )
+
+        # Identify child IDs
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT-1"]
+        assert len(child_ids) == 2
+
+        # Serialize and restore
+        state = _roundtrip(state)
+
+        # Verify parent's decomposition relationships survive
+        for child_id in child_ids:
+            assert state.issues[child_id].decomposed_from == "ROOT-1"
+
+        # Root should not be active (blocked by children)
+        assert state.issues["ROOT-1"].worker_active is False
+
+        # Complete children and verify root unblocks
+        for child_id in child_ids:
+            state, _effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}),
+                gen,
+            )
+
+        # Root should now be dispatched (unblocked)
+        assert state.issues["ROOT-1"].worker_active is True
+
+
+class TestQueueOrderSurvivesRoundtrip:
+    """Create 5 issues in max_workers:1. Serialize, restore. Complete first, verify next activates."""
+
+    def test_queue_order_survives_roundtrip(self) -> None:
+        config = parse_config(CAPPED_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        all_ids = [f"Q-{i}" for i in range(1, 6)]
+        for iid in all_ids:
+            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+
+        # Only Q-1 active, rest queued
+        assert state.issues["Q-1"].worker_active is True
+        for iid in all_ids[1:]:
+            assert state.issues[iid].worker_active is False
+
+        # Serialize and restore
+        state = _roundtrip(state)
+
+        # Verify queue survived
+        assert state.worker_queues.get("work") == ["Q-2", "Q-3", "Q-4", "Q-5"]
+
+        # Complete Q-1 on restored state
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["Q-1"].state == "done"
+
+        # Q-2 should have been activated (next in queue)
+        dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatch_effects) == 1
+        assert dispatch_effects[0].issue_id == "Q-2"
+        assert state.issues["Q-2"].worker_active is True
+
+
+class TestDeepResultHistoryRoundtrip:
+    """Issue loops 10 times. Serialize. Verify 10 history entries survive. Continue to completion."""
+
+    def test_deep_result_history_roundtrip(self) -> None:
+        config = parse_config(SELF_LOOP_CONFIG_YAML)
+        gen = _counter()
+        state = _empty_state()
+
+        # Create — refine is active
+        state, _effects = reduce(config, state, CreateEvent(issue_id="H-1", fields={"title": "History"}), gen)
+
+        # Loop 10 times
+        for _ in range(10):
+            state, _effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id="H-1", result={"outcome": "again"}),
+                gen,
+            )
+
+        assert len(state.issues["H-1"].result_history) == 10
+
+        # Serialize and restore
+        state = _roundtrip(state)
+
+        # Verify all 10 entries survive
+        assert len(state.issues["H-1"].result_history) == 10
+        assert all(e.state == "refine" for e in state.issues["H-1"].result_history)
+        assert all(e.result["outcome"] == "again" for e in state.issues["H-1"].result_history)
+
+        # Continue to completion after roundtrip
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="H-1", result={"outcome": "done"}),
+            gen,
+        )
+        assert state.issues["H-1"].state == "done"
+        assert len(state.issues["H-1"].result_history) == 11
+        assert state.issues["H-1"].result_history[-1].result["outcome"] == "done"

--- a/tests/engine/test_types.py
+++ b/tests/engine/test_types.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    ErrorEffect,
+    FieldDef,
+    Issue,
+    ListFieldDef,
+    OnDecompose,
+    OnTransition,
+    ResultHistoryEntry,
+    State,
+    StateDef,
+    StateMachineConfig,
+    StringFieldDef,
+    WorkerDef,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+class TestIssueConstruction:
+    def test_issue_with_all_dag_fields(self) -> None:
+        issue = Issue(
+            fields={"title": "Fix bug", "priority": "high"},
+            state="open",
+            worker_active=False,
+            decomposed_from="PARENT-1",
+            depends_on=["DEP-1", "DEP-2"],
+            result_history=[],
+        )
+        assert issue.fields == {"title": "Fix bug", "priority": "high"}
+        assert issue.state == "open"
+        assert issue.worker_active is False
+        assert issue.decomposed_from == "PARENT-1"
+        assert issue.depends_on == ["DEP-1", "DEP-2"]
+        assert issue.result_history == []
+
+    def test_issue_without_decomposed_from(self) -> None:
+        issue = Issue(
+            fields={"title": "Root issue"},
+            state="open",
+            worker_active=False,
+            decomposed_from=None,
+            depends_on=[],
+            result_history=[],
+        )
+        assert issue.decomposed_from is None
+
+
+class TestSerializationRoundTrip:
+    def test_state_round_trip(self) -> None:
+        state = State(
+            issues={
+                "ISS-1": Issue(
+                    fields={"title": "Do thing"},
+                    state="open",
+                    worker_active=False,
+                    decomposed_from=None,
+                    depends_on=[],
+                    result_history=[],
+                ),
+            },
+            worker_queues={},
+        )
+        d = state.to_dict()
+        json_str = json.dumps(d)
+        restored = State.from_dict(json.loads(json_str))
+        assert restored.issues["ISS-1"].fields == {"title": "Do thing"}
+        assert restored.issues["ISS-1"].state == "open"
+        assert restored.issues["ISS-1"].worker_active is False
+        assert restored.issues["ISS-1"].decomposed_from is None
+        assert restored.issues["ISS-1"].depends_on == []
+
+    def test_state_with_result_history_round_trip(self) -> None:
+        state = State(
+            issues={
+                "ISS-1": Issue(
+                    fields={"title": "Task"},
+                    state="review",
+                    worker_active=False,
+                    decomposed_from=None,
+                    depends_on=[],
+                    result_history=[
+                        ResultHistoryEntry(state="triage", result={"decision": "approve"}),
+                        ResultHistoryEntry(state="review", result={"verdict": "pass"}),
+                    ],
+                ),
+            },
+            worker_queues={},
+        )
+        d = state.to_dict()
+        json_str = json.dumps(d)
+        restored = State.from_dict(json.loads(json_str))
+        assert len(restored.issues["ISS-1"].result_history) == 2
+        assert restored.issues["ISS-1"].result_history[0].state == "triage"
+        assert restored.issues["ISS-1"].result_history[0].result == {"decision": "approve"}
+        assert restored.issues["ISS-1"].result_history[1].state == "review"
+        assert restored.issues["ISS-1"].result_history[1].result == {"verdict": "pass"}
+
+    def test_state_with_worker_queues_round_trip(self) -> None:
+        state = State(
+            issues={},
+            worker_queues={"triage": ["ISS-1", "ISS-2"], "review": ["ISS-3"]},
+        )
+        d = state.to_dict()
+        json_str = json.dumps(d)
+        restored = State.from_dict(json.loads(json_str))
+        assert restored.worker_queues == {"triage": ["ISS-1", "ISS-2"], "review": ["ISS-3"]}
+
+    def test_state_with_depends_on_round_trip(self) -> None:
+        state = State(
+            issues={
+                "ISS-1": Issue(
+                    fields={},
+                    state="blocked",
+                    worker_active=False,
+                    decomposed_from="ISS-0",
+                    depends_on=["ISS-2", "ISS-3"],
+                    result_history=[],
+                ),
+            },
+            worker_queues={},
+        )
+        d = state.to_dict()
+        json_str = json.dumps(d)
+        restored = State.from_dict(json.loads(json_str))
+        assert restored.issues["ISS-1"].decomposed_from == "ISS-0"
+        assert restored.issues["ISS-1"].depends_on == ["ISS-2", "ISS-3"]
+
+
+class TestEvents:
+    def test_create_event(self) -> None:
+        e = CreateEvent(issue_id="ISS-1", fields={"title": "New"})
+        assert e.issue_id == "ISS-1"
+        assert e.fields == {"title": "New"}
+
+    def test_advance_event(self) -> None:
+        e = AdvanceEvent(issue_id="ISS-1", target_state="review")
+        assert e.issue_id == "ISS-1"
+        assert e.target_state == "review"
+
+    def test_worker_result_event(self) -> None:
+        e = WorkerResultEvent(issue_id="ISS-1", result={"decision": "approve"})
+        assert e.issue_id == "ISS-1"
+        assert e.result == {"decision": "approve"}
+
+    def test_worker_failed_event(self) -> None:
+        e = WorkerFailedEvent(issue_id="ISS-1", error="timeout")
+        assert e.issue_id == "ISS-1"
+        assert e.error == "timeout"
+
+
+class TestEffects:
+    def test_dispatch_worker_effect(self) -> None:
+        e = DispatchWorkerEffect(
+            issue_id="ISS-1",
+            state="triage",
+            result_format={"decision": {"type": "enum", "values": ["approve", "reject"]}},
+            issue={"title": "Fix bug"},
+        )
+        assert e.issue_id == "ISS-1"
+        assert e.state == "triage"
+        assert e.result_format["decision"]["type"] == "enum"
+        assert e.issue == {"title": "Fix bug"}
+
+    def test_error_effect(self) -> None:
+        e = ErrorEffect(issue_id="ISS-1", message="not found")
+        assert e.issue_id == "ISS-1"
+        assert e.message == "not found"
+
+
+class TestConfigTypes:
+    def test_field_def(self) -> None:
+        f = FieldDef(type="string", description="The title")
+        assert f.type == "string"
+        assert f.description == "The title"
+
+    def test_enum_field_def(self) -> None:
+        f = EnumFieldDef(values=["low", "high"], description="Priority")
+        assert f.values == ["low", "high"]
+        assert f.description == "Priority"
+        assert f.values_description == {}
+
+    def test_enum_field_def_with_values_description(self) -> None:
+        f = EnumFieldDef(
+            values=["low", "high"],
+            description="Priority",
+            values_description={"low": "Not urgent", "high": "Urgent"},
+        )
+        assert f.values_description == {"low": "Not urgent", "high": "Urgent"}
+
+    def test_string_field_def(self) -> None:
+        f = StringFieldDef(description="A reason")
+        assert f.description == "A reason"
+        assert f.required_when == []
+
+    def test_string_field_def_with_required_when(self) -> None:
+        f = StringFieldDef(description="A reason", required_when=["rejected"])
+        assert f.required_when == ["rejected"]
+
+    def test_list_field_def(self) -> None:
+        f = ListFieldDef(description="Sub-tasks", items="string")
+        assert f.description == "Sub-tasks"
+        assert f.items == "string"
+        assert f.required_when == []
+
+    def test_list_field_def_with_required_when(self) -> None:
+        f = ListFieldDef(description="Sub-tasks", items="string", required_when=["decompose"])
+        assert f.required_when == ["decompose"]
+
+    def test_worker_def(self) -> None:
+        w = WorkerDef(
+            result_format={
+                "decision": EnumFieldDef(values=["approve", "reject"], description="Decision"),
+            }
+        )
+        assert "decision" in w.result_format
+
+    def test_on_transition(self) -> None:
+        t = OnTransition(target="review")
+        assert t.target == "review"
+
+    def test_on_decompose(self) -> None:
+        d = OnDecompose()
+        assert isinstance(d, OnDecompose)
+
+    def test_state_def_passive(self) -> None:
+        s = StateDef()
+        assert s.worker is None
+        assert s.on == {}
+        assert s.terminal is False
+        assert s.max_workers is None
+
+    def test_state_def_active(self) -> None:
+        worker = WorkerDef(
+            result_format={
+                "decision": EnumFieldDef(values=["approve"], description="Decision"),
+            }
+        )
+        s = StateDef(
+            worker=worker,
+            on={"approve": OnTransition(target="done")},
+            max_workers=3,
+        )
+        assert s.worker is worker
+        assert s.on == {"approve": OnTransition(target="done")}
+        assert s.max_workers == 3
+
+    def test_state_def_terminal(self) -> None:
+        s = StateDef(terminal=True)
+        assert s.terminal is True
+
+    def test_state_machine_config(self) -> None:
+        config = StateMachineConfig(
+            issue_fields={
+                "title": FieldDef(type="string", description="Title"),
+                "priority": FieldDef(type="enum", description="Priority level"),
+            },
+            initial="triage",
+            states={
+                "triage": StateDef(
+                    worker=WorkerDef(
+                        result_format={
+                            "decision": EnumFieldDef(values=["accept", "reject"], description="Decision"),
+                        }
+                    ),
+                    on={
+                        "accept": OnTransition(target="in_progress"),
+                        "reject": OnTransition(target="closed"),
+                    },
+                ),
+                "in_progress": StateDef(),
+                "closed": StateDef(terminal=True),
+            },
+        )
+        assert config.initial == "triage"
+        assert len(config.states) == 3
+        assert config.states["closed"].terminal is True
+        assert len(config.issue_fields) == 2

--- a/tests/engine/test_types.py
+++ b/tests/engine/test_types.py
@@ -283,3 +283,38 @@ class TestConfigTypes:
         assert len(config.states) == 3
         assert config.states["closed"].terminal is True
         assert len(config.issue_fields) == 2
+
+
+class TestPublicAPI:
+    def test_imports_from_engine_package(self) -> None:
+        from orca.engine import (
+            AdvanceEvent,
+            ConfigValidationError,
+            CreateEvent,
+            DispatchWorkerEffect,
+            Effect,
+            ErrorEffect,
+            Event,
+            Issue,
+            State,
+            StateMachineConfig,
+            WorkerFailedEvent,
+            WorkerResultEvent,
+            parse_config,
+            reduce,
+        )
+
+        assert callable(reduce)
+        assert callable(parse_config)
+        assert ConfigValidationError is not None
+        assert AdvanceEvent is not None
+        assert CreateEvent is not None
+        assert DispatchWorkerEffect is not None
+        assert Effect is not None
+        assert ErrorEffect is not None
+        assert Event is not None
+        assert Issue is not None
+        assert State is not None
+        assert StateMachineConfig is not None
+        assert WorkerFailedEvent is not None
+        assert WorkerResultEvent is not None

--- a/uv.lock
+++ b/uv.lock
@@ -181,6 +181,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -192,6 +193,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.7" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -353,6 +355,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 [[package]]
 name = "orca"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -36,6 +45,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -153,21 +171,36 @@ wheels = [
 name = "orca"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0.3" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.7" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -189,6 +222,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +244,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pure reducer function `reduce(config, state, event, generate_id) -> (new_state, effects)` that drives issue lifecycle through a user-defined state machine
- Config parsed from `orca.yml` with 9 validation rules
- DAG model with `decomposed_from` + `depends_on` supporting diamond dependencies
- Dispatch protocol with `max_workers` capacity limits and FIFO queuing
- 4 event types: Create, Advance, WorkerResult, WorkerFailed
- Cascading unblock for both decomposition and dependency edges
- Fully serializable state (JSON round-trip safe)

## Key design decisions
- **DAG over tree**: issues use `decomposed_from`/`depends_on` instead of parent/children, enabling diamond dependencies (e.g., two tasks depending on a shared setup task)
- **Computed blocking**: no `blocked` boolean — blocking is derived from non-terminal children and dependencies
- **Slot retention on failure**: `WorkerFailed` keeps the slot, preventing queue starvation
- **Empty decompose = error**: prevents infinite vacuous-unblock loops

## Test plan
- [x] 134 tests passing across 13 test files
- [x] Unit tests for types, config, dispatch, and all 4 event handlers
- [x] Scenario tests: kanban workflow, CI/CD pipeline with merge serialization, decomposition with diamond deps, queuing stress, edge cases, serialization round-trips
- [x] ruff clean, mypy strict clean
- [ ] CI passes (lint + type-check + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)