### PR TITLE
Add event log, hop limits, and ASCII visualization

### DIFF
--- a/docs/superpowers/plans/2026-03-22-engine-improvements.md
+++ b/docs/superpowers/plans/2026-03-22-engine-improvements.md
@@ -1,0 +1,430 @@
+# Engine Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add event log (replacing result_history), hop limits (max_visits/max_hops), and ASCII visualization to the state machine engine.
+
+**Architecture:** Three layered changes: (1) event log replaces result_history in types/state/reducer/dispatch, (2) hop limits add counters to state and checks to reducer, (3) formatting utility reads state and produces ASCII output. The event log is foundational — the other two depend on it.
+
+**Tech Stack:** Python 3.12, dataclasses, pytest, datetime (for elapsed time formatting)
+
+**Spec:** `docs/superpowers/specs/2026-03-22-engine-improvements-design.md`
+
+---
+
+## File Structure
+
+```
+src/orca/engine/
+├── types.py        — MODIFY: replace ResultHistoryEntry with EventLogEntry, add timestamp to events, add visit_counts/hop_count to Issue, add max_hops to config, add max_visits to StateDef
+├── config.py       — MODIFY: parse max_hops and max_visits, add validation rules
+├── dispatch.py     — MODIFY: update build_issue_context to use event_log, widen effect types, add event log append helper
+├── reducer.py      — MODIFY: add now parameter, emit log entries, add hop limit checks
+├── formatting.py   — CREATE: format_issues() ASCII visualization
+├── __init__.py     — MODIFY: update exports
+tests/engine/
+├── test_types.py              — MODIFY: update for new fields
+├── test_config.py             — MODIFY: add max_hops/max_visits tests
+├── test_dispatch.py           — MODIFY: update for event_log
+├── test_reducer_create.py     — MODIFY: update for event_log, timestamps, visit_counts
+├── test_reducer_advance.py    — MODIFY: update for event_log, timestamps, hop_count
+├── test_reducer_worker_result.py — MODIFY: update for event_log, timestamps, hop limits
+├── test_reducer_worker_failed.py — MODIFY: update for event_log, timestamps
+├── test_scenario_*.py (6 files) — MODIFY: update for new API
+├── test_event_log.py          — CREATE: dedicated event log entry tests
+├── test_hop_limits.py         — CREATE: hop limit tests
+├── test_formatting.py         — CREATE: ASCII visualization tests
+├── conftest.py                — MODIFY: add timestamp helpers, update fixtures
+```
+
+---
+
+### Task 1: Update Types — EventLogEntry, Timestamps, Hop Counters
+
+**Files:**
+- Modify: `src/orca/engine/types.py`
+- Modify: `tests/engine/test_types.py`
+
+This is the foundational change. Everything else builds on it.
+
+- [ ] **Step 1: Update types.py**
+
+Replace `ResultHistoryEntry` with `EventLogEntry`. Add `timestamp` to all events. Add `event_log`, `visit_counts`, `hop_count` to `Issue`. Add `max_hops` to `StateMachineConfig`. Add `max_visits` to `StateDef`. Update `Issue.to_dict()`/`from_dict()` with backward-compatible defaults.
+
+Key changes:
+- `ResultHistoryEntry` → `EventLogEntry(timestamp: str, type: str, data: dict[str, Any])` with `to_dict()`/`from_dict()` methods
+- `Issue.result_history` → `Issue.event_log: list[EventLogEntry]`
+- `Issue` gains `visit_counts: dict[str, int]` and `hop_count: int`
+- `Issue.from_dict()` handles missing `visit_counts` (default `{}`), `hop_count` (default `0`), and `event_log` (default `[]`)
+- All events gain `timestamp: str` field
+- `StateMachineConfig` gains `max_hops: int | None = None`
+- `StateDef` gains `max_visits: int | None = None`
+
+- [ ] **Step 2: Update test_types.py**
+
+Update all tests to use `event_log=[]` instead of `result_history=[]`. Update event construction to include `timestamp`. Add tests for:
+- `EventLogEntry` construction and round-trip
+- `Issue` with `visit_counts` and `hop_count` round-trip
+- `Issue.from_dict()` backward compatibility (missing new fields)
+- Events with `timestamp` field
+- `StateMachineConfig` with `max_hops`
+- `StateDef` with `max_visits`
+
+- [ ] **Step 3: Run tests (expect many failures from other files — types tests should pass)**
+
+Run: `uv run pytest tests/engine/test_types.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: replace ResultHistoryEntry with EventLogEntry, add timestamps and hop counters to types"
+```
+
+---
+
+### Task 2: Update Config Parsing — max_hops and max_visits
+
+**Files:**
+- Modify: `src/orca/engine/config.py`
+- Modify: `tests/engine/test_config.py`
+
+- [ ] **Step 1: Update config.py**
+
+- Parse `max_hops` from top-level YAML into `StateMachineConfig`
+- Parse `max_visits` from state definitions into `StateDef`
+- Add validation rules: both must be positive integers if present
+
+- [ ] **Step 2: Update test_config.py**
+
+Add tests:
+- Config with `max_hops` parsed correctly
+- Config with `max_visits` on a state parsed correctly
+- Validation: `max_hops: 0` → error
+- Validation: `max_hops: -1` → error
+- Validation: `max_visits: 0` → error
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/engine/test_config.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add max_hops and max_visits config parsing and validation"
+```
+
+---
+
+### Task 3: Update Dispatch — event_log in context, effect type widening
+
+**Files:**
+- Modify: `src/orca/engine/dispatch.py`
+- Modify: `tests/engine/test_dispatch.py`
+
+- [ ] **Step 1: Update dispatch.py**
+
+- `build_issue_context()`: replace `result_history` with `event_log` in both parent and child contexts
+- Widen `effects` parameter type from `list[DispatchWorkerEffect]` to `list[Effect]` in `try_dispatch`, `backfill_queue`, and helper functions. This is needed for Task 5 (hop limits emit ErrorEffect from these paths).
+- Add helper: `append_log(issue: Issue, timestamp: str, entry_type: str, data: dict[str, Any]) -> None` that appends an `EventLogEntry` to the issue's `event_log`. Centralizes log entry creation.
+
+**Note:** Intermediate commits (Tasks 1-7) will break some test files that haven't been migrated yet. This is expected — the full suite passes only after Task 8. Use a feature branch; don't expect CI to pass on intermediate commits.
+
+- [ ] **Step 2: Update test_dispatch.py**
+
+- Update all `Issue()` construction to use `event_log=[]` instead of `result_history=[]`
+- Add `visit_counts={}` and `hop_count=0` to Issue construction
+- Update `test_dispatch_includes_resolved_children` to assert `event_log` in context instead of `result_history`
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/engine/test_dispatch.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: update dispatch to use event_log and widen effect types"
+```
+
+---
+
+### Task 4: Update Reducer — Event Log Emission
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+- Modify: `tests/engine/test_reducer_create.py`
+- Modify: `tests/engine/test_reducer_advance.py`
+- Modify: `tests/engine/test_reducer_worker_result.py`
+- Modify: `tests/engine/test_reducer_worker_failed.py`
+- Create: `tests/engine/test_event_log.py`
+
+This is the largest task. The reducer gains `now` parameter and emits log entries at every action point.
+
+- [ ] **Step 1: Update reducer.py**
+
+- Add `now: Callable[[], str]` parameter to `reduce()`. Call `now()` once at the top, store as `ts`.
+- Pass `ts` through to all handlers.
+- **Timestamp rule:** use `event.timestamp` for log entries that directly record an incoming event (`created` from CreateEvent, `advanced` from AdvanceEvent, `worker_result` from WorkerResultEvent, `worker_failed` from WorkerFailedEvent). Use `ts` (from `now()`) for reducer-initiated entries (`worker_dispatched`, `transitioned`, `decomposition_blocked`, `dependency_blocked`, `unblocked`, sub-issue `created`).
+- In `_handle_create`: append `created` log entry to issue. Initialize `visit_counts={config.initial: 1}`, `hop_count=0`. On dispatch, append `worker_dispatched` log entry.
+- In `_handle_advance`: append `advanced` log entry with `{from, to}`. Increment `visit_counts[target]` and `hop_count`. On dispatch, append `worker_dispatched` log entry.
+- In `_handle_worker_result`: append `worker_result` log entry. On transition, append `transitioned` log entry, increment `visit_counts` and `hop_count`. On decompose, append `decomposition_blocked` log entry to parent, `created` log entry to each child. Increment `hop_count` for decompose.
+- In `_handle_worker_failed`: append `worker_failed` log entry. On retry dispatch, append `worker_dispatched` log entry.
+- In `_cascading_unblock`: append `unblocked` log entry. On dispatch, append `worker_dispatched` log entry.
+- In `_apply_decompose`: append `created` to each child, `dependency_blocked` to children that have depends_on.
+- Update all `Issue()` construction to use `event_log=[]` instead of `result_history=[]`, add `visit_counts` and `hop_count`.
+- Replace `issue.result_history.append(ResultHistoryEntry(...))` with `append_log(issue, ts, "worker_result", {...})`.
+- Update all handler signatures to accept `ts: str` parameter.
+- Widen `_apply_transition` and `_apply_decompose` signatures from `list[DispatchWorkerEffect]` to `list[Effect]`. This is needed for Task 5 (hop limits emit ErrorEffect from these paths).
+- Update `try_dispatch` calls to also append `worker_dispatched` log entries. Since `try_dispatch` is in dispatch.py, the reducer appends `worker_dispatched` after each `try_dispatch` call by checking if effects list grew (compare length before/after call).
+- **WorkerFailed log ordering:** In `_handle_worker_failed`, append `worker_failed` log entry FIRST, then `worker_dispatched` log entry, then build the retry `DispatchWorkerEffect` via `build_issue_context`. This ensures the retrying worker sees both the failure and the re-dispatch in its context.
+
+- [ ] **Step 2: Update test_reducer_create.py**
+
+- Add `timestamp` to all event constructors
+- Add `now` parameter to all `reduce()` calls (use `lambda: "2026-01-01T00:00:00Z"` or a counter-based clock)
+- Update assertions: `result_history` → `event_log`
+- Add assertions for `created` and `worker_dispatched` log entries
+- Add assertions for `visit_counts` initialization
+
+- [ ] **Step 3: Update test_reducer_advance.py**
+
+- Same timestamp/now updates
+- Add assertions for `advanced` log entries
+- Add assertions for `hop_count` and `visit_counts` changes
+
+- [ ] **Step 4: Update test_reducer_worker_result.py**
+
+- Same timestamp/now updates
+- Update all `result_history` assertions to `event_log`
+- Add assertions for `worker_result`, `transitioned`, `decomposition_blocked`, `created` (sub-issues) log entries
+- Add assertions for `hop_count` increments on transitions and decompose
+
+- [ ] **Step 5: Update test_reducer_worker_failed.py**
+
+- Same timestamp/now updates
+- Add assertions for `worker_failed` and `worker_dispatched` log entries
+
+- [ ] **Step 6: Create test_event_log.py — dedicated event log tests**
+
+Tests focused on log entry correctness:
+- `test_create_logs_created_entry` — verify timestamp, type, data
+- `test_advance_logs_advanced_entry` — verify from/to in data
+- `test_advance_does_not_log_transitioned` — Advance produces `advanced`, not `transitioned`
+- `test_worker_result_logs_result_and_transition` — both entries present
+- `test_worker_failed_logs_failed_and_dispatch` — both entries present
+- `test_decompose_logs_blocked_and_child_created` — parent gets `decomposition_blocked`, children get `created`
+- `test_unblock_logs_unblocked_entry` — after all children terminal
+- `test_dependency_blocked_child_gets_log_entry` — child with depends_on gets `dependency_blocked`
+- `test_event_log_timestamps_use_event_timestamp` — verify `worker_result` entry uses event.timestamp
+- `test_full_lifecycle_log` — issue goes through create → advance → implement → transition → done, verify complete log sequence
+
+- [ ] **Step 7: Run all reducer and event log tests**
+
+Run: `uv run pytest tests/engine/test_reducer_create.py tests/engine/test_reducer_advance.py tests/engine/test_reducer_worker_result.py tests/engine/test_reducer_worker_failed.py tests/engine/test_event_log.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git commit -m "feat: add event log emission to reducer, replace result_history"
+```
+
+---
+
+### Task 5: Add Hop Limit Checks to Reducer
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+- Create: `tests/engine/test_hop_limits.py`
+
+- [ ] **Step 1: Add limit checks to reducer.py**
+
+In `_handle_worker_result`, before `_apply_transition`:
+- Check `max_visits` on target state: if `issue.visit_counts.get(target, 0) + 1 > max_visits` → error
+- Check `max_hops` on config: if `issue.hop_count + 1 > max_hops` → error
+- On limit hit: set `worker_active=False`, backfill queue, append `limit_reached` log entry, emit `ErrorEffect`, return
+
+In `_handle_worker_result`, before `_apply_decompose`:
+- Check `max_hops`: if `issue.hop_count + 1 > max_hops` → error (same pattern)
+
+In `_handle_advance`, before moving to target state:
+- Same checks for `max_visits` and `max_hops`
+
+- [ ] **Step 2: Create test_hop_limits.py**
+
+Tests:
+- `test_max_visits_blocks_transition` — state with max_visits:2, issue visits it 2 times, third attempt errors
+- `test_max_hops_blocks_transition` — config with max_hops:3, issue does 3 hops, fourth attempt errors
+- `test_max_visits_on_advance` — advance to state with max_visits, verify it's checked
+- `test_decompose_increments_hop_count` — verify hop_count goes up on decompose
+- `test_limit_frees_slot_and_backfills` — in max_workers state, limit hit frees slot, queued issue dispatched
+- `test_limit_logs_limit_reached` — verify log entry
+- `test_no_limit_by_default` — without max_visits/max_hops, loops run freely
+- `test_loop_detection_implementing_qa` — realistic: implementing → qa → implementing loop with max_visits:3 on implementing, verify it stops
+- `test_decompose_loop_detection` — parent decomposes, child completes instantly, parent unblocks and re-runs, decomposes again — verify max_hops stops this cycle
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/engine/test_hop_limits.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add hop limit checks (max_visits, max_hops) to reducer"
+```
+
+---
+
+### Task 6: ASCII Visualization
+
+**Files:**
+- Create: `src/orca/engine/formatting.py`
+- Create: `tests/engine/test_formatting.py`
+
+- [ ] **Step 1: Create test_formatting.py**
+
+Tests:
+- `test_single_root_issue` — one issue, verify format: `ISSUE-1 [todo] ... 0m`
+- `test_terminal_issue_no_marker` — done issue shows just time, no `...`
+- `test_parent_with_children` — decomposed parent with 2 children, verify tree connectors
+- `test_depends_on_annotation` — child with depends_on shows annotation
+- `test_elapsed_time_formatting` — verify minutes, hours, days formatting
+- `test_worker_queues_shown` — state with queued issues, verify footer
+- `test_no_created_event_shows_question_mark` — issue without created log entry
+- `test_sort_order_by_id` — verify lexicographic sort of roots and children
+- `test_empty_state` — no issues, empty string output
+- `test_deep_nesting` — 3-level decomposition tree, verify indentation
+
+- [ ] **Step 2: Create formatting.py**
+
+Implement `format_issues(state, config, now)`:
+1. Find roots (no `decomposed_from`)
+2. Sort by ID
+3. For each root, recursively render children (sorted by ID)
+4. Show `depends_on` annotations
+5. Show `...` for non-terminal states
+6. Compute elapsed time from `created` log entry
+7. Show worker queues at bottom
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/engine/test_formatting.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: add ASCII visualization for issue state"
+```
+
+---
+
+### Task 7: Update Public API and Exports
+
+**Files:**
+- Modify: `src/orca/engine/__init__.py`
+
+- [ ] **Step 1: Update __init__.py**
+
+- Remove `ResultHistoryEntry` (if exported)
+- Add `EventLogEntry`
+- Add `format_issues` from `formatting.py`
+
+- [ ] **Step 2: Run test**
+
+Run: `uv run pytest tests/engine/test_types.py::TestPublicAPI -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat: update public API exports with EventLogEntry and format_issues"
+```
+
+---
+
+### Task 8: Migrate Scenario Tests
+
+**Files:**
+- Modify: `tests/engine/test_scenario_kanban.py`
+- Modify: `tests/engine/test_scenario_pipeline.py`
+- Modify: `tests/engine/test_scenario_decompose.py`
+- Modify: `tests/engine/test_scenario_queuing.py`
+- Modify: `tests/engine/test_scenario_edge_cases.py`
+- Modify: `tests/engine/test_scenario_serialization.py`
+- Modify: `tests/engine/conftest.py`
+
+All scenario tests need the same migration pattern:
+- Add `timestamp` to all event constructors
+- Add `now` (clock function) to all `reduce()` calls
+- Replace `result_history=[]` with `event_log=[]` in any direct `Issue()` construction
+- Add `visit_counts={}` and `hop_count=0` to any direct `Issue()` construction
+- Update assertions that check `result_history` to check `event_log` (filter by type)
+- Update conftest: add a `_clock()` fixture or helper
+
+- [ ] **Step 1: Update conftest.py**
+
+Add helper:
+```python
+def make_clock(start: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: start
+```
+
+Add configs with `max_hops`/`max_visits` if needed.
+
+- [ ] **Step 2: Migrate each scenario test file**
+
+Apply the migration pattern to all 6 files. For each:
+- Find/replace `result_history=[]` → `event_log=[], visit_counts={}, hop_count=0`
+- Add `timestamp="2026-01-01T00:00:00Z"` to event constructors
+- Add `lambda: "2026-01-01T00:00:00Z"` as `now` to `reduce()` calls
+- Update assertions checking `result_history` length to check `event_log` filtered by type
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: Run ruff and mypy**
+
+Run: `uv run ruff check . && uv run ruff format --check . && uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "chore: migrate all scenario tests to event_log API"
+```
+
+---
+
+### Task 9: Final Verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: ALL PASS (134+ original + new tests)
+
+- [ ] **Step 2: Run ruff, format, mypy**
+
+Run: `uv run ruff check . && uv run ruff format --check . && uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 3: Update original engine spec**
+
+Update `docs/superpowers/specs/2026-03-22-state-machine-engine-design.md` to reflect all changes: `event_log` replacing `result_history`, new reducer signature with `now`, timestamps on events, `visit_counts`/`hop_count`, `max_visits`/`max_hops`.
+
+- [ ] **Step 4: Verify CI config includes test job**
+
+Already done in previous PR — the `test` job runs `uv run pytest -v`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "docs: update original engine spec for event log and hop limits"
+```

--- a/docs/superpowers/specs/2026-03-22-engine-improvements-design.md
+++ b/docs/superpowers/specs/2026-03-22-engine-improvements-design.md
@@ -1,0 +1,278 @@
+# Engine Improvements Design
+
+Three improvements to the state machine engine: event log, hop limits, and ASCII visualization.
+
+## 1. Event Log (replaces result_history)
+
+### Goal
+
+Replace `result_history` with a comprehensive `event_log` that records everything that happens to an issue. One log, one source of truth.
+
+### Changes to Issue State
+
+Remove `result_history: list[ResultHistoryEntry]`. Add `event_log: list[EventLogEntry]`.
+
+```python
+@dataclass
+class EventLogEntry:
+    timestamp: str  # ISO 8601
+    type: str
+    data: dict[str, Any]
+```
+
+### Changes to Reducer Signature
+
+```python
+def reduce(
+    config: StateMachineConfig,
+    state: State,
+    event: Event,
+    generate_id: Callable[[], str],
+    now: Callable[[], str],  # returns ISO timestamp
+) -> tuple[State, list[Effect]]
+```
+
+`now()` is called **once** at the start of each `reduce()` invocation. The resulting timestamp is reused for all log entries within that call. This gives snapshot semantics — all entries from a single reduce call share a timestamp. In tests, use a deterministic clock.
+
+### Event Types Added to Events
+
+All event dataclasses get a `timestamp: str` field:
+
+```python
+@dataclass(frozen=True)
+class CreateEvent:
+    issue_id: str
+    fields: dict[str, Any]
+    timestamp: str
+
+@dataclass(frozen=True)
+class AdvanceEvent:
+    issue_id: str
+    target_state: str
+    timestamp: str
+
+@dataclass(frozen=True)
+class WorkerResultEvent:
+    issue_id: str
+    result: dict[str, Any]
+    timestamp: str
+
+@dataclass(frozen=True)
+class WorkerFailedEvent:
+    issue_id: str
+    error: str
+    timestamp: str
+```
+
+### Log Entries
+
+The reducer appends entries to `event_log` at these points:
+
+| When | type | data |
+|------|------|------|
+| Issue created (Create event or decompose sub-issue creation) | `created` | `{}` |
+| Advance event | `advanced` | `{"from": "<state>", "to": "<state>"}` |
+| Worker dispatched (DispatchWorker emitted) | `worker_dispatched` | `{"state": "<state>"}` |
+| WorkerResult received | `worker_result` | `{"state": "<state>", "result": {<full result>}}` |
+| WorkerFailed received | `worker_failed` | `{"state": "<state>", "error": "<msg>"}` |
+| State transition (from WorkerResult routing) | `transitioned` | `{"from": "<state>", "to": "<state>"}` |
+| Decomposition block | `decomposition_blocked` | `{"children": ["<id>", ...]}` |
+| Dependency block | `dependency_blocked` | `{"depends_on": ["<id>", ...]}` |
+| Unblocked | `unblocked` | `{"reason": "decomposition" or "dependency"}` |
+
+**Timestamp sources:** log entries use the event's `timestamp` field when available. For reducer-initiated entries (e.g., `worker_dispatched`, `transitioned`, sub-issue `created`), use the `now()` snapshot captured at the start of the `reduce()` call.
+
+**Sub-issue creation:** when the reducer creates sub-issues via `action: decompose`, each child gets a `created` log entry. This ensures `format_issues` can compute elapsed time for all issues, not just externally created ones.
+
+**WorkerFailed flow:** the handler appends a `worker_failed` log entry, then emits the retry `DispatchWorkerEffect` which also appends a `worker_dispatched` entry. Both appear in the log.
+
+**Advance vs transitioned:** an `Advance` event produces only an `advanced` entry (not `transitioned`). The `transitioned` entry is reserved for transitions caused by `WorkerResult` routing. This makes the log unambiguous about what triggered each state change.
+
+### DispatchWorkerEffect
+
+The `issue` context includes `event_log` instead of `result_history`. Workers that need prior results filter for `type == "worker_result"` entries.
+
+### Serialization
+
+`EventLogEntry` follows the same `to_dict()`/`from_dict()` pattern. The `ResultHistoryEntry` class is removed.
+
+---
+
+## 2. Hop Limits
+
+### Goal
+
+Prevent issues from looping infinitely between states. Two mechanisms: per-state `max_visits` and global `max_hops`.
+
+### Changes to Issue State
+
+Add two fields:
+
+- `visit_counts: dict[str, int]` — how many times the issue has entered each state
+- `hop_count: int` — total number of transitions
+
+### Changes to orca.yml Config
+
+Optional `max_visits` on state definitions:
+
+```yaml
+implementing:
+  max_visits: 5
+  worker: ...
+```
+
+Optional `max_hops` at top level:
+
+```yaml
+max_hops: 50
+
+states:
+  ...
+```
+
+### Changes to StateMachineConfig
+
+Add `max_hops: int | None = None` to `StateMachineConfig`.
+Add `max_visits: int | None = None` to `StateDef`.
+
+### Counting Rules
+
+| Event | hop_count | visit_counts |
+|-------|-----------|-------------|
+| Create (initial placement) | unchanged | +1 for initial state |
+| Advance | +1 | +1 for target state |
+| WorkerResult → simple transition | +1 | +1 for target state |
+| WorkerResult → decompose | +1 | unchanged (stays in same state, but the decompose-unblock-re-run cycle counts as a hop) |
+| Unblock re-dispatch | unchanged | unchanged (already in the state) |
+
+**Why decompose increments hop_count:** without this, a worker that decomposes with a single child that immediately completes could loop infinitely: decompose → child done → parent unblocked → re-run → decompose again. The global `max_hops` safety net catches this.
+
+### Limit Check
+
+Before applying a transition (in WorkerResult or Advance), the reducer checks:
+
+1. If target state has `max_visits` and `visit_counts[target] + 1 > max_visits` → emit `Error` effect, do not transition
+2. If config has `max_hops` and `hop_count + 1 > max_hops` → emit `Error` effect, do not transition
+
+For decompose, the `max_hops` check is performed before creating sub-issues.
+
+On limit hit:
+- Issue stays in current state
+- `worker_active` set to `false` (slot freed)
+- Slot backfill triggered for the current state if it has `max_workers`
+- `Error` effect emitted with descriptive message
+- Log entry added: `{"type": "limit_reached", "data": {"limit": "max_visits" or "max_hops", "state": "...", "count": N}}`
+
+**Dead end:** an issue that hits a limit is parked — no mechanism will move it automatically. This is intentional. The orchestrator must handle it (alert an operator, move to an error state, etc.). A future `ResetLimits` event could be added if automated recovery is needed.
+
+### Implementation Note: Effect Type Widening
+
+The current `_apply_transition` and dispatch helpers accept `list[DispatchWorkerEffect]`. With hop limits, they need to emit `ErrorEffect` as well. The effects parameter in these internal functions must be widened to `list[Effect]` (the union type). This is a refactor of internal function signatures, not a public API change.
+
+### Validation
+
+- `max_visits` if present must be a positive integer
+- `max_hops` if present must be a positive integer
+
+### Issue State Initialization
+
+On `Create`: `hop_count = 0`, `visit_counts = {config.initial: 1}`.
+
+On deserialization of existing state without these fields: default to `hop_count = 0`, `visit_counts = {}`.
+
+---
+
+## 3. ASCII Visualization
+
+### Goal
+
+Utility function to display the current state of all issues as a formatted ASCII string.
+
+### Function
+
+```python
+def format_issues(state: State, config: StateMachineConfig, now: str) -> str
+```
+
+Located in `src/orca/engine/formatting.py`.
+
+### Output Format
+
+```
+ISSUE-1 [scoping] ... 2h 15m
+├── ISSUE-4 [done] 20m
+├── ISSUE-2 [done] 45m
+└── ISSUE-3 [implementing] ... 1h 30m
+    └── depends on: ISSUE-4
+
+Queued in 'apply': ISSUE-5, ISSUE-6
+```
+
+### Rules
+
+- Root issues (no `decomposed_from`) are top-level entries
+- Children indented under their decomposition parent with `├──` / `└──` connectors
+- Sort order: roots and children sorted by issue ID (lexicographic). Deterministic across serialization round-trips.
+- `depends_on` shown as annotation line under the dependent issue, indented with same tree connector style
+- Non-terminal states show `...` after the state name
+- Terminal states show just the elapsed time, no marker
+- Elapsed time computed from the `created` entry in `event_log` to the `now` parameter, formatted as `Xd Yh Zm` (dropping zero leading units, minimum shows `0m`)
+- Worker queues listed at the bottom: `Queued in '<state>': ID-1, ID-2` — shows contents of `worker_queues[state]` for each non-empty queue
+- Issues without a `created` event in their log show `?` for elapsed time
+
+### No Config Changes
+
+Read-only utility on existing state. No changes to the reducer or config.
+
+---
+
+## Migration
+
+This is a breaking change to the reducer signature, state format, and worker-facing API.
+
+### State format changes
+
+- `result_history` field removed from `Issue`, replaced with `event_log`
+- `ResultHistoryEntry` class removed, replaced with `EventLogEntry`
+- New fields added to `Issue`: `visit_counts: dict[str, int]`, `hop_count: int`
+- `Issue.from_dict()` must handle missing `visit_counts`/`hop_count` with defaults (`{}` and `0`)
+
+### Reducer signature change
+
+- `reduce(config, state, event, gen)` → `reduce(config, state, event, gen, now)`
+
+### Event changes
+
+- All event dataclasses gain a `timestamp: str` field
+
+### Worker-facing API change
+
+- `DispatchWorkerEffect.issue` context includes `event_log` instead of `result_history`
+- Workers that previously read `result_history` must be updated to filter `event_log` for `type == "worker_result"` entries
+
+### Config changes
+
+- `StateMachineConfig` gains `max_hops: int | None`
+- `StateDef` gains `max_visits: int | None`
+- `parse_config` updated to parse these fields
+- Validation rules added for positive integer checks
+
+### Test updates
+
+- All `result_history=[]` → `event_log=[]`
+- All `ResultHistoryEntry(...)` → removed
+- All `reduce(config, state, event, gen)` → `reduce(config, state, event, gen, now)`
+- All event constructors need `timestamp` argument
+- Tests asserting on `result_history` → assert on `event_log` entries filtered by type
+- New fields `visit_counts={}` and `hop_count=0` added to `Issue` constructors in tests
+
+### Original spec update
+
+The original engine spec (`docs/superpowers/specs/2026-03-22-state-machine-engine-design.md`) must be updated to reflect all changes. This should be done as part of the implementation, not as a separate task.
+
+## Future Considerations
+
+- Event log compaction — for long-running issues, the log could grow large. A future improvement could archive old entries.
+- Event log querying — helper functions like `get_worker_results(event_log)` for common filters.
+- `ResetLimits` event — for automated recovery of issues that hit hop/visit limits.
+- Cross-group dependencies in `format_issues` — if non-sibling `depends_on` is added later, the display may need adjustment.

--- a/src/orca/engine/__init__.py
+++ b/src/orca/engine/__init__.py
@@ -1,6 +1,7 @@
 """Orca state machine engine."""
 
 from orca.engine.config import ConfigValidationError, parse_config
+from orca.engine.formatting import format_issues
 from orca.engine.reducer import reduce
 from orca.engine.types import (
     AdvanceEvent,
@@ -9,6 +10,7 @@ from orca.engine.types import (
     Effect,
     ErrorEffect,
     Event,
+    EventLogEntry,
     Issue,
     State,
     StateMachineConfig,
@@ -19,6 +21,7 @@ from orca.engine.types import (
 __all__ = [
     "ConfigValidationError",
     "parse_config",
+    "format_issues",
     "reduce",
     "AdvanceEvent",
     "CreateEvent",
@@ -26,6 +29,7 @@ __all__ = [
     "Effect",
     "ErrorEffect",
     "Event",
+    "EventLogEntry",
     "Issue",
     "State",
     "StateMachineConfig",

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -99,11 +99,14 @@ def _parse_state(name: str, raw_data: dict[str, Any] | None) -> StateDef:
         for key, value in on_data.items():
             on[key] = _parse_on_rule(key, value)
 
+    max_visits = data.get("max_visits")
+
     return StateDef(
         worker=worker,
         on=on,
         terminal=terminal,
         max_workers=max_workers,
+        max_visits=max_visits,
     )
 
 
@@ -121,6 +124,11 @@ def _parse_issue_fields(data: dict[str, Any] | None) -> dict[str, FieldDef]:
 
 def _validate(config: StateMachineConfig) -> None:
     state_names = set(config.states.keys())
+
+    # Validate max_hops if present
+    if config.max_hops is not None and (not isinstance(config.max_hops, int) or config.max_hops < 1):
+        msg = f"max_hops must be a positive integer, got {config.max_hops}"
+        raise ConfigValidationError(msg)
 
     # Rule 1: initial references an existing state
     if config.initial not in state_names:
@@ -140,6 +148,11 @@ def _validate(config: StateMachineConfig) -> None:
         # Rule 9: max_workers must be positive integer
         if state.max_workers is not None and (not isinstance(state.max_workers, int) or state.max_workers < 1):
             msg = f"max_workers for state '{name}' must be a positive integer, got {state.max_workers}"
+            raise ConfigValidationError(msg)
+
+        # max_visits must be positive integer
+        if state.max_visits is not None and (not isinstance(state.max_visits, int) or state.max_visits < 1):
+            msg = f"max_visits for state '{name}' must be a positive integer, got {state.max_visits}"
             raise ConfigValidationError(msg)
 
         # Rule 5: terminal states have no worker or on
@@ -215,11 +228,13 @@ def parse_config(yaml_str: str) -> StateMachineConfig:
         states[name] = _parse_state(name, state_data)
 
     initial: str = raw.get("initial", "")
+    max_hops = raw.get("max_hops")
 
     config = StateMachineConfig(
         issue_fields=issue_fields,
         initial=initial,
         states=states,
+        max_hops=max_hops,
     )
 
     _validate(config)

--- a/src/orca/engine/dispatch.py
+++ b/src/orca/engine/dispatch.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from orca.engine.types import (
     DispatchWorkerEffect,
+    Effect,
     EnumFieldDef,
+    EventLogEntry,
+    Issue,
     ListFieldDef,
     State,
     StateMachineConfig,
@@ -53,12 +56,12 @@ def build_issue_context(state: State, issue_id: str) -> dict[str, Any]:
                 "issue_id": child_id,
                 "fields": child.fields,
                 "state": child.state,
-                "result_history": [entry.to_dict() for entry in child.result_history],
+                "event_log": [entry.to_dict() for entry in child.event_log],
             }
         )
     return {
         "fields": issue.fields,
-        "result_history": [entry.to_dict() for entry in issue.result_history],
+        "event_log": [entry.to_dict() for entry in issue.event_log],
         "decomposed_from": issue.decomposed_from,
         "depends_on": issue.depends_on,
         "children": children,
@@ -95,11 +98,16 @@ def build_result_format(config: StateMachineConfig, state_name: str) -> dict[str
     return result
 
 
+def append_log(issue: Issue, timestamp: str, entry_type: str, data: dict[str, Any]) -> None:
+    """Append an event log entry to an issue."""
+    issue.event_log.append(EventLogEntry(timestamp=timestamp, type=entry_type, data=data))
+
+
 def try_dispatch(
     config: StateMachineConfig,
     state: State,
     issue_id: str,
-    effects: list[DispatchWorkerEffect],
+    effects: list[Effect],
 ) -> None:
     """Core dispatch protocol."""
     issue = state.issues[issue_id]
@@ -138,7 +146,7 @@ def backfill_queue(
     config: StateMachineConfig,
     state: State,
     state_name: str,
-    effects: list[DispatchWorkerEffect],
+    effects: list[Effect],
 ) -> None:
     """When a slot frees up in a capped state, pop next non-blocked issue from queue and dispatch."""
     queue = state.worker_queues.get(state_name)

--- a/src/orca/engine/formatting.py
+++ b/src/orca/engine/formatting.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from orca.engine.types import Issue, State, StateMachineConfig
+
+
+def _format_elapsed(created_ts: str, now: str) -> str:
+    """Format elapsed time between created timestamp and now."""
+    created = datetime.fromisoformat(created_ts)
+    current = datetime.fromisoformat(now)
+    # Ensure both are UTC-aware for correct diff
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    delta = current - created
+    total_seconds = max(0, int(delta.total_seconds()))
+    days = total_seconds // 86400
+    hours = (total_seconds % 86400) // 3600
+    minutes = (total_seconds % 3600) // 60
+
+    parts: list[str] = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0 or not parts:
+        parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+def _get_created_timestamp(issue: Issue) -> str | None:
+    """Find the 'created' event timestamp in the issue's event log."""
+    for entry in issue.event_log:
+        if entry.type == "created":
+            return entry.timestamp
+    return None
+
+
+def _get_children(state: State, issue_id: str) -> list[str]:
+    """Get child issue IDs sorted lexicographically."""
+    children = [
+        iid for iid, issue in state.issues.items() if issue.decomposed_from == issue_id
+    ]
+    return sorted(children)
+
+
+def _render_issue(
+    state: State,
+    config: StateMachineConfig,
+    issue_id: str,
+    now: str,
+    prefix: str,
+    connector: str,
+) -> list[str]:
+    """Render a single issue and its children recursively."""
+    issue = state.issues[issue_id]
+    state_def = config.states[issue.state]
+    is_terminal = state_def.terminal
+
+    # Elapsed time
+    created_ts = _get_created_timestamp(issue)
+    elapsed = _format_elapsed(created_ts, now) if created_ts is not None else "?"
+
+    # State marker
+    marker = "" if is_terminal else " ..."
+
+    line = f"{prefix}{connector}{issue_id} [{issue.state}]{marker} {elapsed}"
+    lines: list[str] = [line]
+
+    # Determine the continuation prefix for children/annotations
+    if connector == "":
+        child_prefix = prefix
+    elif connector == "\u251c\u2500\u2500 ":
+        child_prefix = prefix + "\u2502   "
+    else:  # "└── "
+        child_prefix = prefix + "    "
+
+    # depends_on annotation
+    if issue.depends_on:
+        dep_str = ", ".join(sorted(issue.depends_on))
+        lines.append(f"{child_prefix}\u2514\u2500\u2500 depends on: {dep_str}")
+
+    # Children
+    children = _get_children(state, issue_id)
+    for i, child_id in enumerate(children):
+        is_last = i == len(children) - 1
+        child_connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
+        lines.extend(
+            _render_issue(state, config, child_id, now, child_prefix, child_connector)
+        )
+
+    return lines
+
+
+def format_issues(state: State, config: StateMachineConfig, now: str) -> str:
+    """Format the current state as an ASCII tree visualization."""
+    if not state.issues:
+        return ""
+
+    # Find root issues (no decomposed_from), sorted by ID
+    roots = sorted(
+        iid for iid, issue in state.issues.items() if issue.decomposed_from is None
+    )
+
+    lines: list[str] = []
+
+    for root_id in roots:
+        children = _get_children(state, root_id)
+        root_lines = _render_issue(state, config, root_id, now, "", "")
+
+        if not children:
+            lines.extend(root_lines)
+        else:
+            # Root with children: render root, then children with tree connectors
+            issue = state.issues[root_id]
+            state_def = config.states[issue.state]
+            is_terminal = state_def.terminal
+            created_ts = _get_created_timestamp(issue)
+            elapsed = (
+                _format_elapsed(created_ts, now) if created_ts is not None else "?"
+            )
+            marker = "" if is_terminal else " ..."
+            lines.append(f"{root_id} [{issue.state}]{marker} {elapsed}")
+
+            # depends_on for root
+            if issue.depends_on:
+                dep_str = ", ".join(sorted(issue.depends_on))
+                lines.append(f"\u2514\u2500\u2500 depends on: {dep_str}")
+
+            for i, child_id in enumerate(children):
+                is_last = i == len(children) - 1
+                connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
+                lines.extend(
+                    _render_issue(state, config, child_id, now, "", connector)
+                )
+
+        lines.append("")  # blank line after each root tree
+
+    # Worker queues
+    for state_name in sorted(state.worker_queues.keys()):
+        queue = state.worker_queues[state_name]
+        if queue:
+            lines.append(f"Queued in '{state_name}': {', '.join(queue)}")
+
+    # Strip trailing blank lines, then join
+    while lines and lines[-1] == "":
+        lines.pop()
+
+    return "\n".join(lines)

--- a/src/orca/engine/formatting.py
+++ b/src/orca/engine/formatting.py
@@ -40,9 +40,7 @@ def _get_created_timestamp(issue: Issue) -> str | None:
 
 def _get_children(state: State, issue_id: str) -> list[str]:
     """Get child issue IDs sorted lexicographically."""
-    children = [
-        iid for iid, issue in state.issues.items() if issue.decomposed_from == issue_id
-    ]
+    children = [iid for iid, issue in state.issues.items() if issue.decomposed_from == issue_id]
     return sorted(children)
 
 
@@ -87,9 +85,7 @@ def _render_issue(
     for i, child_id in enumerate(children):
         is_last = i == len(children) - 1
         child_connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-        lines.extend(
-            _render_issue(state, config, child_id, now, child_prefix, child_connector)
-        )
+        lines.extend(_render_issue(state, config, child_id, now, child_prefix, child_connector))
 
     return lines
 
@@ -100,9 +96,7 @@ def format_issues(state: State, config: StateMachineConfig, now: str) -> str:
         return ""
 
     # Find root issues (no decomposed_from), sorted by ID
-    roots = sorted(
-        iid for iid, issue in state.issues.items() if issue.decomposed_from is None
-    )
+    roots = sorted(iid for iid, issue in state.issues.items() if issue.decomposed_from is None)
 
     lines: list[str] = []
 
@@ -118,9 +112,7 @@ def format_issues(state: State, config: StateMachineConfig, now: str) -> str:
             state_def = config.states[issue.state]
             is_terminal = state_def.terminal
             created_ts = _get_created_timestamp(issue)
-            elapsed = (
-                _format_elapsed(created_ts, now) if created_ts is not None else "?"
-            )
+            elapsed = _format_elapsed(created_ts, now) if created_ts is not None else "?"
             marker = "" if is_terminal else " ..."
             lines.append(f"{root_id} [{issue.state}]{marker} {elapsed}")
 
@@ -132,9 +124,7 @@ def format_issues(state: State, config: StateMachineConfig, now: str) -> str:
             for i, child_id in enumerate(children):
                 is_last = i == len(children) - 1
                 connector = "\u2514\u2500\u2500 " if is_last else "\u251c\u2500\u2500 "
-                lines.extend(
-                    _render_issue(state, config, child_id, now, "", connector)
-                )
+                lines.extend(_render_issue(state, config, child_id, now, "", connector))
 
         lines.append("")  # blank line after each root tree
 

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -136,6 +136,34 @@ def _handle_advance(
 
     old_state = issue.state
 
+    # Hop limit checks before moving
+    target_state_def = config.states[event.target_state]
+    if target_state_def.max_visits is not None:
+        current_visits = issue.visit_counts.get(event.target_state, 0)
+        if current_visits + 1 > target_state_def.max_visits:
+            append_log(
+                issue,
+                ts,
+                "limit_reached",
+                {"limit": "max_visits", "state": event.target_state, "count": current_visits + 1},
+            )
+            effects.append(
+                ErrorEffect(
+                    issue_id=event.issue_id,
+                    message=f"max_visits ({target_state_def.max_visits}) reached for state '{event.target_state}'",
+                )
+            )
+            return
+    if config.max_hops is not None and issue.hop_count + 1 > config.max_hops:
+        append_log(issue, ts, "limit_reached", {"limit": "max_hops", "count": issue.hop_count + 1})
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"max_hops ({config.max_hops}) reached",
+            )
+        )
+        return
+
     # Move to target state
     issue.state = event.target_state
 
@@ -145,9 +173,6 @@ def _handle_advance(
     # Update visit counts and hop count
     issue.visit_counts[event.target_state] = issue.visit_counts.get(event.target_state, 0) + 1
     issue.hop_count += 1
-
-    # If target state is active, dispatch
-    target_state_def = config.states[event.target_state]
     if target_state_def.worker is not None:
         prev_len = len(effects)
         try_dispatch(config, state, event.issue_id, effects)
@@ -235,7 +260,47 @@ def _handle_worker_result(
     if state_def.max_workers is not None:
         backfill_queue(config, state, old_state_name, dispatch_effects)
 
-    # 3. Route based on rule type
+    # 3. Hop limit checks before transition/decompose
+    if isinstance(rule, OnTransition):
+        target = rule.target
+        target_def = config.states[target]
+        if target_def.max_visits is not None:
+            current_visits = issue.visit_counts.get(target, 0)
+            if current_visits + 1 > target_def.max_visits:
+                append_log(
+                    issue, ts, "limit_reached", {"limit": "max_visits", "state": target, "count": current_visits + 1}
+                )
+                effects.append(
+                    ErrorEffect(
+                        issue_id=event.issue_id,
+                        message=f"max_visits ({target_def.max_visits}) reached for state '{target}'",
+                    )
+                )
+                effects.extend(dispatch_effects)
+                return
+        if config.max_hops is not None and issue.hop_count + 1 > config.max_hops:
+            append_log(issue, ts, "limit_reached", {"limit": "max_hops", "count": issue.hop_count + 1})
+            effects.append(
+                ErrorEffect(
+                    issue_id=event.issue_id,
+                    message=f"max_hops ({config.max_hops}) reached",
+                )
+            )
+            effects.extend(dispatch_effects)
+            return
+
+    if isinstance(rule, OnDecompose) and config.max_hops is not None and issue.hop_count + 1 > config.max_hops:
+        append_log(issue, ts, "limit_reached", {"limit": "max_hops", "count": issue.hop_count + 1})
+        effects.append(
+            ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"max_hops ({config.max_hops}) reached",
+            )
+        )
+        effects.extend(dispatch_effects)
+        return
+
+    # 4. Route based on rule type
     if isinstance(rule, OnTransition):
         _apply_transition(config, state, event.issue_id, issue, old_state_name, rule.target, dispatch_effects, ts)
     elif isinstance(rule, OnDecompose):

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -4,6 +4,7 @@ import copy
 from collections.abc import Callable
 
 from orca.engine.dispatch import (
+    append_log,
     backfill_queue,
     build_issue_context,
     build_result_format,
@@ -22,7 +23,6 @@ from orca.engine.types import (
     Issue,
     OnDecompose,
     OnTransition,
-    EventLogEntry,
     State,
     StateMachineConfig,
     WorkerFailedEvent,
@@ -35,19 +35,21 @@ def reduce(
     state: State,
     event: Event,
     generate_id: Callable[[], str],
+    now: Callable[[], str],
 ) -> tuple[State, list[Effect]]:
     """Dispatch event to the appropriate handler and return (new_state, effects)."""
     new_state = copy.deepcopy(state)
     effects: list[Effect] = []
+    ts = now()
 
     if isinstance(event, CreateEvent):
-        _handle_create(config, new_state, event, effects)
+        _handle_create(config, new_state, event, effects, ts)
     elif isinstance(event, AdvanceEvent):
-        _handle_advance(config, new_state, event, effects)
+        _handle_advance(config, new_state, event, effects, ts)
     elif isinstance(event, WorkerResultEvent):
-        _handle_worker_result(config, new_state, event, effects, generate_id)
+        _handle_worker_result(config, new_state, event, effects, generate_id, ts)
     elif isinstance(event, WorkerFailedEvent):
-        _handle_worker_failed(config, new_state, event, effects)
+        _handle_worker_failed(config, new_state, event, effects, ts)
 
     return new_state, effects
 
@@ -57,6 +59,7 @@ def _handle_create(
     state: State,
     event: CreateEvent,
     effects: list[Effect],
+    ts: str,
 ) -> None:
     if event.issue_id in state.issues:
         effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' already exists"))
@@ -69,15 +72,21 @@ def _handle_create(
         decomposed_from=None,
         depends_on=[],
         event_log=[],
+        visit_counts={config.initial: 1},
+        hop_count=0,
     )
     state.issues[event.issue_id] = issue
+
+    # Log the creation
+    append_log(issue, event.timestamp, "created", {"state": config.initial})
 
     # If initial state is active (has a worker), dispatch
     state_def = config.states[config.initial]
     if state_def.worker is not None:
-        dispatch_effects: list[Effect] = []
-        try_dispatch(config, state, event.issue_id, dispatch_effects)
-        effects.extend(dispatch_effects)
+        prev_len = len(effects)
+        try_dispatch(config, state, event.issue_id, effects)
+        if len(effects) > prev_len:
+            append_log(issue, ts, "worker_dispatched", {"state": issue.state})
 
 
 def _handle_advance(
@@ -85,6 +94,7 @@ def _handle_advance(
     state: State,
     event: AdvanceEvent,
     effects: list[Effect],
+    ts: str,
 ) -> None:
     # Issue must exist
     if event.issue_id not in state.issues:
@@ -124,15 +134,25 @@ def _handle_advance(
         )
         return
 
+    old_state = issue.state
+
     # Move to target state
     issue.state = event.target_state
+
+    # Log the advance
+    append_log(issue, event.timestamp, "advanced", {"from": old_state, "to": event.target_state})
+
+    # Update visit counts and hop count
+    issue.visit_counts[event.target_state] = issue.visit_counts.get(event.target_state, 0) + 1
+    issue.hop_count += 1
 
     # If target state is active, dispatch
     target_state_def = config.states[event.target_state]
     if target_state_def.worker is not None:
-        dispatch_effects: list[Effect] = []
-        try_dispatch(config, state, event.issue_id, dispatch_effects)
-        effects.extend(dispatch_effects)
+        prev_len = len(effects)
+        try_dispatch(config, state, event.issue_id, effects)
+        if len(effects) > prev_len:
+            append_log(issue, ts, "worker_dispatched", {"state": issue.state})
 
 
 def _handle_worker_result(
@@ -141,6 +161,7 @@ def _handle_worker_result(
     event: WorkerResultEvent,
     effects: list[Effect],
     generate_id: Callable[[], str],
+    ts: str,
 ) -> None:
     # --- Validation (before any mutation) ---
 
@@ -206,8 +227,8 @@ def _handle_worker_result(
     # 1. Set worker_active = False (frees slot)
     issue.worker_active = False
 
-    # 2. Append EventLogEntry
-    issue.event_log.append(EventLogEntry(timestamp=event.timestamp, type="worker_result", data=event.result))
+    # 2. Append worker_result log entry
+    append_log(issue, event.timestamp, "worker_result", event.result)
 
     # Slot backfill: if old state has max_workers, backfill
     dispatch_effects: list[Effect] = []
@@ -216,9 +237,9 @@ def _handle_worker_result(
 
     # 3. Route based on rule type
     if isinstance(rule, OnTransition):
-        _apply_transition(config, state, event.issue_id, issue, old_state_name, rule.target, dispatch_effects)
+        _apply_transition(config, state, event.issue_id, issue, old_state_name, rule.target, dispatch_effects, ts)
     elif isinstance(rule, OnDecompose):
-        _apply_decompose(config, state, event, issue, generate_id, dispatch_effects)
+        _apply_decompose(config, state, event, issue, generate_id, dispatch_effects, ts)
 
     effects.extend(dispatch_effects)
 
@@ -228,6 +249,7 @@ def _handle_worker_failed(
     state: State,
     event: WorkerFailedEvent,
     effects: list[Effect],
+    ts: str,
 ) -> None:
     # Issue must exist
     if event.issue_id not in state.issues:
@@ -249,6 +271,12 @@ def _handle_worker_failed(
         effects.append(ErrorEffect(issue_id=event.issue_id, message=f"State '{issue.state}' has no worker"))
         return
 
+    # Log the failure
+    append_log(issue, event.timestamp, "worker_failed", {"state": issue.state, "error": event.error})
+
+    # Log the retry dispatch
+    append_log(issue, ts, "worker_dispatched", {"state": issue.state})
+
     # worker_active stays True — slot is RETAINED (not freed)
     # Emit DispatchWorkerEffect unconditionally (retry), bypassing dispatch protocol
     effects.append(
@@ -269,6 +297,7 @@ def _apply_transition(
     old_state_name: str,
     target_state: str,
     effects: list[Effect],
+    ts: str,
 ) -> None:
     # Remove issue from old state's worker queue
     remove_from_queue(state, old_state_name, issue_id)
@@ -277,12 +306,22 @@ def _apply_transition(
     issue.state = target_state
     target_def = config.states[target_state]
 
+    # Log the transition
+    append_log(issue, ts, "transitioned", {"from": old_state_name, "to": target_state})
+
+    # Update visit counts and hop count
+    issue.visit_counts[target_state] = issue.visit_counts.get(target_state, 0) + 1
+    issue.hop_count += 1
+
     if target_def.terminal:
         # Run cascading unblock check
-        _cascading_unblock(config, state, issue_id, effects)
+        _cascading_unblock(config, state, issue_id, effects, ts)
     elif target_def.worker is not None:
         # Target is active -> dispatch
+        prev_len = len(effects)
         try_dispatch(config, state, issue_id, effects)
+        if len(effects) > prev_len:
+            append_log(issue, ts, "worker_dispatched", {"state": issue.state})
 
 
 def _apply_decompose(
@@ -292,8 +331,15 @@ def _apply_decompose(
     _parent_issue: Issue,
     generate_id: Callable[[], str],
     effects: list[Effect],
+    ts: str,
 ) -> None:
     sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
+
+    # Log decomposition blocked on parent
+    append_log(_parent_issue, ts, "decomposition_blocked", {})
+
+    # Increment parent hop count
+    _parent_issue.hop_count += 1
 
     # Generate IDs and build key -> real_id mapping
     key_to_id: dict[str, str] = {}
@@ -325,15 +371,28 @@ def _apply_decompose(
             decomposed_from=event.issue_id,
             depends_on=resolved_depends,
             event_log=[],
+            visit_counts={config.initial: 1},
+            hop_count=0,
         )
         state.issues[real_id] = child
+
+        # Log creation on child
+        append_log(child, ts, "created", {"state": config.initial})
+
+        # If child has dependencies, log dependency_blocked
+        if resolved_depends:
+            append_log(child, ts, "dependency_blocked", {"depends_on": resolved_depends})
 
     # Dispatch each child that is not blocked and whose initial state is active
     initial_def = config.states[config.initial]
     if initial_def.worker is not None:
         for _key, real_id in key_to_id.items():
             if not is_blocked(state, config, real_id):
+                prev_len = len(effects)
                 try_dispatch(config, state, real_id, effects)
+                if len(effects) > prev_len:
+                    child_issue = state.issues[real_id]
+                    append_log(child_issue, ts, "worker_dispatched", {"state": child_issue.state})
 
 
 def _cascading_unblock(
@@ -341,6 +400,7 @@ def _cascading_unblock(
     state: State,
     terminal_issue_id: str,
     effects: list[Effect],
+    ts: str,
 ) -> None:
     terminal_issue = state.issues[terminal_issue_id]
 
@@ -351,8 +411,13 @@ def _cascading_unblock(
         children = get_children(state, parent_id)
         all_terminal = all(config.states[state.issues[cid].state].terminal for cid in children)
         if all_terminal and not parent.worker_active:
+            # Log unblocked on parent
+            append_log(parent, ts, "unblocked", {"reason": "decomposition"})
             # Parent is no longer decomposition-blocked -> dispatch
+            prev_len = len(effects)
             try_dispatch(config, state, parent_id, effects)
+            if len(effects) > prev_len:
+                append_log(parent, ts, "worker_dispatched", {"state": parent.state})
 
     # 2. Dependency unblock: find all issues that depend on the terminal issue
     for iid, iss in state.issues.items():
@@ -365,4 +430,9 @@ def _cascading_unblock(
                 and not iss.worker_active
                 and config.states[iss.state].worker is not None
             ):
+                # Log unblocked on the dependent issue
+                append_log(iss, ts, "unblocked", {"reason": "dependency"})
+                prev_len = len(effects)
                 try_dispatch(config, state, iid, effects)
+                if len(effects) > prev_len:
+                    append_log(iss, ts, "worker_dispatched", {"state": iss.state})

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -22,7 +22,7 @@ from orca.engine.types import (
     Issue,
     OnDecompose,
     OnTransition,
-    ResultHistoryEntry,
+    EventLogEntry,
     State,
     StateMachineConfig,
     WorkerFailedEvent,
@@ -68,14 +68,14 @@ def _handle_create(
         worker_active=False,
         decomposed_from=None,
         depends_on=[],
-        result_history=[],
+        event_log=[],
     )
     state.issues[event.issue_id] = issue
 
     # If initial state is active (has a worker), dispatch
     state_def = config.states[config.initial]
     if state_def.worker is not None:
-        dispatch_effects: list[DispatchWorkerEffect] = []
+        dispatch_effects: list[Effect] = []
         try_dispatch(config, state, event.issue_id, dispatch_effects)
         effects.extend(dispatch_effects)
 
@@ -130,7 +130,7 @@ def _handle_advance(
     # If target state is active, dispatch
     target_state_def = config.states[event.target_state]
     if target_state_def.worker is not None:
-        dispatch_effects: list[DispatchWorkerEffect] = []
+        dispatch_effects: list[Effect] = []
         try_dispatch(config, state, event.issue_id, dispatch_effects)
         effects.extend(dispatch_effects)
 
@@ -206,11 +206,11 @@ def _handle_worker_result(
     # 1. Set worker_active = False (frees slot)
     issue.worker_active = False
 
-    # 2. Append ResultHistoryEntry
-    issue.result_history.append(ResultHistoryEntry(state=issue.state, result=event.result))
+    # 2. Append EventLogEntry
+    issue.event_log.append(EventLogEntry(timestamp=event.timestamp, type="worker_result", data=event.result))
 
     # Slot backfill: if old state has max_workers, backfill
-    dispatch_effects: list[DispatchWorkerEffect] = []
+    dispatch_effects: list[Effect] = []
     if state_def.max_workers is not None:
         backfill_queue(config, state, old_state_name, dispatch_effects)
 
@@ -268,7 +268,7 @@ def _apply_transition(
     issue: Issue,
     old_state_name: str,
     target_state: str,
-    effects: list[DispatchWorkerEffect],
+    effects: list[Effect],
 ) -> None:
     # Remove issue from old state's worker queue
     remove_from_queue(state, old_state_name, issue_id)
@@ -291,7 +291,7 @@ def _apply_decompose(
     event: WorkerResultEvent,
     _parent_issue: Issue,
     generate_id: Callable[[], str],
-    effects: list[DispatchWorkerEffect],
+    effects: list[Effect],
 ) -> None:
     sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
 
@@ -324,7 +324,7 @@ def _apply_decompose(
             worker_active=False,
             decomposed_from=event.issue_id,
             depends_on=resolved_depends,
-            result_history=[],
+            event_log=[],
         )
         state.issues[real_id] = child
 
@@ -340,7 +340,7 @@ def _cascading_unblock(
     config: StateMachineConfig,
     state: State,
     terminal_issue_id: str,
-    effects: list[DispatchWorkerEffect],
+    effects: list[Effect],
 ) -> None:
     terminal_issue = state.issues[terminal_issue_id]
 

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -59,6 +59,7 @@ class StateDef:
     on: dict[str, OnRule] = field(default_factory=dict)
     terminal: bool = False
     max_workers: int | None = None
+    max_visits: int | None = None
 
 
 @dataclass(frozen=True)
@@ -66,22 +67,24 @@ class StateMachineConfig:
     issue_fields: dict[str, FieldDef]
     initial: str
     states: dict[str, StateDef]
+    max_hops: int | None = None
 
 
 # --- Runtime state types (mutable, with serialization) ---
 
 
 @dataclass
-class ResultHistoryEntry:
-    state: str
-    result: dict[str, Any]
+class EventLogEntry:
+    timestamp: str  # ISO 8601
+    type: str
+    data: dict[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
-        return {"state": self.state, "result": self.result}
+        return {"timestamp": self.timestamp, "type": self.type, "data": self.data}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ResultHistoryEntry:
-        return cls(state=data["state"], result=data["result"])
+    def from_dict(cls, data: dict[str, Any]) -> EventLogEntry:
+        return cls(timestamp=data["timestamp"], type=data["type"], data=data["data"])
 
 
 @dataclass
@@ -91,7 +94,9 @@ class Issue:
     worker_active: bool
     decomposed_from: str | None
     depends_on: list[str]
-    result_history: list[ResultHistoryEntry]
+    event_log: list[EventLogEntry]
+    visit_counts: dict[str, int] = field(default_factory=dict)
+    hop_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -100,7 +105,9 @@ class Issue:
             "worker_active": self.worker_active,
             "decomposed_from": self.decomposed_from,
             "depends_on": self.depends_on,
-            "result_history": [entry.to_dict() for entry in self.result_history],
+            "event_log": [entry.to_dict() for entry in self.event_log],
+            "visit_counts": self.visit_counts,
+            "hop_count": self.hop_count,
         }
 
     @classmethod
@@ -111,7 +118,9 @@ class Issue:
             worker_active=data["worker_active"],
             decomposed_from=data["decomposed_from"],
             depends_on=data["depends_on"],
-            result_history=[ResultHistoryEntry.from_dict(e) for e in data["result_history"]],
+            event_log=[EventLogEntry.from_dict(e) for e in data.get("event_log", [])],
+            visit_counts=data.get("visit_counts", {}),
+            hop_count=data.get("hop_count", 0),
         )
 
 
@@ -141,24 +150,28 @@ class State:
 class CreateEvent:
     issue_id: str
     fields: dict[str, Any]
+    timestamp: str
 
 
 @dataclass(frozen=True)
 class AdvanceEvent:
     issue_id: str
     target_state: str
+    timestamp: str
 
 
 @dataclass(frozen=True)
 class WorkerResultEvent:
     issue_id: str
     result: dict[str, Any]
+    timestamp: str
 
 
 @dataclass(frozen=True)
 class WorkerFailedEvent:
     issue_id: str
     error: str
+    timestamp: str
 
 
 Event = CreateEvent | AdvanceEvent | WorkerResultEvent | WorkerFailedEvent

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
+
+
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
 
 
 @pytest.fixture()

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -316,3 +316,117 @@ initial: todo
 """
         with pytest.raises(ConfigValidationError, match="max_workers"):
             parse_config(yaml_str)
+
+    def test_max_hops_zero(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+max_hops: 0
+"""
+        with pytest.raises(ConfigValidationError, match="max_hops"):
+            parse_config(yaml_str)
+
+    def test_max_hops_negative(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+max_hops: -1
+"""
+        with pytest.raises(ConfigValidationError, match="max_hops"):
+            parse_config(yaml_str)
+
+    def test_max_visits_zero(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    max_visits: 0
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        with pytest.raises(ConfigValidationError, match="max_visits"):
+            parse_config(yaml_str)
+
+
+class TestParseMaxHops:
+    def test_max_hops_parsed(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+max_hops: 50
+"""
+        cfg = parse_config(yaml_str)
+        assert cfg.max_hops == 50
+
+
+class TestParseMaxVisits:
+    def test_max_visits_parsed(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    max_visits: 5
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        cfg = parse_config(yaml_str)
+        assert cfg.states["todo"].max_visits == 5

--- a/tests/engine/test_dispatch.py
+++ b/tests/engine/test_dispatch.py
@@ -11,11 +11,12 @@ from orca.engine.dispatch import (
 )
 from orca.engine.types import (
     DispatchWorkerEffect,
+    Effect,
     EnumFieldDef,
+    EventLogEntry,
     FieldDef,
     Issue,
     ListFieldDef,
-    ResultHistoryEntry,
     State,
     StateDef,
     StateMachineConfig,
@@ -70,7 +71,9 @@ def _make_issue(
     decomposed_from: str | None = None,
     depends_on: list[str] | None = None,
     fields: dict[str, object] | None = None,
-    result_history: list[ResultHistoryEntry] | None = None,
+    event_log: list[EventLogEntry] | None = None,
+    visit_counts: dict[str, int] | None = None,
+    hop_count: int = 0,
 ) -> Issue:
     return Issue(
         fields=fields or {"title": "Test"},
@@ -78,7 +81,9 @@ def _make_issue(
         worker_active=worker_active,
         decomposed_from=decomposed_from,
         depends_on=depends_on or [],
-        result_history=result_history or [],
+        event_log=event_log or [],
+        visit_counts=visit_counts or {},
+        hop_count=hop_count,
     )
 
 
@@ -161,14 +166,20 @@ class TestBuildIssueContext:
                     state="done",
                     decomposed_from="A",
                     fields={"title": "Child1"},
-                    result_history=[ResultHistoryEntry(state="done", result={"outcome": "complete"})],
+                    event_log=[
+                        EventLogEntry(
+                            timestamp="2026-03-22T10:00:00Z",
+                            type="worker_result",
+                            data={"outcome": "complete"},
+                        )
+                    ],
                 ),
             },
             worker_queues={},
         )
         ctx = build_issue_context(state, "A")
         assert ctx["fields"] == {"title": "Parent"}
-        assert ctx["result_history"] == []
+        assert ctx["event_log"] == []
         assert ctx["decomposed_from"] is None
         assert ctx["depends_on"] == []
         assert len(ctx["children"]) == 1
@@ -176,7 +187,9 @@ class TestBuildIssueContext:
         assert child["issue_id"] == "B"
         assert child["fields"] == {"title": "Child1"}
         assert child["state"] == "done"
-        assert child["result_history"] == [{"state": "done", "result": {"outcome": "complete"}}]
+        assert child["event_log"] == [
+            {"timestamp": "2026-03-22T10:00:00Z", "type": "worker_result", "data": {"outcome": "complete"}}
+        ]
 
 
 class TestBuildResultFormat:
@@ -240,9 +253,10 @@ class TestTryDispatch:
     def test_dispatch_no_limit(self) -> None:
         config = _make_config()
         state = State(issues={"A": _make_issue(state="todo")}, worker_queues={})
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         try_dispatch(config, state, "A", effects)
         assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "A"
         assert effects[0].state == "todo"
         assert state.issues["A"].worker_active is True
@@ -255,7 +269,7 @@ class TestTryDispatch:
             },
             worker_queues={},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         try_dispatch(config, state, "A", effects)
         assert len(effects) == 1
         assert state.issues["A"].worker_active is True
@@ -269,7 +283,7 @@ class TestTryDispatch:
             },
             worker_queues={},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         try_dispatch(config, state, "B", effects)
         assert len(effects) == 0
         assert state.issues["B"].worker_active is False
@@ -284,7 +298,7 @@ class TestTryDispatch:
             },
             worker_queues={},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         try_dispatch(config, state, "A", effects)
         assert len(effects) == 0
         assert state.issues["A"].worker_active is False
@@ -292,7 +306,7 @@ class TestTryDispatch:
     def test_no_worker_not_dispatched(self) -> None:
         config = _make_config()
         state = State(issues={"A": _make_issue(state="done")}, worker_queues={})
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         try_dispatch(config, state, "A", effects)
         assert len(effects) == 0
 
@@ -307,9 +321,10 @@ class TestBackfillQueue:
             },
             worker_queues={"apply": ["A", "B"]},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         backfill_queue(config, state, "apply", effects)
         assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "A"
         assert state.issues["A"].worker_active is True
         assert state.worker_queues["apply"] == ["B"]
@@ -324,9 +339,10 @@ class TestBackfillQueue:
             },
             worker_queues={"apply": ["A", "B"]},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         backfill_queue(config, state, "apply", effects)
         assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "B"
         assert state.worker_queues["apply"] == ["A"]
 
@@ -340,9 +356,10 @@ class TestBackfillQueue:
             },
             worker_queues={"apply": ["A", "B"]},
         )
-        effects: list[DispatchWorkerEffect] = []
+        effects: list[Effect] = []
         backfill_queue(config, state, "apply", effects)
         assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "B"
         assert state.worker_queues["apply"] == ["A"]
 

--- a/tests/engine/test_event_log.py
+++ b/tests/engine/test_event_log.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    FieldDef,
+    State,
+    StateDef,
+    StateMachineConfig,
+    WorkerDef,
+    WorkerFailedEvent,
+    WorkerResultEvent,
+)
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
+
+
+def _passive_initial_config() -> StateMachineConfig:
+    """Config where initial state 'backlog' is passive (no worker)."""
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial="backlog",
+        states={
+            "backlog": StateDef(),
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                    }
+                ),
+                on={},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+def _active_initial_config() -> StateMachineConfig:
+    """Config where initial state 'todo' is active (has worker)."""
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="Title")},
+        initial="todo",
+        states={
+            "todo": StateDef(
+                worker=WorkerDef(
+                    result_format={
+                        "outcome": EnumFieldDef(values=["done"], description="Decision"),
+                    }
+                ),
+                on={"done": __import__("orca.engine.types", fromlist=["OnTransition"]).OnTransition(target="done")},
+            ),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+class TestCreateLogsCreatedEntry:
+    def test_create_logs_created_entry(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"}, timestamp="2026-01-01T12:00:00Z")
+
+        new_state, _effects = reduce(config, state, event, _counter(), _clock())
+
+        issue = new_state.issues["A"]
+        assert len(issue.event_log) == 1
+        assert issue.event_log[0].type == "created"
+        assert issue.event_log[0].timestamp == "2026-01-01T12:00:00Z"  # event.timestamp
+        assert issue.event_log[0].data == {"state": "backlog"}
+
+
+class TestCreateActiveLogsCreatedAndDispatched:
+    def test_create_active_logs_created_and_dispatched(self) -> None:
+        config = _active_initial_config()
+        state = State(issues={}, worker_queues={})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"}, timestamp="2026-01-01T12:00:00Z")
+
+        new_state, effects = reduce(config, state, event, _counter(), _clock("2026-01-01T12:00:01Z"))
+
+        issue = new_state.issues["A"]
+        assert len(issue.event_log) == 2
+        assert issue.event_log[0].type == "created"
+        assert issue.event_log[0].timestamp == "2026-01-01T12:00:00Z"
+        assert issue.event_log[1].type == "worker_dispatched"
+        assert issue.event_log[1].timestamp == "2026-01-01T12:00:01Z"
+        assert len(effects) == 1
+        assert isinstance(effects[0], DispatchWorkerEffect)
+
+
+class TestAdvanceLogsAdvancedEntry:
+    def test_advance_logs_advanced_entry(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+        clock = _clock("2026-01-01T12:00:00Z")
+
+        # Create issue first
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T11:00:00Z"),
+            gen,
+            clock,
+        )
+
+        # Advance to todo (active)
+        state, _effects = reduce(
+            config,
+            state,
+            AdvanceEvent(issue_id="A", target_state="todo", timestamp="2026-01-01T12:00:00Z"),
+            gen,
+            _clock("2026-01-01T12:00:01Z"),
+        )
+
+        issue = state.issues["A"]
+        # Should have: created, advanced, worker_dispatched
+        advanced_entries = [e for e in issue.event_log if e.type == "advanced"]
+        assert len(advanced_entries) == 1
+        assert advanced_entries[0].timestamp == "2026-01-01T12:00:00Z"
+        assert advanced_entries[0].data == {"from": "backlog", "to": "todo"}
+
+
+class TestAdvanceDoesNotLogTransitioned:
+    def test_advance_does_not_log_transitioned(self) -> None:
+        config = _passive_initial_config()
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+        clock = _clock()
+
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            clock,
+        )
+
+        state, _ = reduce(
+            config,
+            state,
+            AdvanceEvent(issue_id="A", target_state="todo", timestamp="2026-01-01T00:00:01Z"),
+            gen,
+            clock,
+        )
+
+        issue = state.issues["A"]
+        transitioned_entries = [e for e in issue.event_log if e.type == "transitioned"]
+        assert len(transitioned_entries) == 0
+
+
+class TestWorkerResultLogsResultAndTransition:
+    def test_worker_result_logs_result_and_transition(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create issue in todo (active)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock("2026-01-01T00:00:00Z"),
+        )
+
+        # Worker result: start -> implementing
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:01:00Z"),
+            gen,
+            _clock("2026-01-01T00:01:01Z"),
+        )
+
+        issue = state.issues["A"]
+        result_entries = [e for e in issue.event_log if e.type == "worker_result"]
+        assert len(result_entries) == 1
+        assert result_entries[0].timestamp == "2026-01-01T00:01:00Z"
+        assert result_entries[0].data == {"outcome": "start"}
+
+        transitioned_entries = [e for e in issue.event_log if e.type == "transitioned"]
+        assert len(transitioned_entries) == 1
+        assert transitioned_entries[0].timestamp == "2026-01-01T00:01:01Z"
+        assert transitioned_entries[0].data == {"from": "todo", "to": "implementing"}
+
+
+class TestWorkerFailedLogsFailedAndDispatch:
+    def test_worker_failed_logs_failed_and_dispatch(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock("2026-01-01T00:00:00Z"),
+        )
+
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="A", error="timeout", timestamp="2026-01-01T00:01:00Z"),
+            gen,
+            _clock("2026-01-01T00:01:01Z"),
+        )
+
+        issue = state.issues["A"]
+        failed_entries = [e for e in issue.event_log if e.type == "worker_failed"]
+        assert len(failed_entries) == 1
+        assert failed_entries[0].timestamp == "2026-01-01T00:01:00Z"
+        assert failed_entries[0].data == {"state": "todo", "error": "timeout"}
+
+        dispatched_entries = [e for e in issue.event_log if e.type == "worker_dispatched"]
+        # One from create + one from retry
+        assert len(dispatched_entries) == 2
+        assert dispatched_entries[1].timestamp == "2026-01-01T00:01:01Z"
+
+
+class TestDecomposeLogsBlockedAndChildCreated:
+    def test_decompose_logs_blocked_and_child_created(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock("2026-01-01T00:00:00Z"),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:01:00Z"),
+            gen,
+            _clock("2026-01-01T00:01:00Z"),
+        )
+
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "C1"}},
+                        {"key": "c2", "fields": {"title": "C2"}},
+                    ],
+                },
+                timestamp="2026-01-01T00:02:00Z",
+            ),
+            gen,
+            _clock("2026-01-01T00:02:01Z"),
+        )
+
+        parent = state.issues["P"]
+        blocked_entries = [e for e in parent.event_log if e.type == "decomposition_blocked"]
+        assert len(blocked_entries) == 1
+
+        # Children should have "created" entries
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "P"]
+        assert len(child_ids) == 2
+        for cid in child_ids:
+            child = state.issues[cid]
+            created_entries = [e for e in child.event_log if e.type == "created"]
+            assert len(created_entries) == 1
+
+
+class TestUnblockLogsUnblockedEntry:
+    def test_unblock_logs_unblocked_entry(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+        ts = "2026-01-01T00:00:00Z"
+
+        # Create parent, scope, decompose into 1 child
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="P", fields={"title": "P"}, timestamp=ts), gen, _clock(ts)
+        )
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp=ts), gen, _clock(ts)
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={"outcome": "decompose", "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}]},
+                timestamp=ts,
+            ),
+            gen,
+            _clock(ts),
+        )
+
+        child_id = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "P"][0]
+
+        # Complete child: todo -> scoping -> implementing -> done
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}, timestamp=ts),
+            gen,
+            _clock(ts),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "implement"}, timestamp=ts),
+            gen,
+            _clock(ts),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}, timestamp=ts),
+            gen,
+            _clock(ts),
+        )
+
+        assert state.issues[child_id].state == "done"
+
+        # Parent should have unblocked entry
+        parent = state.issues["P"]
+        unblocked_entries = [e for e in parent.event_log if e.type == "unblocked"]
+        assert len(unblocked_entries) == 1
+        assert unblocked_entries[0].data == {"reason": "decomposition"}
+
+
+class TestDependencyUnblockLogsEntry:
+    def test_dependency_unblock_logs_entry(self, decompose_config_yaml: str) -> None:
+        config = parse_config(decompose_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+        ts = "2026-01-01T00:00:00Z"
+
+        # Create parent, scope, decompose with dependency
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="P", fields={"title": "P"}, timestamp=ts), gen, _clock(ts)
+        )
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp=ts), gen, _clock(ts)
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "c1", "fields": {"title": "C1"}},
+                        {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
+                    ],
+                },
+                timestamp=ts,
+            ),
+            gen,
+            _clock(ts),
+        )
+
+        children = {iid: iss for iid, iss in state.issues.items() if iss.decomposed_from == "P"}
+        c1_id = [iid for iid, iss in children.items() if not iss.depends_on][0]
+        c2_id = [iid for iid, iss in children.items() if iss.depends_on][0]
+
+        # Complete c1
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}, timestamp=ts), gen, _clock(ts)
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}, timestamp=ts),
+            gen,
+            _clock(ts),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}, timestamp=ts),
+            gen,
+            _clock(ts),
+        )
+
+        assert state.issues[c1_id].state == "done"
+
+        # c2 should have unblocked entry with reason="dependency"
+        c2 = state.issues[c2_id]
+        unblocked_entries = [e for e in c2.event_log if e.type == "unblocked"]
+        assert len(unblocked_entries) == 1
+        assert unblocked_entries[0].data == {"reason": "dependency"}
+
+
+class TestEventLogTimestampsUseEventTimestamp:
+    def test_event_log_timestamps_use_event_timestamp(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock("2026-01-01T00:00:01Z"),
+        )
+
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:01:00Z"),
+            gen,
+            _clock("2026-01-01T00:01:05Z"),
+        )
+
+        issue = state.issues["A"]
+        # worker_result uses event.timestamp
+        result_entry = [e for e in issue.event_log if e.type == "worker_result"][0]
+        assert result_entry.timestamp == "2026-01-01T00:01:00Z"
+
+        # transitioned uses now()
+        transitioned_entry = [e for e in issue.event_log if e.type == "transitioned"][0]
+        assert transitioned_entry.timestamp == "2026-01-01T00:01:05Z"
+
+
+class TestFullLifecycleLog:
+    def test_full_lifecycle_log(self, simple_config_yaml: str) -> None:
+        config = parse_config(simple_config_yaml)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="T0"),
+            gen,
+            _clock("NOW0"),
+        )
+
+        # Worker result: start -> implementing
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="T1"),
+            gen,
+            _clock("NOW1"),
+        )
+
+        # Worker result: complete -> done
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "complete"}, timestamp="T2"),
+            gen,
+            _clock("NOW2"),
+        )
+
+        issue = state.issues["A"]
+        types = [e.type for e in issue.event_log]
+        assert types == [
+            "created",  # from create
+            "worker_dispatched",  # from create (active initial)
+            "worker_result",  # from first WorkerResult
+            "transitioned",  # todo -> implementing
+            "worker_dispatched",  # implementing dispatched
+            "worker_result",  # from second WorkerResult
+            "transitioned",  # implementing -> done
+        ]
+
+        assert issue.state == "done"
+        assert issue.worker_active is False

--- a/tests/engine/test_formatting.py
+++ b/tests/engine/test_formatting.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from orca.engine.formatting import format_issues
+from orca.engine.types import (
+    EventLogEntry,
+    FieldDef,
+    Issue,
+    State,
+    StateDef,
+    StateMachineConfig,
+)
+
+
+def _make_config(
+    states: dict[str, StateDef] | None = None,
+) -> StateMachineConfig:
+    return StateMachineConfig(
+        issue_fields={"title": FieldDef(type="string", description="t")},
+        initial="todo",
+        states=states
+        or {
+            "todo": StateDef(),
+            "work": StateDef(),
+            "done": StateDef(terminal=True),
+        },
+    )
+
+
+def _make_issue(
+    state: str = "todo",
+    created_ts: str | None = "2026-01-01T00:00:00Z",
+    decomposed_from: str | None = None,
+    depends_on: list[str] | None = None,
+) -> Issue:
+    event_log: list[EventLogEntry] = []
+    if created_ts is not None:
+        event_log.append(
+            EventLogEntry(timestamp=created_ts, type="created", data={})
+        )
+    return Issue(
+        fields={"title": "Test"},
+        state=state,
+        worker_active=False,
+        decomposed_from=decomposed_from,
+        depends_on=depends_on or [],
+        event_log=event_log,
+        visit_counts={state: 1},
+        hop_count=0,
+    )
+
+
+class TestFormatIssues:
+    def test_empty_state(self) -> None:
+        state = State(issues={}, worker_queues={})
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
+        assert result == ""
+
+    def test_single_root_issue(self) -> None:
+        state = State(
+            issues={"ISSUE-1": _make_issue(state="todo")},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:00:00Z"
+        )
+        assert "ISSUE-1 [todo] ... 0m" in result
+
+    def test_terminal_issue_no_marker(self) -> None:
+        state = State(
+            issues={"ISSUE-1": _make_issue(state="done")},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:30:00Z"
+        )
+        assert "ISSUE-1 [done] 30m" in result
+        assert "..." not in result
+
+    def test_parent_with_children(self) -> None:
+        state = State(
+            issues={
+                "ISSUE-1": _make_issue(state="work"),
+                "ISSUE-3": _make_issue(
+                    state="todo", decomposed_from="ISSUE-1"
+                ),
+                "ISSUE-2": _make_issue(
+                    state="done", decomposed_from="ISSUE-1"
+                ),
+            },
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T01:00:00Z"
+        )
+        lines = result.split("\n")
+        # Root first
+        assert "ISSUE-1 [work] ... 1h" in lines[0]
+        # Children sorted: ISSUE-2 before ISSUE-3
+        assert "\u251c\u2500\u2500 ISSUE-2 [done] 1h" in lines[1]
+        assert "\u2514\u2500\u2500 ISSUE-3 [todo] ... 1h" in lines[2]
+
+    def test_depends_on_annotation(self) -> None:
+        state = State(
+            issues={
+                "ISSUE-1": _make_issue(state="work", depends_on=["ISSUE-2"]),
+                "ISSUE-2": _make_issue(state="done"),
+            },
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:00:00Z"
+        )
+        assert "depends on: ISSUE-2" in result
+
+    def test_elapsed_time_minutes(self) -> None:
+        state = State(
+            issues={"I-1": _make_issue(state="todo")},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:30:00Z"
+        )
+        assert "30m" in result
+
+    def test_elapsed_time_hours(self) -> None:
+        state = State(
+            issues={"I-1": _make_issue(state="todo")},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T02:15:00Z"
+        )
+        assert "2h 15m" in result
+
+    def test_elapsed_time_days(self) -> None:
+        state = State(
+            issues={"I-1": _make_issue(state="todo")},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-02T03:00:00Z"
+        )
+        assert "1d 3h" in result
+
+    def test_worker_queues_shown(self) -> None:
+        state = State(
+            issues={
+                "I-1": _make_issue(state="work"),
+                "I-2": _make_issue(state="work"),
+            },
+            worker_queues={"work": ["I-3", "I-4"]},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:00:00Z"
+        )
+        assert "Queued in 'work': I-3, I-4" in result
+
+    def test_no_created_event_shows_question_mark(self) -> None:
+        state = State(
+            issues={"I-1": _make_issue(state="todo", created_ts=None)},
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:00:00Z"
+        )
+        assert "I-1 [todo] ... ?" in result
+
+    def test_sort_order_by_id(self) -> None:
+        state = State(
+            issues={
+                "C-1": _make_issue(state="todo"),
+                "A-1": _make_issue(state="todo"),
+                "B-1": _make_issue(state="todo"),
+            },
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T00:00:00Z"
+        )
+        lines = [line for line in result.split("\n") if line.strip()]
+        assert lines[0].startswith("A-1")
+        assert lines[1].startswith("B-1")
+        assert lines[2].startswith("C-1")
+
+    def test_deep_nesting(self) -> None:
+        state = State(
+            issues={
+                "I-1": _make_issue(state="work"),
+                "I-2": _make_issue(state="work", decomposed_from="I-1"),
+                "I-3": _make_issue(state="done", decomposed_from="I-2"),
+            },
+            worker_queues={},
+        )
+        result = format_issues(
+            state, _make_config(), now="2026-01-01T01:00:00Z"
+        )
+        lines = result.split("\n")
+        assert "I-1 [work] ... 1h" in lines[0]
+        assert "\u2514\u2500\u2500 I-2 [work] ... 1h" in lines[1]
+        assert "    \u2514\u2500\u2500 I-3 [done] 1h" in lines[2]

--- a/tests/engine/test_formatting.py
+++ b/tests/engine/test_formatting.py
@@ -34,9 +34,7 @@ def _make_issue(
 ) -> Issue:
     event_log: list[EventLogEntry] = []
     if created_ts is not None:
-        event_log.append(
-            EventLogEntry(timestamp=created_ts, type="created", data={})
-        )
+        event_log.append(EventLogEntry(timestamp=created_ts, type="created", data={}))
     return Issue(
         fields={"title": "Test"},
         state=state,
@@ -60,9 +58,7 @@ class TestFormatIssues:
             issues={"ISSUE-1": _make_issue(state="todo")},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
         assert "ISSUE-1 [todo] ... 0m" in result
 
     def test_terminal_issue_no_marker(self) -> None:
@@ -70,9 +66,7 @@ class TestFormatIssues:
             issues={"ISSUE-1": _make_issue(state="done")},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:30:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:30:00Z")
         assert "ISSUE-1 [done] 30m" in result
         assert "..." not in result
 
@@ -80,18 +74,12 @@ class TestFormatIssues:
         state = State(
             issues={
                 "ISSUE-1": _make_issue(state="work"),
-                "ISSUE-3": _make_issue(
-                    state="todo", decomposed_from="ISSUE-1"
-                ),
-                "ISSUE-2": _make_issue(
-                    state="done", decomposed_from="ISSUE-1"
-                ),
+                "ISSUE-3": _make_issue(state="todo", decomposed_from="ISSUE-1"),
+                "ISSUE-2": _make_issue(state="done", decomposed_from="ISSUE-1"),
             },
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T01:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T01:00:00Z")
         lines = result.split("\n")
         # Root first
         assert "ISSUE-1 [work] ... 1h" in lines[0]
@@ -107,9 +95,7 @@ class TestFormatIssues:
             },
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
         assert "depends on: ISSUE-2" in result
 
     def test_elapsed_time_minutes(self) -> None:
@@ -117,9 +103,7 @@ class TestFormatIssues:
             issues={"I-1": _make_issue(state="todo")},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:30:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:30:00Z")
         assert "30m" in result
 
     def test_elapsed_time_hours(self) -> None:
@@ -127,9 +111,7 @@ class TestFormatIssues:
             issues={"I-1": _make_issue(state="todo")},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T02:15:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T02:15:00Z")
         assert "2h 15m" in result
 
     def test_elapsed_time_days(self) -> None:
@@ -137,9 +119,7 @@ class TestFormatIssues:
             issues={"I-1": _make_issue(state="todo")},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-02T03:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-02T03:00:00Z")
         assert "1d 3h" in result
 
     def test_worker_queues_shown(self) -> None:
@@ -150,9 +130,7 @@ class TestFormatIssues:
             },
             worker_queues={"work": ["I-3", "I-4"]},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
         assert "Queued in 'work': I-3, I-4" in result
 
     def test_no_created_event_shows_question_mark(self) -> None:
@@ -160,9 +138,7 @@ class TestFormatIssues:
             issues={"I-1": _make_issue(state="todo", created_ts=None)},
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
         assert "I-1 [todo] ... ?" in result
 
     def test_sort_order_by_id(self) -> None:
@@ -174,9 +150,7 @@ class TestFormatIssues:
             },
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T00:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
         lines = [line for line in result.split("\n") if line.strip()]
         assert lines[0].startswith("A-1")
         assert lines[1].startswith("B-1")
@@ -191,9 +165,7 @@ class TestFormatIssues:
             },
             worker_queues={},
         )
-        result = format_issues(
-            state, _make_config(), now="2026-01-01T01:00:00Z"
-        )
+        result = format_issues(state, _make_config(), now="2026-01-01T01:00:00Z")
         lines = result.split("\n")
         assert "I-1 [work] ... 1h" in lines[0]
         assert "\u2514\u2500\u2500 I-2 [work] ... 1h" in lines[1]

--- a/tests/engine/test_hop_limits.py
+++ b/tests/engine/test_hop_limits.py
@@ -1,0 +1,909 @@
+"""Tests for hop limit checks (max_visits, max_hops) in the reducer."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    AdvanceEvent,
+    CreateEvent,
+    ErrorEffect,
+    State,
+    WorkerResultEvent,
+)
+
+
+def _clock(v: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: v
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+
+    return gen
+
+
+# --- Config with max_visits on implementing ---
+
+_LOOP_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    max_visits: 2
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+            - reject
+          description: Outcome
+    on:
+      complete: done
+      reject: todo
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+# --- Config with max_hops ---
+
+_MAX_HOPS_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+            - reject
+          description: Outcome
+    on:
+      complete: done
+      reject: todo
+
+  done:
+    terminal: true
+
+initial: todo
+max_hops: 3
+"""
+
+
+# --- Config with passive advance states and max_visits ---
+
+_ADVANCE_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  backlog:
+    on:
+      start: implementing
+
+  implementing:
+    max_visits: 2
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+            - needs_review
+          description: Outcome
+    on:
+      complete: done
+      needs_review: review
+
+  review:
+    on:
+      approve: done
+      rework: implementing
+
+  done:
+    terminal: true
+
+initial: backlog
+"""
+
+
+# --- Config with decompose and max_hops ---
+
+_DECOMPOSE_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  scoping:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - decompose
+            - complete
+          description: Decision
+        sub_issues:
+          type: list
+          items: "$issue"
+          description: Sub-issues
+          required_when:
+            - decompose
+    on:
+      decompose:
+        action: decompose
+      complete: done
+
+  done:
+    terminal: true
+
+initial: scoping
+max_hops: 2
+"""
+
+
+# --- Config with max_workers + max_visits for backfill test ---
+
+_CAPPED_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  todo:
+    max_workers: 1
+    max_visits: 2
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    max_visits: 1
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - reject
+            - complete
+          description: Outcome
+    on:
+      reject: todo
+      complete: done
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+
+# --- Config with no limits ---
+
+_NO_LIMIT_CONFIG_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - complete
+            - reject
+          description: Outcome
+    on:
+      complete: done
+      reject: todo
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+
+# --- Config: implementing -> qa -> implementing loop with max_visits ---
+
+_IMPL_QA_LOOP_YAML = """\
+issue:
+  fields:
+    title:
+      type: string
+      description: Title
+
+states:
+  todo:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - start
+          description: Decision
+    on:
+      start: implementing
+
+  implementing:
+    max_visits: 3
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - submit
+          description: Outcome
+    on:
+      submit: qa
+
+  qa:
+    worker:
+      result_format:
+        outcome:
+          type: enum
+          values:
+            - pass
+            - fail
+          description: QA result
+    on:
+      pass: done
+      fail: implementing
+
+  done:
+    terminal: true
+
+initial: todo
+"""
+
+
+class TestMaxVisitsBlocksTransition:
+    """State with max_visits:2 — visit twice OK, third time blocked."""
+
+    def test_max_visits_blocks_transition(self) -> None:
+        config = parse_config(_LOOP_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> todo (visit 1 for todo)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "todo"
+
+        # Worker result: start -> implementing (visit 1 for implementing)
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"
+        assert state.issues["A"].visit_counts["implementing"] == 1
+
+        # Worker result: reject -> todo (visit 2 for todo)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "todo"
+
+        # Worker result: start -> implementing (visit 2 for implementing) — should succeed
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"
+        assert state.issues["A"].visit_counts["implementing"] == 2
+
+        # Worker result: reject -> todo (visit 3 for todo)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "todo"
+
+        # Worker result: start -> implementing (visit 3) — BLOCKED by max_visits=2
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "todo"  # did not move
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_visits" in error_effects[0].message
+
+
+class TestMaxHopsBlocksTransition:
+    """Config max_hops:3 — 3 hops OK, fourth blocked."""
+
+    def test_max_hops_blocks_transition(self) -> None:
+        config = parse_config(_MAX_HOPS_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> todo (hop_count = 0)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Hop 1: todo -> implementing
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].hop_count == 1
+
+        # Hop 2: implementing -> todo (reject)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].hop_count == 2
+
+        # Hop 3: todo -> implementing
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].hop_count == 3
+
+        # Hop 4: implementing -> todo — BLOCKED by max_hops=3
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"  # did not move
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_hops" in error_effects[0].message
+
+
+class TestMaxVisitsOnAdvance:
+    """Advance checks max_visits too."""
+
+    def test_max_visits_on_advance(self) -> None:
+        config = parse_config(_ADVANCE_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> backlog (passive)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "backlog"
+
+        # Advance: backlog -> implementing (visit 1)
+        state, _ = reduce(
+            config, state,
+            AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"
+
+        # Worker result: needs_review -> review (passive)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "needs_review"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "review"
+
+        # Advance: review -> implementing (visit 2)
+        state, _ = reduce(
+            config, state,
+            AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"
+
+        # Worker result: needs_review -> review
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "needs_review"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "review"
+
+        # Advance: review -> implementing (visit 3) — BLOCKED by max_visits=2
+        state, effects = reduce(
+            config, state,
+            AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "review"  # did not move
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_visits" in error_effects[0].message
+
+
+class TestDecomposeIncrementsHopCount:
+    """Verify hop_count increases on decompose."""
+
+    def test_decompose_increments_hop_count(self) -> None:
+        config = parse_config(_DECOMPOSE_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> scoping
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 0
+
+        # Decompose
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 1
+
+
+class TestMaxHopsBlocksDecompose:
+    """Decompose blocked by max_hops."""
+
+    def test_max_hops_blocks_decompose(self) -> None:
+        config = parse_config(_DECOMPOSE_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> scoping (hop_count=0)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 1: hop_count -> 1
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 1
+
+        # Complete child so parent unblocks
+        child_id = "GEN-1"
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 2: hop_count -> 2
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c2", "fields": {"title": "C2"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 2
+
+        # Complete second child
+        child_id2 = "GEN-2"
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id=child_id2, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 3: hop_count would be 3, max_hops=2 -> BLOCKED
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c3", "fields": {"title": "C3"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 2  # did not increment
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_hops" in error_effects[0].message
+
+
+class TestLimitFreesSlotAndBackfills:
+    """In max_workers state, limit hit frees slot, queued issue dispatched."""
+
+    def test_limit_frees_slot_and_backfills(self) -> None:
+        config = parse_config(_CAPPED_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create A -> todo, dispatched (slot used)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "A"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].worker_active is True
+
+        # Create B -> todo, queued (slot full)
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="B", fields={"title": "B"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["B"].worker_active is False
+
+        # A: todo -> implementing (frees todo slot, B should get dispatched)
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "implementing"
+        assert state.issues["B"].worker_active is True  # backfilled
+
+        # A: implementing -> todo (reject), visit 2 for todo
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        # B still has the slot, A queued
+        assert state.issues["A"].state == "todo"
+
+        # B: todo -> implementing
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="B", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        # Now A should be dispatched in todo
+        assert state.issues["A"].worker_active is True
+
+        # A: todo -> implementing — BLOCKED by max_visits=1 on implementing
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "todo"  # did not move
+        assert state.issues["A"].worker_active is False  # slot freed
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_visits" in error_effects[0].message
+
+
+class TestLimitLogsLimitReached:
+    """Verify log entry type and data on limit."""
+
+    def test_limit_logs_limit_reached(self) -> None:
+        config = parse_config(_LOOP_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> todo
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Visit implementing twice
+        for _ in range(2):
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+                gen, _clock(),
+            )
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+                gen, _clock(),
+            )
+
+        # Third attempt triggers limit
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        log = state.issues["A"].event_log
+        limit_entries = [e for e in log if e.type == "limit_reached"]
+        assert len(limit_entries) == 1
+        entry = limit_entries[0]
+        assert entry.data["limit"] == "max_visits"
+        assert entry.data["state"] == "implementing"
+        assert entry.data["count"] == 3
+
+
+class TestNoLimitByDefault:
+    """Without max_visits/max_hops, loops run freely."""
+
+    def test_no_limit_by_default(self) -> None:
+        config = parse_config(_NO_LIMIT_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> todo
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Loop 10 times: todo -> implementing -> todo
+        for _ in range(10):
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+                gen, _clock(),
+            )
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
+                gen, _clock(),
+            )
+
+        # Should still be running fine
+        assert state.issues["A"].state == "todo"
+        assert state.issues["A"].visit_counts["implementing"] == 10
+        assert state.issues["A"].hop_count == 20
+        # No error effects during the loop
+        limit_entries = [e for e in state.issues["A"].event_log if e.type == "limit_reached"]
+        assert len(limit_entries) == 0
+
+
+class TestLoopDetectionImplementingQa:
+    """implementing -> qa -> implementing loop with max_visits:3 on implementing."""
+
+    def test_loop_detection_implementing_qa(self) -> None:
+        config = parse_config(_IMPL_QA_LOOP_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create -> todo
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # todo -> implementing (visit 1)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].visit_counts["implementing"] == 1
+
+        # implementing -> qa
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # qa -> implementing (visit 2)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].visit_counts["implementing"] == 2
+
+        # implementing -> qa
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # qa -> implementing (visit 3)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].visit_counts["implementing"] == 3
+
+        # implementing -> qa
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # qa -> implementing (visit 4) — BLOCKED by max_visits=3
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+        assert state.issues["A"].state == "qa"  # did not move
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_visits" in error_effects[0].message
+
+
+class TestDecomposeLoopDetection:
+    """Parent decomposes, child completes, parent unblocks, decomposes again — max_hops stops it."""
+
+    def test_decompose_loop_detection(self) -> None:
+        config = parse_config(_DECOMPOSE_CONFIG_YAML)
+        state = State(issues={}, worker_queues={})
+        gen = _counter()
+
+        # Create parent -> scoping
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 1 (hop 1)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 1
+
+        # Complete child 1
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="GEN-1", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 2 (hop 2) — should succeed (max_hops=2)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c2", "fields": {"title": "C2"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 2
+
+        # Complete child 2
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(issue_id="GEN-2", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen, _clock(),
+        )
+
+        # Decompose 3 (hop 3) — BLOCKED by max_hops=2
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="P",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "c3", "fields": {"title": "C3"}}],
+                },
+                timestamp="2026-01-01T00:00:00Z",
+            ),
+            gen, _clock(),
+        )
+        assert state.issues["P"].hop_count == 2  # unchanged
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) == 1
+        assert "max_hops" in error_effects[0].message

--- a/tests/engine/test_hop_limits.py
+++ b/tests/engine/test_hop_limits.py
@@ -339,51 +339,63 @@ class TestMaxVisitsBlocksTransition:
 
         # Create -> todo (visit 1 for todo)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "todo"
 
         # Worker result: start -> implementing (visit 1 for implementing)
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"
         assert state.issues["A"].visit_counts["implementing"] == 1
 
         # Worker result: reject -> todo (visit 2 for todo)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "todo"
 
         # Worker result: start -> implementing (visit 2 for implementing) — should succeed
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"
         assert state.issues["A"].visit_counts["implementing"] == 2
 
         # Worker result: reject -> todo (visit 3 for todo)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "todo"
 
         # Worker result: start -> implementing (visit 3) — BLOCKED by max_visits=2
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "todo"  # did not move
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -401,40 +413,50 @@ class TestMaxHopsBlocksTransition:
 
         # Create -> todo (hop_count = 0)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Hop 1: todo -> implementing
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].hop_count == 1
 
         # Hop 2: implementing -> todo (reject)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].hop_count == 2
 
         # Hop 3: todo -> implementing
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].hop_count == 3
 
         # Hop 4: implementing -> todo — BLOCKED by max_hops=3
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"  # did not move
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -452,49 +474,61 @@ class TestMaxVisitsOnAdvance:
 
         # Create -> backlog (passive)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "backlog"
 
         # Advance: backlog -> implementing (visit 1)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"
 
         # Worker result: needs_review -> review (passive)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "needs_review"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "review"
 
         # Advance: review -> implementing (visit 2)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"
 
         # Worker result: needs_review -> review
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "needs_review"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "review"
 
         # Advance: review -> implementing (visit 3) — BLOCKED by max_visits=2
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "review"  # did not move
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -512,15 +546,18 @@ class TestDecomposeIncrementsHopCount:
 
         # Create -> scoping
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 0
 
         # Decompose
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -529,7 +566,8 @@ class TestDecomposeIncrementsHopCount:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 1
 
@@ -544,14 +582,17 @@ class TestMaxHopsBlocksDecompose:
 
         # Create -> scoping (hop_count=0)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 1: hop_count -> 1
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -560,21 +601,25 @@ class TestMaxHopsBlocksDecompose:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 1
 
         # Complete child so parent unblocks
         child_id = "GEN-1"
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 2: hop_count -> 2
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -583,21 +628,25 @@ class TestMaxHopsBlocksDecompose:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 2
 
         # Complete second child
         child_id2 = "GEN-2"
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id=child_id2, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 3: hop_count would be 3, max_hops=2 -> BLOCKED
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -606,7 +655,8 @@ class TestMaxHopsBlocksDecompose:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 2  # did not increment
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -624,52 +674,64 @@ class TestLimitFreesSlotAndBackfills:
 
         # Create A -> todo, dispatched (slot used)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "A"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].worker_active is True
 
         # Create B -> todo, queued (slot full)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="B", fields={"title": "B"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["B"].worker_active is False
 
         # A: todo -> implementing (frees todo slot, B should get dispatched)
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "implementing"
         assert state.issues["B"].worker_active is True  # backfilled
 
         # A: implementing -> todo (reject), visit 2 for todo
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         # B still has the slot, A queued
         assert state.issues["A"].state == "todo"
 
         # B: todo -> implementing
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="B", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         # Now A should be dispatched in todo
         assert state.issues["A"].worker_active is True
 
         # A: todo -> implementing — BLOCKED by max_visits=1 on implementing
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "todo"  # did not move
         assert state.issues["A"].worker_active is False  # slot freed
@@ -688,29 +750,37 @@ class TestLimitLogsLimitReached:
 
         # Create -> todo
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Visit implementing twice
         for _ in range(2):
             state, _ = reduce(
-                config, state,
+                config,
+                state,
                 WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-                gen, _clock(),
+                gen,
+                _clock(),
             )
             state, _ = reduce(
-                config, state,
+                config,
+                state,
                 WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-                gen, _clock(),
+                gen,
+                _clock(),
             )
 
         # Third attempt triggers limit
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         log = state.issues["A"].event_log
@@ -732,22 +802,28 @@ class TestNoLimitByDefault:
 
         # Create -> todo
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Loop 10 times: todo -> implementing -> todo
         for _ in range(10):
             state, _ = reduce(
-                config, state,
+                config,
+                state,
                 WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-                gen, _clock(),
+                gen,
+                _clock(),
             )
             state, _ = reduce(
-                config, state,
+                config,
+                state,
                 WorkerResultEvent(issue_id="A", result={"outcome": "reject"}, timestamp="2026-01-01T00:00:00Z"),
-                gen, _clock(),
+                gen,
+                _clock(),
             )
 
         # Should still be running fine
@@ -769,61 +845,77 @@ class TestLoopDetectionImplementingQa:
 
         # Create -> todo
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # todo -> implementing (visit 1)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].visit_counts["implementing"] == 1
 
         # implementing -> qa
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # qa -> implementing (visit 2)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].visit_counts["implementing"] == 2
 
         # implementing -> qa
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # qa -> implementing (visit 3)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].visit_counts["implementing"] == 3
 
         # implementing -> qa
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "submit"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # qa -> implementing (visit 4) — BLOCKED by max_visits=3
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="A", result={"outcome": "fail"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["A"].state == "qa"  # did not move
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -841,14 +933,17 @@ class TestDecomposeLoopDetection:
 
         # Create parent -> scoping
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 1 (hop 1)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -857,20 +952,24 @@ class TestDecomposeLoopDetection:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 1
 
         # Complete child 1
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="GEN-1", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 2 (hop 2) — should succeed (max_hops=2)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -879,20 +978,24 @@ class TestDecomposeLoopDetection:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 2
 
         # Complete child 2
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(issue_id="GEN-2", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Decompose 3 (hop 3) — BLOCKED by max_hops=2
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="P",
                 result={
@@ -901,7 +1004,8 @@ class TestDecomposeLoopDetection:
                 },
                 timestamp="2026-01-01T00:00:00Z",
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["P"].hop_count == 2  # unchanged
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]

--- a/tests/engine/test_reducer_advance.py
+++ b/tests/engine/test_reducer_advance.py
@@ -28,6 +28,10 @@ def _counter() -> Callable[[], str]:
     return next_id
 
 
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
+
+
 def _make_issue(
     state: str = "backlog",
     worker_active: bool = False,
@@ -40,7 +44,9 @@ def _make_issue(
         worker_active=worker_active,
         decomposed_from=decomposed_from,
         depends_on=depends_on or [],
-        result_history=[],
+        event_log=[],
+        visit_counts={},
+        hop_count=0,
     )
 
 
@@ -80,9 +86,9 @@ class TestAdvancePassiveToActive:
             issues={"A": _make_issue(state="backlog")},
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="todo")
+        event = AdvanceEvent(issue_id="A", target_state="todo", timestamp="2026-01-01T00:00:00Z")
 
-        new_state, effects = reduce(config, state, event, _counter())
+        new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert new_state.issues["A"].state == "todo"
         assert len(effects) == 1
@@ -98,9 +104,9 @@ class TestAdvanceFromActive:
             issues={"A": _make_issue(state="todo")},
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="implementing")
+        event = AdvanceEvent(issue_id="A", target_state="implementing", timestamp="2026-01-01T00:00:00Z")
 
-        _new_state, effects = reduce(config, state, event, _counter())
+        _new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -117,9 +123,9 @@ class TestAdvanceBlocked:
             },
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="todo")
+        event = AdvanceEvent(issue_id="A", target_state="todo", timestamp="2026-01-01T00:00:00Z")
 
-        _new_state, effects = reduce(config, state, event, _counter())
+        _new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -130,9 +136,9 @@ class TestAdvanceNonexistent:
     def test_error_for_missing_issue(self) -> None:
         config = _config()
         state = State(issues={}, worker_queues={})
-        event = AdvanceEvent(issue_id="Z", target_state="todo")
+        event = AdvanceEvent(issue_id="Z", target_state="todo", timestamp="2026-01-01T00:00:00Z")
 
-        _new_state, effects = reduce(config, state, event, _counter())
+        _new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -146,9 +152,9 @@ class TestAdvanceToNonexistentState:
             issues={"A": _make_issue(state="backlog")},
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="nonexistent")
+        event = AdvanceEvent(issue_id="A", target_state="nonexistent", timestamp="2026-01-01T00:00:00Z")
 
-        _new_state, effects = reduce(config, state, event, _counter())
+        _new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -162,9 +168,9 @@ class TestAdvancePassiveToPassive:
             issues={"A": _make_issue(state="backlog")},
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="review")
+        event = AdvanceEvent(issue_id="A", target_state="review", timestamp="2026-01-01T00:00:00Z")
 
-        new_state, effects = reduce(config, state, event, _counter())
+        new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert new_state.issues["A"].state == "review"
         assert effects == []
@@ -177,9 +183,9 @@ class TestAdvanceToTerminal:
             issues={"A": _make_issue(state="backlog")},
             worker_queues={},
         )
-        event = AdvanceEvent(issue_id="A", target_state="done")
+        event = AdvanceEvent(issue_id="A", target_state="done", timestamp="2026-01-01T00:00:00Z")
 
-        new_state, effects = reduce(config, state, event, _counter())
+        new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert new_state.issues["A"].state == "done"
         # Terminal states have no worker, so no dispatch

--- a/tests/engine/test_reducer_create.py
+++ b/tests/engine/test_reducer_create.py
@@ -27,6 +27,10 @@ def _counter() -> Callable[[], str]:
     return next_id
 
 
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
+
+
 def _passive_initial_config() -> StateMachineConfig:
     """Config where initial state 'backlog' is passive (no worker)."""
     return StateMachineConfig(
@@ -70,9 +74,9 @@ class TestCreatePassiveInitial:
     def test_creates_issue_with_correct_fields(self) -> None:
         config = _passive_initial_config()
         state = State(issues={}, worker_queues={})
-        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"}, timestamp="2026-01-01T00:00:00Z")
 
-        new_state, effects = reduce(config, state, event, _counter())
+        new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert "A" in new_state.issues
         issue = new_state.issues["A"]
@@ -81,14 +85,15 @@ class TestCreatePassiveInitial:
         assert issue.worker_active is False
         assert issue.decomposed_from is None
         assert issue.depends_on == []
-        assert issue.result_history == []
+        assert len(issue.event_log) == 1
+        assert issue.event_log[0].type == "created"
 
     def test_no_effects_for_passive_initial(self) -> None:
         config = _passive_initial_config()
         state = State(issues={}, worker_queues={})
-        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"}, timestamp="2026-01-01T00:00:00Z")
 
-        _new_state, effects = reduce(config, state, event, _counter())
+        _new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert effects == []
 
@@ -97,9 +102,9 @@ class TestCreateActiveInitial:
     def test_dispatch_effect_emitted(self) -> None:
         config = _active_initial_config()
         state = State(issues={}, worker_queues={})
-        event = CreateEvent(issue_id="A", fields={"title": "My Issue"})
+        event = CreateEvent(issue_id="A", fields={"title": "My Issue"}, timestamp="2026-01-01T00:00:00Z")
 
-        new_state, effects = reduce(config, state, event, _counter())
+        new_state, effects = reduce(config, state, event, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], DispatchWorkerEffect)
@@ -112,12 +117,12 @@ class TestCreateDuplicate:
     def test_error_on_duplicate_id(self) -> None:
         config = _passive_initial_config()
         state = State(issues={}, worker_queues={})
-        event = CreateEvent(issue_id="A", fields={"title": "First"})
-        state, _effects = reduce(config, state, event, _counter())
+        event = CreateEvent(issue_id="A", fields={"title": "First"}, timestamp="2026-01-01T00:00:00Z")
+        state, _effects = reduce(config, state, event, _counter(), _clock())
 
         # Try creating again with the same ID
-        event2 = CreateEvent(issue_id="A", fields={"title": "Second"})
-        new_state, effects = reduce(config, state, event2, _counter())
+        event2 = CreateEvent(issue_id="A", fields={"title": "Second"}, timestamp="2026-01-01T00:00:00Z")
+        new_state, effects = reduce(config, state, event2, _counter(), _clock())
 
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)

--- a/tests/engine/test_reducer_worker_failed.py
+++ b/tests/engine/test_reducer_worker_failed.py
@@ -25,6 +25,10 @@ def _counter() -> Callable[[], str]:
     return next_id
 
 
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
+
+
 class TestWorkerFailedRetries:
     """Test 1: Worker failed retries — worker_active stays True, DispatchWorkerEffect emitted."""
 
@@ -34,12 +38,24 @@ class TestWorkerFailedRetries:
         gen = _counter()
 
         # Create issue -> lands in todo (active), worker dispatched
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].worker_active is True
         assert state.issues["A"].state == "todo"
 
         # Worker fails
-        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="timeout"), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="A", error="timeout", timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         # worker_active stays True (slot retained)
         assert state.issues["A"].worker_active is True
@@ -61,22 +77,64 @@ class TestWorkerFailedRetainsSlot:
         gen = _counter()
 
         # Create A, advance to apply state (max_workers=1)
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "A"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "ready"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "A"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "ready"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "apply"
         assert state.issues["A"].worker_active is True
 
         # Create B, advance to apply state — should be queued
-        state, _ = reduce(config, state, CreateEvent(issue_id="B", fields={"title": "B"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "start"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "ready"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="B", fields={"title": "B"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="B", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="B", result={"outcome": "ready"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["B"].state == "apply"
         assert state.issues["B"].worker_active is False
         assert "B" in state.worker_queues.get("apply", [])
 
         # A's worker fails — slot is retained, B stays queued
-        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="crash"), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="A", error="crash", timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         # A still holds slot
         assert state.issues["A"].worker_active is True
@@ -98,7 +156,13 @@ class TestWorkerFailedNonexistentIssue:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="NOPE", error="timeout"), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="NOPE", error="timeout", timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         assert "NOPE" in effects[0].message
@@ -112,11 +176,23 @@ class TestWorkerFailedNotActive:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         # Manually deactivate worker
         state.issues["A"].worker_active = False
 
-        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error="timeout"), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerFailedEvent(issue_id="A", error="timeout", timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
 
@@ -129,11 +205,23 @@ class TestWorkerFailedRepeated:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].worker_active is True
 
         for i in range(3):
-            state, effects = reduce(config, state, WorkerFailedEvent(issue_id="A", error=f"failure-{i}"), gen)
+            state, effects = reduce(
+                config,
+                state,
+                WorkerFailedEvent(issue_id="A", error=f"failure-{i}", timestamp="2026-01-01T00:00:00Z"),
+                gen,
+                _clock(),
+            )
             # Slot retained every time
             assert state.issues["A"].worker_active is True
             # Retry dispatched every time

--- a/tests/engine/test_reducer_worker_result.py
+++ b/tests/engine/test_reducer_worker_result.py
@@ -25,6 +25,10 @@ def _counter() -> Callable[[], str]:
     return next_id
 
 
+def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
+    return lambda: value
+
+
 def _create_and_advance(
     config: object,
     state: State,
@@ -35,14 +39,26 @@ def _create_and_advance(
     from orca.engine.types import StateMachineConfig
 
     assert isinstance(config, StateMachineConfig)
-    state, _ = reduce(config, state, CreateEvent(issue_id=issue_id, fields={"title": "T", "text": "D"}), gen)
+    state, _ = reduce(
+        config,
+        state,
+        CreateEvent(issue_id=issue_id, fields={"title": "T", "text": "D"}, timestamp="2026-01-01T00:00:00Z"),
+        gen,
+        _clock(),
+    )
     if state.issues[issue_id].state != target_state:
-        state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state=target_state), gen)
+        state, _ = reduce(
+            config,
+            state,
+            AdvanceEvent(issue_id=issue_id, target_state=target_state, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
     return state
 
 
 class TestSimpleTransition:
-    """Test 1: implementing -> done, verify state change, result_history, worker_active=False."""
+    """Test 1: implementing -> done, verify state change, event_log, worker_active=False."""
 
     def test_transition_to_terminal(self, simple_config_yaml: str) -> None:
         config = parse_config(simple_config_yaml)
@@ -50,23 +66,41 @@ class TestSimpleTransition:
         gen = _counter()
 
         # Create issue -> lands in todo (active), worker dispatched
-        state, effects = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].worker_active is True
 
         # Worker returns "start" -> transition to implementing
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "implementing"
         assert state.issues["A"].worker_active is True  # re-dispatched in implementing
 
         # Worker returns "complete" -> transition to done (terminal)
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "done"
         assert state.issues["A"].worker_active is False
-        assert len(state.issues["A"].result_history) == 2
-        assert state.issues["A"].result_history[0].state == "todo"
-        assert state.issues["A"].result_history[0].result == {"outcome": "start"}
-        assert state.issues["A"].result_history[1].state == "implementing"
-        assert state.issues["A"].result_history[1].result == {"outcome": "complete"}
+        # Check event_log for worker_result entries
+        result_entries = [e for e in state.issues["A"].event_log if e.type == "worker_result"]
+        assert len(result_entries) == 2
+        assert result_entries[0].data == {"outcome": "start"}
+        assert result_entries[1].data == {"outcome": "complete"}
         # No dispatch effects for terminal state
         assert not any(isinstance(e, DispatchWorkerEffect) for e in effects)
 
@@ -79,9 +113,21 @@ class TestTransitionToActiveState:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         # todo -> implementing via "start"
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "implementing"
         # Should get a DispatchWorkerEffect for the implementing state
         dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
@@ -99,8 +145,20 @@ class TestWorkerResultOnBlockedIssue:
         gen = _counter()
 
         # Create parent, advance to scoping
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "T"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["P"].state == "scoping"
         assert state.issues["P"].worker_active is True
 
@@ -114,8 +172,10 @@ class TestWorkerResultOnBlockedIssue:
                     "outcome": "decompose",
                     "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
         # Parent should be blocked (children not terminal)
         # Trying to send WorkerResult to blocked parent should error
@@ -123,7 +183,13 @@ class TestWorkerResultOnBlockedIssue:
         # We need to set it True to test the blocked validation
         state.issues["P"].worker_active = True
 
-        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "implement"}), gen)
+        state2, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "implement"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         assert "blocked" in effects[0].message.lower()
@@ -137,13 +203,37 @@ class TestWorkerResultOnTerminalIssue:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "done"
 
         # Try sending result to terminal issue
-        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "complete"}), gen)
+        state2, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
 
@@ -156,11 +246,23 @@ class TestWorkerResultWhenInactive:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         # Manually set worker_active to False
         state.issues["A"].worker_active = False
 
-        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
+        state2, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         assert "worker_active" in effects[0].message.lower() or "active" in effects[0].message.lower()
@@ -174,11 +276,23 @@ class TestUnknownOutcome:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "T"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "T"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].worker_active is True
         assert state.issues["A"].state == "todo"
 
-        state2, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "nonexistent"}), gen)
+        state2, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "nonexistent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         # worker_active stays True since validation is before mutation
@@ -194,8 +308,20 @@ class TestDecomposeCreatesChildren:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["P"].state == "scoping"
 
         state, effects = reduce(
@@ -210,8 +336,10 @@ class TestDecomposeCreatesChildren:
                         {"key": "c2", "fields": {"title": "Child 2"}},
                     ],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
 
         # Parent stays in scoping state
@@ -236,8 +364,20 @@ class TestDecomposeWithDependsOn:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         state, effects = reduce(
             config,
@@ -251,8 +391,10 @@ class TestDecomposeWithDependsOn:
                         {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
                     ],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
 
         # Find the child that depends on the other
@@ -285,8 +427,20 @@ class TestEmptyDecompose:
         state = State(issues={}, worker_queues={})
         gen = _counter()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         state2, effects = reduce(
             config,
@@ -294,8 +448,10 @@ class TestEmptyDecompose:
             WorkerResultEvent(
                 issue_id="P",
                 result={"outcome": "decompose", "sub_issues": []},
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
         assert any(isinstance(e, ErrorEffect) for e in effects)
         # State should not be mutated (validation before mutation)
@@ -311,8 +467,20 @@ class TestCascadingDecompositionUnblock:
         gen = _counter()
 
         # Create parent, move to scoping
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         # Decompose into one child
         state, _ = reduce(
@@ -324,8 +492,10 @@ class TestCascadingDecompositionUnblock:
                     "outcome": "decompose",
                     "sub_issues": [{"key": "c1", "fields": {"title": "C1"}}],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
 
         # Find child ID
@@ -338,16 +508,32 @@ class TestCascadingDecompositionUnblock:
         assert state.issues[child_id].worker_active is True
 
         # Child: todo -> scoping via "scope"
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues[child_id].state == "scoping"
 
         # Child: scoping -> implementing via "implement"
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "implement"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "implement"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues[child_id].state == "implementing"
 
         # Child: implementing -> done via "complete"
         state, effects = reduce(
-            config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}), gen
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
         )
         assert state.issues[child_id].state == "done"
 
@@ -367,8 +553,20 @@ class TestDependencyUnblock:
         gen = _counter()
 
         # Create parent, move to scoping, decompose with dependency
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         state, _ = reduce(
             config,
             state,
@@ -381,8 +579,10 @@ class TestDependencyUnblock:
                         {"key": "c2", "fields": {"title": "C2"}, "depends_on": ["c1"]},
                     ],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
 
         # Find children
@@ -394,9 +594,27 @@ class TestDependencyUnblock:
         assert state.issues[c2_id].worker_active is False
 
         # Complete c1: todo -> scoping -> implementing -> done
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}), gen)
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues[c1_id].state == "done"
 
         # c2 should now be dispatched
@@ -415,22 +633,64 @@ class TestSlotBackfillOnWorkerResult:
         gen = _counter()
 
         # Create two issues, both reach "apply" state (max_workers=1)
-        state, _ = reduce(config, state, CreateEvent(issue_id="A", fields={"title": "A"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "start"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "ready"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="A", fields={"title": "A"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "ready"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         # A is now in apply, dispatched
         assert state.issues["A"].state == "apply"
         assert state.issues["A"].worker_active is True
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="B", fields={"title": "B"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "start"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="B", result={"outcome": "ready"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="B", fields={"title": "B"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="B", result={"outcome": "start"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="B", result={"outcome": "ready"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         # B is in apply but queued (max_workers=1, A is active)
         assert state.issues["B"].state == "apply"
         assert state.issues["B"].worker_active is False
 
         # A completes apply -> done, B should be backfilled
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="A", result={"outcome": "applied"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="A", result={"outcome": "applied"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         assert state.issues["A"].state == "done"
 
         # B should now be dispatched
@@ -449,8 +709,20 @@ class TestDiamondDependency:
         gen = _counter()
 
         # Create parent, decompose into 3 children: c1, c2 depends on c1, c3 depends on c1
-        state, _ = reduce(config, state, CreateEvent(issue_id="P", fields={"title": "Parent"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P", result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            CreateEvent(issue_id="P", fields={"title": "Parent"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P", result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
         state, _ = reduce(
             config,
             state,
@@ -464,8 +736,10 @@ class TestDiamondDependency:
                         {"key": "c3", "fields": {"title": "C3"}, "depends_on": ["c1"]},
                     ],
                 },
+                timestamp="2026-01-01T00:00:00Z",
             ),
             gen,
+            _clock(),
         )
 
         # Find children
@@ -479,9 +753,27 @@ class TestDiamondDependency:
             assert state.issues[did].worker_active is False
 
         # Complete c1
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}), gen)
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "scope"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "implement"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=c1_id, result={"outcome": "complete"}, timestamp="2026-01-01T00:00:00Z"),
+            gen,
+            _clock(),
+        )
 
         # Both c2 and c3 should now be dispatched
         dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]

--- a/tests/engine/test_scenario_decompose.py
+++ b/tests/engine/test_scenario_decompose.py
@@ -69,6 +69,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter() -> Callable[[], str]:
     n = 0
@@ -90,7 +96,7 @@ def _advance_to_scoping(
 ) -> tuple[State, list[Effect]]:
     """Advance an issue from todo to scoping via worker result."""
     result: tuple[State, list[Effect]] = reduce(
-        config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "scope"}), gen
+        config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "scope"}, timestamp=TS), gen, _clock()
     )
     return result
 
@@ -98,11 +104,17 @@ def _advance_to_scoping(
 def _complete_child(config: StateMachineConfig, state: State, child_id: str, gen: Callable[[], str]) -> State:
     """Take a child through todo→scoping(ready)→implementing→done."""
     # Child starts in todo (active, auto-dispatched). Move to scoping.
-    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}, timestamp=TS), gen, _clock()
+    )
     # Scoping says ready → implementing
-    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}, timestamp=TS), gen, _clock()
+    )
     # Implementing done → done
-    state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen)
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}, timestamp=TS), gen, _clock()
+    )
     return state
 
 
@@ -115,7 +127,9 @@ class TestSingleLevelDecomposeAndUnblock:
         state = _empty_state()
 
         # Create root and advance to scoping
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         # Decompose into 2 children
@@ -131,8 +145,10 @@ class TestSingleLevelDecomposeAndUnblock:
                         {"key": "child-b", "fields": {"title": "Child B"}},
                     ],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         # Children created with generated IDs
@@ -157,12 +173,16 @@ class TestSingleLevelDecomposeAndUnblock:
         assert state.issues["ROOT"].state == "scoping"
 
         # Parent returns ready → implementing
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}), gen)
+        state, effects = reduce(
+            config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["ROOT"].state == "implementing"
         assert state.issues["ROOT"].worker_active is True
 
         # Implementing done
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "done"}), gen)
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id="ROOT", result={"outcome": "done"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["ROOT"].state == "done"
 
 
@@ -175,7 +195,9 @@ class TestThreeLevelCascadingUnblock:
         state = _empty_state()
 
         # L1: create and decompose
-        state, _ = reduce(config, state, CreateEvent(issue_id="L1", fields={"title": "Level 1"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="L1", fields={"title": "Level 1"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "L1", gen)
         state, _ = reduce(
             config,
@@ -186,8 +208,10 @@ class TestThreeLevelCascadingUnblock:
                     "outcome": "decompose",
                     "sub_issues": [{"key": "l2", "fields": {"title": "Level 2"}}],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         l2_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "L1"]
@@ -195,7 +219,9 @@ class TestThreeLevelCascadingUnblock:
         l2_id = l2_ids[0]
 
         # L2: in todo (active, auto-dispatched), move to scoping
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "scope"}), gen)
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "scope"}, timestamp=TS), gen, _clock()
+        )
         state, _ = reduce(
             config,
             state,
@@ -205,8 +231,10 @@ class TestThreeLevelCascadingUnblock:
                     "outcome": "decompose",
                     "sub_issues": [{"key": "l3", "fields": {"title": "Level 3"}}],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         l3_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == l2_id]
@@ -222,8 +250,12 @@ class TestThreeLevelCascadingUnblock:
         assert state.issues[l2_id].state == "scoping"
 
         # L2: ready → implementing → done
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "ready"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "done"}), gen)
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "ready"}, timestamp=TS), gen, _clock()
+        )
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id=l2_id, result={"outcome": "done"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues[l2_id].state == "done"
 
         # L1 should be unblocked and re-dispatched in scoping
@@ -239,7 +271,9 @@ class TestEmptyDecomposeError:
         gen = _counter()
         state = _empty_state()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         state, effects = reduce(
@@ -248,8 +282,10 @@ class TestEmptyDecomposeError:
             WorkerResultEvent(
                 issue_id="ROOT",
                 result={"outcome": "decompose", "sub_issues": []},
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         assert len(effects) == 1
@@ -268,7 +304,9 @@ class TestMassiveFanOut:
         gen = _counter()
         state = _empty_state()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         sub_issues = [{"key": f"child-{i}", "fields": {"title": f"Child {i}"}} for i in range(20)]
@@ -278,8 +316,10 @@ class TestMassiveFanOut:
             WorkerResultEvent(
                 issue_id="ROOT",
                 result={"outcome": "decompose", "sub_issues": sub_issues},
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"]
@@ -302,7 +342,9 @@ class TestDiamondDependency:
         gen = _counter()
         state = _empty_state()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         state, effects = reduce(
@@ -318,8 +360,10 @@ class TestDiamondDependency:
                         {"key": "orders", "fields": {"title": "Orders Service"}, "depends_on": ["db"]},
                     ],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         # Find the real IDs
@@ -365,7 +409,9 @@ class TestDispatchIncludesChildrenContext:
         gen = _counter()
         state = _empty_state()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         state, _ = reduce(
@@ -379,8 +425,10 @@ class TestDispatchIncludesChildrenContext:
                         {"key": "c1", "fields": {"title": "Child 1"}},
                     ],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "ROOT"]
@@ -389,10 +437,22 @@ class TestDispatchIncludesChildrenContext:
 
         # Complete the child (todo→scoping→implementing→done) — last step triggers parent re-dispatch
         # Child is auto-dispatched in todo
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}), gen)
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "scope"}, timestamp=TS),
+            gen,
+            _clock(),
+        )
+        state, _ = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id=child_id, result={"outcome": "ready"}, timestamp=TS),
+            gen,
+            _clock(),
+        )
         state, effects_from_last = reduce(
-            config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}), gen
+            config, state, WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}, timestamp=TS), gen, _clock()
         )
 
         # The last step should produce a dispatch for the parent
@@ -408,7 +468,7 @@ class TestDispatchIncludesChildrenContext:
         child_context = dispatch.issue["children"][0]
         assert child_context["issue_id"] == child_id
         assert child_context["state"] == "done"
-        assert len(child_context["result_history"]) > 0
+        assert len(child_context["event_log"]) > 0
 
 
 class TestBlockedIssueRejectsWorkerResult:
@@ -419,7 +479,9 @@ class TestBlockedIssueRejectsWorkerResult:
         gen = _counter()
         state = _empty_state()
 
-        state, _ = reduce(config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="ROOT", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
         state, _ = _advance_to_scoping(config, state, "ROOT", gen)
 
         # Decompose
@@ -432,8 +494,10 @@ class TestBlockedIssueRejectsWorkerResult:
                     "outcome": "decompose",
                     "sub_issues": [{"key": "c1", "fields": {"title": "Child 1"}}],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         # Parent is now blocked. Try to send a worker result to it.
@@ -441,8 +505,9 @@ class TestBlockedIssueRejectsWorkerResult:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}),
+            WorkerResultEvent(issue_id="ROOT", result={"outcome": "ready"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)

--- a/tests/engine/test_scenario_edge_cases.py
+++ b/tests/engine/test_scenario_edge_cases.py
@@ -85,6 +85,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter(start: int = 0) -> Callable[[], str]:
     n = start
@@ -110,7 +116,9 @@ class TestMinimalSingleStateMachine:
         state = _empty_state()
 
         # Create — initial state is active, so dispatch happens
-        state, effects = reduce(config, state, CreateEvent(issue_id="M-1", fields={"title": "Minimal"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="M-1", fields={"title": "Minimal"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["M-1"].state == "work"
         assert state.issues["M-1"].worker_active is True
         assert len(effects) == 1
@@ -120,13 +128,15 @@ class TestMinimalSingleStateMachine:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="M-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="M-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["M-1"].state == "done"
         assert state.issues["M-1"].worker_active is False
         assert effects == []
-        assert len(state.issues["M-1"].result_history) == 1
+        worker_results = [e for e in state.issues["M-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 1
 
 
 class TestPassiveToPassiveAdvance:
@@ -138,7 +148,9 @@ class TestPassiveToPassiveAdvance:
         state = _empty_state()
 
         # Create issue (triage is active, dispatched immediately)
-        state, effects = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "Passive"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="P-1", fields={"title": "Passive"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["P-1"].state == "triage"
         assert state.issues["P-1"].worker_active is True
 
@@ -146,15 +158,18 @@ class TestPassiveToPassiveAdvance:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}),
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["P-1"].state == "review"
         assert state.issues["P-1"].worker_active is False
         assert effects == []
 
         # Advance review → approved (both passive)
-        state, effects = reduce(config, state, AdvanceEvent(issue_id="P-1", target_state="approved"), gen)
+        state, effects = reduce(
+            config, state, AdvanceEvent(issue_id="P-1", target_state="approved", timestamp=TS), gen, _clock()
+        )
         assert state.issues["P-1"].state == "approved"
         assert state.issues["P-1"].worker_active is False
         assert effects == []
@@ -169,25 +184,30 @@ class TestAdvanceToTerminal:
         state = _empty_state()
 
         # Create issue (triage is active)
-        state, _effects = reduce(config, state, CreateEvent(issue_id="P-1", fields={"title": "Skip"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="P-1", fields={"title": "Skip"}, timestamp=TS), gen, _clock()
+        )
 
         # Complete triage → review (passive)
         state, _effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}),
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "ready"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["P-1"].state == "review"
 
         # Advance review → done (passive to terminal)
-        state, effects = reduce(config, state, AdvanceEvent(issue_id="P-1", target_state="done"), gen)
+        state, effects = reduce(
+            config, state, AdvanceEvent(issue_id="P-1", target_state="done", timestamp=TS), gen, _clock()
+        )
         assert state.issues["P-1"].state == "done"
         assert effects == []
 
 
 class TestSelfLoopState:
-    """Loop 3 times in refine, then done. Verify 4 result_history entries."""
+    """Loop 3 times in refine, then done. Verify 4 event_log worker_result entries."""
 
     def test_self_loop_state(self) -> None:
         config = parse_config(SELF_LOOP_CONFIG_YAML)
@@ -195,7 +215,9 @@ class TestSelfLoopState:
         state = _empty_state()
 
         # Create — refine is active, dispatched immediately
-        state, effects = reduce(config, state, CreateEvent(issue_id="L-1", fields={"title": "Loop"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="L-1", fields={"title": "Loop"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["L-1"].state == "refine"
         assert state.issues["L-1"].worker_active is True
 
@@ -204,8 +226,9 @@ class TestSelfLoopState:
             state, effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id="L-1", result={"outcome": "again"}),
+                WorkerResultEvent(issue_id="L-1", result={"outcome": "again"}, timestamp=TS),
                 gen,
+                _clock(),
             )
             assert state.issues["L-1"].state == "refine"
             assert state.issues["L-1"].worker_active is True
@@ -216,15 +239,17 @@ class TestSelfLoopState:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="L-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="L-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["L-1"].state == "done"
         assert state.issues["L-1"].worker_active is False
 
         # 3 "again" + 1 "done" = 4 entries
-        assert len(state.issues["L-1"].result_history) == 4
-        outcomes = [e.result["outcome"] for e in state.issues["L-1"].result_history]
+        worker_results = [e for e in state.issues["L-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 4
+        outcomes = [e.data["outcome"] for e in worker_results]
         assert outcomes == ["again", "again", "again", "done"]
 
 
@@ -236,10 +261,14 @@ class TestDuplicateCreateErrors:
         gen = _counter()
         state = _empty_state()
 
-        state, _effects = reduce(config, state, CreateEvent(issue_id="D-1", fields={"title": "First"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="D-1", fields={"title": "First"}, timestamp=TS), gen, _clock()
+        )
         original_fields = state.issues["D-1"].fields.copy()
 
-        state, effects = reduce(config, state, CreateEvent(issue_id="D-1", fields={"title": "Duplicate"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="D-1", fields={"title": "Duplicate"}, timestamp=TS), gen, _clock()
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         assert "already exists" in effects[0].message
@@ -257,12 +286,15 @@ class TestWorkerResultOnTerminalErrors:
         state = _empty_state()
 
         # Create and complete
-        state, _effects = reduce(config, state, CreateEvent(issue_id="T-1", fields={"title": "Terminal"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="T-1", fields={"title": "Terminal"}, timestamp=TS), gen, _clock()
+        )
         state, _effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["T-1"].state == "done"
 
@@ -270,8 +302,9 @@ class TestWorkerResultOnTerminalErrors:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="T-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -286,15 +319,18 @@ class TestWorkerResultUnknownOutcomeErrors:
         gen = _counter()
         state = _empty_state()
 
-        state, _effects = reduce(config, state, CreateEvent(issue_id="U-1", fields={"title": "Unknown"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="U-1", fields={"title": "Unknown"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["U-1"].worker_active is True
 
         # Send invalid outcome
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="U-1", result={"outcome": "invalid_value"}),
+            WorkerResultEvent(issue_id="U-1", result={"outcome": "invalid_value"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -312,15 +348,18 @@ class TestDoubleWorkerResultRaceCondition:
         gen = _counter()
         state = _empty_state()
 
-        state, _effects = reduce(config, state, CreateEvent(issue_id="R-1", fields={"title": "Race"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="R-1", fields={"title": "Race"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["R-1"].worker_active is True
 
         # First result succeeds
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["R-1"].state == "done"
         assert not any(isinstance(e, ErrorEffect) for e in effects)
@@ -329,8 +368,9 @@ class TestDoubleWorkerResultRaceCondition:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="R-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -345,7 +385,9 @@ class TestEventsOnNonexistentIssue:
         state = _empty_state()
 
         # AdvanceEvent on nonexistent
-        state, effects = reduce(config, state, AdvanceEvent(issue_id="NOPE-1", target_state="done"), gen)
+        state, effects = reduce(
+            config, state, AdvanceEvent(issue_id="NOPE-1", target_state="done", timestamp=TS), gen, _clock()
+        )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
         assert "does not exist" in effects[0].message
@@ -354,8 +396,9 @@ class TestEventsOnNonexistentIssue:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="NOPE-2", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="NOPE-2", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -365,8 +408,9 @@ class TestEventsOnNonexistentIssue:
         state, effects = reduce(
             config,
             state,
-            WorkerFailedEvent(issue_id="NOPE-3", error="boom"),
+            WorkerFailedEvent(issue_id="NOPE-3", error="boom", timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)
@@ -382,15 +426,18 @@ class TestWorkerFailedWhenNotActiveErrors:
         state = _empty_state()
 
         # Create issue — active initial state, so dispatched
-        state, _effects = reduce(config, state, CreateEvent(issue_id="F-1", fields={"title": "Fail"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="F-1", fields={"title": "Fail"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["F-1"].worker_active is True
 
         # Complete the worker so worker_active becomes False
         state, _effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="F-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="F-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["F-1"].worker_active is False
 
@@ -398,8 +445,9 @@ class TestWorkerFailedWhenNotActiveErrors:
         state, effects = reduce(
             config,
             state,
-            WorkerFailedEvent(issue_id="F-1", error="boom"),
+            WorkerFailedEvent(issue_id="F-1", error="boom", timestamp=TS),
             gen,
+            _clock(),
         )
         assert len(effects) == 1
         assert isinstance(effects[0], ErrorEffect)

--- a/tests/engine/test_scenario_kanban.py
+++ b/tests/engine/test_scenario_kanban.py
@@ -56,6 +56,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter() -> Callable[[], str]:
     n = 0
@@ -81,13 +87,17 @@ class TestFullHappyPath:
         state = _empty_state()
 
         # Create issue in todo (passive state, no dispatch)
-        state, effects = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature A"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature A"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["K-1"].state == "todo"
         assert state.issues["K-1"].worker_active is False
         assert effects == []
 
         # Advance to implementing (active state, should dispatch)
-        state, effects = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+        state, effects = reduce(
+            config, state, AdvanceEvent(issue_id="K-1", target_state="implementing", timestamp=TS), gen, _clock()
+        )
         assert state.issues["K-1"].state == "implementing"
         assert state.issues["K-1"].worker_active is True
         assert len(effects) == 1
@@ -97,26 +107,33 @@ class TestFullHappyPath:
 
         # Worker completes implementing → transitions to review
         state, effects = reduce(
-            config, state, WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": "Built it"}), gen
+            config,
+            state,
+            WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": "Built it"}, timestamp=TS),
+            gen,
+            _clock(),
         )
         assert state.issues["K-1"].state == "review"
         assert state.issues["K-1"].worker_active is True
         assert len(effects) == 1
         assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].state == "review"
-        assert len(state.issues["K-1"].result_history) == 1
+        worker_results = [e for e in state.issues["K-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 1
 
         # Review approves → transitions to done (terminal)
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "LGTM"}),
+            WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "LGTM"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["K-1"].state == "done"
         assert state.issues["K-1"].worker_active is False
         assert effects == []
-        assert len(state.issues["K-1"].result_history) == 2
+        worker_results = [e for e in state.issues["K-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 2
 
 
 class TestReviewRejectionLoop:
@@ -128,16 +145,23 @@ class TestReviewRejectionLoop:
         state = _empty_state()
 
         # Create and advance to implementing
-        state, _ = reduce(config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature B"}), gen)
-        state, _ = reduce(config, state, AdvanceEvent(issue_id="K-1", target_state="implementing"), gen)
+        state, _ = reduce(
+            config, state, CreateEvent(issue_id="K-1", fields={"title": "Feature B"}, timestamp=TS), gen, _clock()
+        )
+        state, _ = reduce(
+            config, state, AdvanceEvent(issue_id="K-1", target_state="implementing", timestamp=TS), gen, _clock()
+        )
 
         for attempt in range(1, 4):
             # Implementing completes → review
             state, effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id="K-1", result={"outcome": "done", "summary": f"Attempt {attempt}"}),
+                WorkerResultEvent(
+                    issue_id="K-1", result={"outcome": "done", "summary": f"Attempt {attempt}"}, timestamp=TS
+                ),
                 gen,
+                _clock(),
             )
             assert state.issues["K-1"].state == "review"
             assert len(effects) == 1
@@ -148,8 +172,11 @@ class TestReviewRejectionLoop:
                 state, effects = reduce(
                     config,
                     state,
-                    WorkerResultEvent(issue_id="K-1", result={"outcome": "rejected", "feedback": "Needs work"}),
+                    WorkerResultEvent(
+                        issue_id="K-1", result={"outcome": "rejected", "feedback": "Needs work"}, timestamp=TS
+                    ),
                     gen,
+                    _clock(),
                 )
                 assert state.issues["K-1"].state == "implementing"
                 assert state.issues["K-1"].worker_active is True
@@ -161,16 +188,22 @@ class TestReviewRejectionLoop:
                 state, effects = reduce(
                     config,
                     state,
-                    WorkerResultEvent(issue_id="K-1", result={"outcome": "approved", "feedback": "Ship it"}),
+                    WorkerResultEvent(
+                        issue_id="K-1", result={"outcome": "approved", "feedback": "Ship it"}, timestamp=TS
+                    ),
                     gen,
+                    _clock(),
                 )
                 assert state.issues["K-1"].state == "done"
 
         # 3 implementing results + 2 rejected reviews + 1 approved review = 6
-        assert len(state.issues["K-1"].result_history) == 6
-        # Verify the pattern of states in result_history
-        states_in_history = [e.state for e in state.issues["K-1"].result_history]
-        assert states_in_history == [
+        worker_results = [e for e in state.issues["K-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 6
+        # Verify the pattern of states via transitioned entries (from field)
+        transitioned = [e for e in state.issues["K-1"].event_log if e.type == "transitioned"]
+        # Filter to only transitions triggered by worker results (from implementing/review)
+        worker_transitions = [e.data["from"] for e in transitioned if e.data["from"] in ("implementing", "review")]
+        assert worker_transitions == [
             "implementing",
             "review",
             "implementing",
@@ -192,8 +225,12 @@ class TestParallelIssues:
 
         # Create all issues and advance to implementing
         for iid in issue_ids:
-            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
-            state, effects = reduce(config, state, AdvanceEvent(issue_id=iid, target_state="implementing"), gen)
+            state, _ = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}, timestamp=TS), gen, _clock()
+            )
+            state, effects = reduce(
+                config, state, AdvanceEvent(issue_id=iid, target_state="implementing", timestamp=TS), gen, _clock()
+            )
             assert len(effects) == 1
             assert isinstance(effects[0], DispatchWorkerEffect)
 
@@ -206,7 +243,11 @@ class TestParallelIssues:
         for iid in reversed(issue_ids):
             # implementing → review
             state, effects = reduce(
-                config, state, WorkerResultEvent(issue_id=iid, result={"outcome": "done", "summary": "Done"}), gen
+                config,
+                state,
+                WorkerResultEvent(issue_id=iid, result={"outcome": "done", "summary": "Done"}, timestamp=TS),
+                gen,
+                _clock(),
             )
             assert state.issues[iid].state == "review"
             assert len(effects) == 1
@@ -215,8 +256,9 @@ class TestParallelIssues:
             state, effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id=iid, result={"outcome": "approved", "feedback": "OK"}),
+                WorkerResultEvent(issue_id=iid, result={"outcome": "approved", "feedback": "OK"}, timestamp=TS),
                 gen,
+                _clock(),
             )
             assert state.issues[iid].state == "done"
             assert state.issues[iid].worker_active is False
@@ -224,4 +266,5 @@ class TestParallelIssues:
         # Verify all done, no interference
         for iid in issue_ids:
             assert state.issues[iid].state == "done"
-            assert len(state.issues[iid].result_history) == 2
+            worker_results = [e for e in state.issues[iid].event_log if e.type == "worker_result"]
+            assert len(worker_results) == 2

--- a/tests/engine/test_scenario_pipeline.py
+++ b/tests/engine/test_scenario_pipeline.py
@@ -64,6 +64,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter() -> Callable[[], str]:
     n = 0
@@ -85,9 +91,15 @@ def _advance_to_apply(config: object, state: State, issue_id: str, gen: Callable
     from orca.engine.types import StateMachineConfig
 
     assert isinstance(config, StateMachineConfig)
-    state, _ = reduce(config, state, AdvanceEvent(issue_id=issue_id, target_state="implementing"), gen)
-    state, _ = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "done"}), gen)
-    state, _ = reduce(config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "passed"}), gen)
+    state, _ = reduce(
+        config, state, AdvanceEvent(issue_id=issue_id, target_state="implementing", timestamp=TS), gen, _clock()
+    )
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "done"}, timestamp=TS), gen, _clock()
+    )
+    state, _ = reduce(
+        config, state, WorkerResultEvent(issue_id=issue_id, result={"outcome": "passed"}, timestamp=TS), gen, _clock()
+    )
     return state
 
 
@@ -103,7 +115,9 @@ class TestSerializedMerge4Issues:
 
         # Create all issues
         for iid in ids:
-            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state, _ = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": iid}, timestamp=TS), gen, _clock()
+            )
 
         # Advance all to apply
         for iid in ids:
@@ -121,7 +135,13 @@ class TestSerializedMerge4Issues:
 
         # Merge them one by one
         for i, iid in enumerate(ids):
-            state, effects = reduce(config, state, WorkerResultEvent(issue_id=iid, result={"outcome": "merged"}), gen)
+            state, effects = reduce(
+                config,
+                state,
+                WorkerResultEvent(issue_id=iid, result={"outcome": "merged"}, timestamp=TS),
+                gen,
+                _clock(),
+            )
             assert state.issues[iid].state == "done"
 
             if i < len(ids) - 1:
@@ -151,7 +171,9 @@ class TestConflictFreesSlotForNext:
         state = _empty_state()
 
         for iid in ["P-1", "P-2"]:
-            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state, _ = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": iid}, timestamp=TS), gen, _clock()
+            )
             state = _advance_to_apply(config, state, iid, gen)
 
         assert state.issues["P-1"].worker_active is True
@@ -159,7 +181,13 @@ class TestConflictFreesSlotForNext:
         assert state.worker_queues.get("apply") == ["P-2"]
 
         # P-1 conflicts → goes back to implementing, P-2 gets dispatched in apply
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}, timestamp=TS),
+            gen,
+            _clock(),
+        )
         assert state.issues["P-1"].state == "implementing"
         assert state.issues["P-1"].worker_active is True  # implementing dispatches immediately
 
@@ -179,14 +207,22 @@ class TestConflictReenterAtBackOfQueue:
         state = _empty_state()
 
         for iid in ["P-1", "P-2", "P-3"]:
-            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state, _ = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": iid}, timestamp=TS), gen, _clock()
+            )
             state = _advance_to_apply(config, state, iid, gen)
 
         assert state.issues["P-1"].worker_active is True
         assert state.worker_queues.get("apply") == ["P-2", "P-3"]
 
         # P-1 conflicts → goes back to implementing
-        state, effects = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}), gen)
+        state, effects = reduce(
+            config,
+            state,
+            WorkerResultEvent(issue_id="P-1", result={"outcome": "conflict"}, timestamp=TS),
+            gen,
+            _clock(),
+        )
         assert state.issues["P-1"].state == "implementing"
 
         # P-2 should now be active in apply
@@ -197,8 +233,12 @@ class TestConflictReenterAtBackOfQueue:
         assert state.worker_queues.get("apply") == ["P-3"]
 
         # P-1 goes back through implementing→qa→apply, should end up queued behind P-3
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "done"}), gen)
-        state, _ = reduce(config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "passed"}), gen)
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "done"}, timestamp=TS), gen, _clock()
+        )
+        state, _ = reduce(
+            config, state, WorkerResultEvent(issue_id="P-1", result={"outcome": "passed"}, timestamp=TS), gen, _clock()
+        )
 
         assert state.issues["P-1"].state == "apply"
         assert state.issues["P-1"].worker_active is False
@@ -214,14 +254,18 @@ class TestWorkerFailedRetainsSlot:
         state = _empty_state()
 
         for iid in ["P-1", "P-2"]:
-            state, _ = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": iid}), gen)
+            state, _ = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": iid}, timestamp=TS), gen, _clock()
+            )
             state = _advance_to_apply(config, state, iid, gen)
 
         assert state.issues["P-1"].worker_active is True
         assert state.worker_queues.get("apply") == ["P-2"]
 
         # Worker fails on P-1 → slot retained, P-2 stays queued
-        state, effects = reduce(config, state, WorkerFailedEvent(issue_id="P-1", error="timeout"), gen)
+        state, effects = reduce(
+            config, state, WorkerFailedEvent(issue_id="P-1", error="timeout", timestamp=TS), gen, _clock()
+        )
         assert state.issues["P-1"].worker_active is True  # slot retained
         assert state.issues["P-1"].state == "apply"
 

--- a/tests/engine/test_scenario_queuing.py
+++ b/tests/engine/test_scenario_queuing.py
@@ -67,6 +67,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter(start: int = 0) -> Callable[[], str]:
     n = start
@@ -94,7 +100,9 @@ class TestMaxWorkersRespected:
         # Create 10 issues
         all_ids = [f"Q-{i}" for i in range(1, 11)]
         for iid in all_ids:
-            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+            state, _effects = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}, timestamp=TS), gen, _clock()
+            )
 
         # First 3 should be active, remaining 7 queued
         active = [iid for iid in all_ids if state.issues[iid].worker_active]
@@ -107,8 +115,9 @@ class TestMaxWorkersRespected:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["Q-1"].state == "done"
 
@@ -131,7 +140,9 @@ class TestWorkerFailureRetainsSlotInCappedState:
 
         all_ids = [f"Q-{i}" for i in range(1, 6)]
         for iid in all_ids:
-            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+            state, _effects = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}, timestamp=TS), gen, _clock()
+            )
 
         # 3 active, 2 queued
         active = [iid for iid in all_ids if state.issues[iid].worker_active]
@@ -142,8 +153,9 @@ class TestWorkerFailureRetainsSlotInCappedState:
             state, effects = reduce(
                 config,
                 state,
-                WorkerFailedEvent(issue_id="Q-1", error="boom"),
+                WorkerFailedEvent(issue_id="Q-1", error="boom", timestamp=TS),
                 gen,
+                _clock(),
             )
             # Worker should be retried (DispatchWorkerEffect emitted)
             assert len(effects) == 1
@@ -172,7 +184,9 @@ class TestSequentialDrain:
 
         all_ids = [f"Q-{i}" for i in range(1, 11)]
         for iid in all_ids:
-            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+            state, _effects = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}, timestamp=TS), gen, _clock()
+            )
 
         completed: list[str] = []
         while True:
@@ -187,8 +201,9 @@ class TestSequentialDrain:
             state, _effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id=active_id, result={"outcome": "done"}),
+                WorkerResultEvent(issue_id=active_id, result={"outcome": "done"}, timestamp=TS),
                 gen,
+                _clock(),
             )
             completed.append(active_id)
 
@@ -216,8 +231,9 @@ class TestDecomposeFanoutRespectsMaxWorkers:
         state, effects = reduce(
             config,
             state,
-            CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}),
+            CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["ROOT-1"].worker_active is True
         assert len(effects) == 1
@@ -233,8 +249,10 @@ class TestDecomposeFanoutRespectsMaxWorkers:
                     "outcome": "decompose",
                     "sub_issues": [{"key": f"child-{i}", "fields": {"title": f"Child {i}"}} for i in range(1, 6)],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         # Root should no longer be active (it's decomposition-blocked)

--- a/tests/engine/test_scenario_serialization.py
+++ b/tests/engine/test_scenario_serialization.py
@@ -110,6 +110,12 @@ states:
     terminal: true
 """
 
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
 
 def _counter(start: int = 0) -> Callable[[], str]:
     n = start
@@ -149,7 +155,9 @@ class TestMidWorkflowRoundtrip:
         state = _empty_state()
 
         # Create issue — dispatched immediately (active initial state)
-        state, effects = reduce(config, state, CreateEvent(issue_id="S-1", fields={"title": "Serialize"}), gen)
+        state, effects = reduce(
+            config, state, CreateEvent(issue_id="S-1", fields={"title": "Serialize"}, timestamp=TS), gen, _clock()
+        )
         assert state.issues["S-1"].worker_active is True
 
         # Serialize and restore (simulating restart)
@@ -164,12 +172,14 @@ class TestMidWorkflowRoundtrip:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="S-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="S-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["S-1"].state == "done"
         assert state.issues["S-1"].worker_active is False
-        assert len(state.issues["S-1"].result_history) == 1
+        worker_results = [e for e in state.issues["S-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 1
 
 
 class TestBlockedStateRoundtrip:
@@ -181,7 +191,9 @@ class TestBlockedStateRoundtrip:
         state = _empty_state()
 
         # Create root
-        state, _effects = reduce(config, state, CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="ROOT-1", fields={"title": "Root"}, timestamp=TS), gen, _clock()
+        )
 
         # Decompose into 2 children
         state, _effects = reduce(
@@ -196,8 +208,10 @@ class TestBlockedStateRoundtrip:
                         {"key": "c2", "fields": {"title": "Child 2"}},
                     ],
                 },
+                timestamp=TS,
             ),
             gen,
+            _clock(),
         )
 
         # Identify child IDs
@@ -219,8 +233,9 @@ class TestBlockedStateRoundtrip:
             state, _effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}),
+                WorkerResultEvent(issue_id=child_id, result={"outcome": "done"}, timestamp=TS),
                 gen,
+                _clock(),
             )
 
         # Root should now be dispatched (unblocked)
@@ -237,7 +252,9 @@ class TestQueueOrderSurvivesRoundtrip:
 
         all_ids = [f"Q-{i}" for i in range(1, 6)]
         for iid in all_ids:
-            state, _effects = reduce(config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}), gen)
+            state, _effects = reduce(
+                config, state, CreateEvent(issue_id=iid, fields={"title": f"Issue {iid}"}, timestamp=TS), gen, _clock()
+            )
 
         # Only Q-1 active, rest queued
         assert state.issues["Q-1"].worker_active is True
@@ -254,8 +271,9 @@ class TestQueueOrderSurvivesRoundtrip:
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="Q-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["Q-1"].state == "done"
 
@@ -266,43 +284,49 @@ class TestQueueOrderSurvivesRoundtrip:
         assert state.issues["Q-2"].worker_active is True
 
 
-class TestDeepResultHistoryRoundtrip:
-    """Issue loops 10 times. Serialize. Verify 10 history entries survive. Continue to completion."""
+class TestDeepEventLogRoundtrip:
+    """Issue loops 10 times. Serialize. Verify 10 event_log entries survive. Continue to completion."""
 
-    def test_deep_result_history_roundtrip(self) -> None:
+    def test_deep_event_log_roundtrip(self) -> None:
         config = parse_config(SELF_LOOP_CONFIG_YAML)
         gen = _counter()
         state = _empty_state()
 
         # Create — refine is active
-        state, _effects = reduce(config, state, CreateEvent(issue_id="H-1", fields={"title": "History"}), gen)
+        state, _effects = reduce(
+            config, state, CreateEvent(issue_id="H-1", fields={"title": "History"}, timestamp=TS), gen, _clock()
+        )
 
         # Loop 10 times
         for _ in range(10):
             state, _effects = reduce(
                 config,
                 state,
-                WorkerResultEvent(issue_id="H-1", result={"outcome": "again"}),
+                WorkerResultEvent(issue_id="H-1", result={"outcome": "again"}, timestamp=TS),
                 gen,
+                _clock(),
             )
 
-        assert len(state.issues["H-1"].result_history) == 10
+        worker_results = [e for e in state.issues["H-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 10
 
         # Serialize and restore
         state = _roundtrip(state)
 
         # Verify all 10 entries survive
-        assert len(state.issues["H-1"].result_history) == 10
-        assert all(e.state == "refine" for e in state.issues["H-1"].result_history)
-        assert all(e.result["outcome"] == "again" for e in state.issues["H-1"].result_history)
+        worker_results = [e for e in state.issues["H-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 10
+        assert all(e.data["outcome"] == "again" for e in worker_results)
 
         # Continue to completion after roundtrip
         state, effects = reduce(
             config,
             state,
-            WorkerResultEvent(issue_id="H-1", result={"outcome": "done"}),
+            WorkerResultEvent(issue_id="H-1", result={"outcome": "done"}, timestamp=TS),
             gen,
+            _clock(),
         )
         assert state.issues["H-1"].state == "done"
-        assert len(state.issues["H-1"].result_history) == 11
-        assert state.issues["H-1"].result_history[-1].result["outcome"] == "done"
+        worker_results = [e for e in state.issues["H-1"].event_log if e.type == "worker_result"]
+        assert len(worker_results) == 11
+        assert worker_results[-1].data["outcome"] == "done"

--- a/tests/engine/test_types.py
+++ b/tests/engine/test_types.py
@@ -8,12 +8,12 @@ from orca.engine.types import (
     DispatchWorkerEffect,
     EnumFieldDef,
     ErrorEffect,
+    EventLogEntry,
     FieldDef,
     Issue,
     ListFieldDef,
     OnDecompose,
     OnTransition,
-    ResultHistoryEntry,
     State,
     StateDef,
     StateMachineConfig,
@@ -32,14 +32,18 @@ class TestIssueConstruction:
             worker_active=False,
             decomposed_from="PARENT-1",
             depends_on=["DEP-1", "DEP-2"],
-            result_history=[],
+            event_log=[],
+            visit_counts={},
+            hop_count=0,
         )
         assert issue.fields == {"title": "Fix bug", "priority": "high"}
         assert issue.state == "open"
         assert issue.worker_active is False
         assert issue.decomposed_from == "PARENT-1"
         assert issue.depends_on == ["DEP-1", "DEP-2"]
-        assert issue.result_history == []
+        assert issue.event_log == []
+        assert issue.visit_counts == {}
+        assert issue.hop_count == 0
 
     def test_issue_without_decomposed_from(self) -> None:
         issue = Issue(
@@ -48,9 +52,35 @@ class TestIssueConstruction:
             worker_active=False,
             decomposed_from=None,
             depends_on=[],
-            result_history=[],
+            event_log=[],
+            visit_counts={},
+            hop_count=0,
         )
         assert issue.decomposed_from is None
+
+
+class TestEventLogEntry:
+    def test_construction(self) -> None:
+        entry = EventLogEntry(
+            timestamp="2026-03-22T10:00:00Z",
+            type="worker_result",
+            data={"outcome": "approve"},
+        )
+        assert entry.timestamp == "2026-03-22T10:00:00Z"
+        assert entry.type == "worker_result"
+        assert entry.data == {"outcome": "approve"}
+
+    def test_round_trip(self) -> None:
+        entry = EventLogEntry(
+            timestamp="2026-03-22T10:00:00Z",
+            type="advance",
+            data={"target_state": "review"},
+        )
+        d = entry.to_dict()
+        restored = EventLogEntry.from_dict(d)
+        assert restored.timestamp == entry.timestamp
+        assert restored.type == entry.type
+        assert restored.data == entry.data
 
 
 class TestSerializationRoundTrip:
@@ -63,7 +93,9 @@ class TestSerializationRoundTrip:
                     worker_active=False,
                     decomposed_from=None,
                     depends_on=[],
-                    result_history=[],
+                    event_log=[],
+                    visit_counts={},
+                    hop_count=0,
                 ),
             },
             worker_queues={},
@@ -77,7 +109,7 @@ class TestSerializationRoundTrip:
         assert restored.issues["ISS-1"].decomposed_from is None
         assert restored.issues["ISS-1"].depends_on == []
 
-    def test_state_with_result_history_round_trip(self) -> None:
+    def test_state_with_event_log_round_trip(self) -> None:
         state = State(
             issues={
                 "ISS-1": Issue(
@@ -86,10 +118,20 @@ class TestSerializationRoundTrip:
                     worker_active=False,
                     decomposed_from=None,
                     depends_on=[],
-                    result_history=[
-                        ResultHistoryEntry(state="triage", result={"decision": "approve"}),
-                        ResultHistoryEntry(state="review", result={"verdict": "pass"}),
+                    event_log=[
+                        EventLogEntry(
+                            timestamp="2026-03-22T10:00:00Z",
+                            type="worker_result",
+                            data={"decision": "approve"},
+                        ),
+                        EventLogEntry(
+                            timestamp="2026-03-22T11:00:00Z",
+                            type="advance",
+                            data={"target_state": "review"},
+                        ),
                     ],
+                    visit_counts={"triage": 1, "review": 1},
+                    hop_count=2,
                 ),
             },
             worker_queues={},
@@ -97,11 +139,12 @@ class TestSerializationRoundTrip:
         d = state.to_dict()
         json_str = json.dumps(d)
         restored = State.from_dict(json.loads(json_str))
-        assert len(restored.issues["ISS-1"].result_history) == 2
-        assert restored.issues["ISS-1"].result_history[0].state == "triage"
-        assert restored.issues["ISS-1"].result_history[0].result == {"decision": "approve"}
-        assert restored.issues["ISS-1"].result_history[1].state == "review"
-        assert restored.issues["ISS-1"].result_history[1].result == {"verdict": "pass"}
+        assert len(restored.issues["ISS-1"].event_log) == 2
+        assert restored.issues["ISS-1"].event_log[0].type == "worker_result"
+        assert restored.issues["ISS-1"].event_log[0].data == {"decision": "approve"}
+        assert restored.issues["ISS-1"].event_log[1].type == "advance"
+        assert restored.issues["ISS-1"].visit_counts == {"triage": 1, "review": 1}
+        assert restored.issues["ISS-1"].hop_count == 2
 
     def test_state_with_worker_queues_round_trip(self) -> None:
         state = State(
@@ -122,7 +165,9 @@ class TestSerializationRoundTrip:
                     worker_active=False,
                     decomposed_from="ISS-0",
                     depends_on=["ISS-2", "ISS-3"],
-                    result_history=[],
+                    event_log=[],
+                    visit_counts={},
+                    hop_count=0,
                 ),
             },
             worker_queues={},
@@ -133,27 +178,61 @@ class TestSerializationRoundTrip:
         assert restored.issues["ISS-1"].decomposed_from == "ISS-0"
         assert restored.issues["ISS-1"].depends_on == ["ISS-2", "ISS-3"]
 
+    def test_issue_visit_counts_hop_count_round_trip(self) -> None:
+        issue = Issue(
+            fields={"title": "Test"},
+            state="review",
+            worker_active=False,
+            decomposed_from=None,
+            depends_on=[],
+            event_log=[],
+            visit_counts={"triage": 2, "review": 1},
+            hop_count=3,
+        )
+        d = issue.to_dict()
+        restored = Issue.from_dict(d)
+        assert restored.visit_counts == {"triage": 2, "review": 1}
+        assert restored.hop_count == 3
+
+    def test_issue_from_dict_backward_compat(self) -> None:
+        """from_dict handles missing visit_counts, hop_count, and event_log."""
+        raw = {
+            "fields": {"title": "Old"},
+            "state": "open",
+            "worker_active": False,
+            "decomposed_from": None,
+            "depends_on": [],
+        }
+        issue = Issue.from_dict(raw)
+        assert issue.event_log == []
+        assert issue.visit_counts == {}
+        assert issue.hop_count == 0
+
 
 class TestEvents:
     def test_create_event(self) -> None:
-        e = CreateEvent(issue_id="ISS-1", fields={"title": "New"})
+        e = CreateEvent(issue_id="ISS-1", fields={"title": "New"}, timestamp="2026-03-22T10:00:00Z")
         assert e.issue_id == "ISS-1"
         assert e.fields == {"title": "New"}
+        assert e.timestamp == "2026-03-22T10:00:00Z"
 
     def test_advance_event(self) -> None:
-        e = AdvanceEvent(issue_id="ISS-1", target_state="review")
+        e = AdvanceEvent(issue_id="ISS-1", target_state="review", timestamp="2026-03-22T10:00:00Z")
         assert e.issue_id == "ISS-1"
         assert e.target_state == "review"
+        assert e.timestamp == "2026-03-22T10:00:00Z"
 
     def test_worker_result_event(self) -> None:
-        e = WorkerResultEvent(issue_id="ISS-1", result={"decision": "approve"})
+        e = WorkerResultEvent(issue_id="ISS-1", result={"decision": "approve"}, timestamp="2026-03-22T10:00:00Z")
         assert e.issue_id == "ISS-1"
         assert e.result == {"decision": "approve"}
+        assert e.timestamp == "2026-03-22T10:00:00Z"
 
     def test_worker_failed_event(self) -> None:
-        e = WorkerFailedEvent(issue_id="ISS-1", error="timeout")
+        e = WorkerFailedEvent(issue_id="ISS-1", error="timeout", timestamp="2026-03-22T10:00:00Z")
         assert e.issue_id == "ISS-1"
         assert e.error == "timeout"
+        assert e.timestamp == "2026-03-22T10:00:00Z"
 
 
 class TestEffects:
@@ -236,6 +315,7 @@ class TestConfigTypes:
         assert s.on == {}
         assert s.terminal is False
         assert s.max_workers is None
+        assert s.max_visits is None
 
     def test_state_def_active(self) -> None:
         worker = WorkerDef(
@@ -255,6 +335,10 @@ class TestConfigTypes:
     def test_state_def_terminal(self) -> None:
         s = StateDef(terminal=True)
         assert s.terminal is True
+
+    def test_state_def_with_max_visits(self) -> None:
+        s = StateDef(max_visits=5)
+        assert s.max_visits == 5
 
     def test_state_machine_config(self) -> None:
         config = StateMachineConfig(
@@ -283,38 +367,13 @@ class TestConfigTypes:
         assert len(config.states) == 3
         assert config.states["closed"].terminal is True
         assert len(config.issue_fields) == 2
+        assert config.max_hops is None
 
-
-class TestPublicAPI:
-    def test_imports_from_engine_package(self) -> None:
-        from orca.engine import (
-            AdvanceEvent,
-            ConfigValidationError,
-            CreateEvent,
-            DispatchWorkerEffect,
-            Effect,
-            ErrorEffect,
-            Event,
-            Issue,
-            State,
-            StateMachineConfig,
-            WorkerFailedEvent,
-            WorkerResultEvent,
-            parse_config,
-            reduce,
+    def test_state_machine_config_with_max_hops(self) -> None:
+        config = StateMachineConfig(
+            issue_fields={},
+            initial="todo",
+            states={"todo": StateDef(terminal=True)},
+            max_hops=50,
         )
-
-        assert callable(reduce)
-        assert callable(parse_config)
-        assert ConfigValidationError is not None
-        assert AdvanceEvent is not None
-        assert CreateEvent is not None
-        assert DispatchWorkerEffect is not None
-        assert Effect is not None
-        assert ErrorEffect is not None
-        assert Event is not None
-        assert Issue is not None
-        assert State is not None
-        assert StateMachineConfig is not None
-        assert WorkerFailedEvent is not None
-        assert WorkerResultEvent is not None
+        assert config.max_hops == 50


### PR DESCRIPTION
## Summary
- Replace `result_history` with comprehensive `event_log` — every action on an issue is timestamped and logged (created, advanced, worker_dispatched, worker_result, worker_failed, transitioned, blocked, unblocked, limit_reached)
- Add hop limits: per-state `max_visits` and global `max_hops` prevent infinite loops between states
- Add `format_issues()` ASCII visualization showing issue DAG with tree connectors, elapsed time, and queue status
- Inject `now: Callable[[], str]` clock into reducer for pure timestamping
- Add `timestamp` field to all event types

## Breaking changes
- `ResultHistoryEntry` removed, replaced by `EventLogEntry`
- `Issue.result_history` → `Issue.event_log`
- `reduce()` signature gains `now` parameter
- All events gain `timestamp` field
- `DispatchWorkerEffect.issue` context uses `event_log` instead of `result_history`

## Test plan
- [x] 177 tests passing (134 migrated + 43 new)
- [x] New tests: event log entries, hop limits, ASCII formatting
- [x] All scenario tests migrated to new API
- [x] ruff clean, mypy strict clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)