### PR TITLE
feat: add structured JSONL logging and session sync

### DIFF
--- a/docs/superpowers/plans/2026-03-22-structured-logging.md
+++ b/docs/superpowers/plans/2026-03-22-structured-logging.md
@@ -1,0 +1,567 @@
+# Structured Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JSONL structured logging so orca runs produce a machine-readable log file at `.orca/runs/{branch}/orca.log.jsonl`.
+
+**Architecture:** A `JSONFormatter` and `setup_logging()` function in a new `log.py` module. Configured once in `runner.py` at startup. All orchestrator modules use stdlib `logging.getLogger(__name__)` with structured `extra={}` fields. Logs go to file only (not stderr/stdout).
+
+**Tech Stack:** Python 3.12 stdlib `logging`, `json`
+
+**Spec:** `docs/superpowers/specs/2026-03-22-structured-logging-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| Create: `src/orca/orchestrator/log.py` | `JSONFormatter` and `setup_logging()` |
+| Create: `tests/orchestrator/test_log.py` | Tests for formatter and setup |
+| Modify: `src/orca/orchestrator/runner.py` | Call `setup_logging()`, add lifecycle logs |
+| Modify: `src/orca/orchestrator/orchestrator.py` | Add structured log calls with `extra={}` |
+| Modify: `src/orca/orchestrator/worker.py` | Add DEBUG subprocess logs |
+
+**Note:** Module named `log.py` (not `logging.py`) to avoid shadowing stdlib `logging`.
+
+---
+
+### Task 1: JSONFormatter and setup_logging
+
+**Files:**
+- Create: `src/orca/orchestrator/log.py`
+- Create: `tests/orchestrator/test_log.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/orchestrator/test_log.py
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from orca.orchestrator.log import JSONFormatter, setup_logging
+
+
+class TestJSONFormatter:
+    def test_formats_basic_record(self) -> None:
+        """Format a log record as a single JSON line with standard fields."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+
+        result = json.loads(formatter.format(record))
+
+        assert result["level"] == "INFO"
+        assert result["logger"] == "orca.test"
+        assert result["message"] == "Hello world"
+        assert "timestamp" in result
+
+    def test_includes_extra_fields(self) -> None:
+        """Extra fields from the log call appear in the JSON output."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test",
+            args=(),
+            exc_info=None,
+        )
+        record.event = "worker_dispatched"  # type: ignore[attr-defined]
+        record.issue_id = "abc-123"  # type: ignore[attr-defined]
+
+        result = json.loads(formatter.format(record))
+
+        assert result["event"] == "worker_dispatched"
+        assert result["issue_id"] == "abc-123"
+
+    def test_excludes_standard_log_record_attrs(self) -> None:
+        """Standard LogRecord attributes do not leak into the JSON output."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="/some/path.py",
+            lineno=42,
+            msg="test",
+            args=(),
+            exc_info=None,
+        )
+
+        result = json.loads(formatter.format(record))
+
+        assert "pathname" not in result
+        assert "lineno" not in result
+        assert "args" not in result
+        assert "msg" not in result
+
+    def test_output_is_single_line(self) -> None:
+        """Output must be a single line (no embedded newlines)."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="line1\nline2",
+            args=(),
+            exc_info=None,
+        )
+
+        output = formatter.format(record)
+
+        assert "\n" not in output
+
+
+class TestSetupLogging:
+    def test_creates_log_file(self, tmp_path: Path) -> None:
+        """setup_logging creates the log file and writes JSON lines."""
+        log_path = tmp_path / "runs" / "main" / "orca.log.jsonl"
+        setup_logging(log_path)
+
+        test_logger = logging.getLogger("orca.test.setup")
+        test_logger.info("test message", extra={"event": "test_event"})
+
+        # Flush handler
+        for handler in logging.getLogger("orca").handlers:
+            handler.flush()
+
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+
+        entry = json.loads(lines[0])
+        assert entry["message"] == "test message"
+        assert entry["event"] == "test_event"
+        assert entry["level"] == "INFO"
+
+    def test_does_not_propagate(self, tmp_path: Path) -> None:
+        """The orca logger should not propagate to root logger."""
+        log_path = tmp_path / "runs" / "main" / "orca.log.jsonl"
+        setup_logging(log_path)
+
+        orca_logger = logging.getLogger("orca")
+        assert orca_logger.propagate is False
+
+    def teardown_method(self) -> None:
+        """Clean up handlers added by setup_logging."""
+        orca_logger = logging.getLogger("orca")
+        for handler in orca_logger.handlers[:]:
+            handler.close()
+            orca_logger.removeHandler(handler)
+        orca_logger.setLevel(logging.WARNING)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/orchestrator/test_log.py -v`
+Expected: FAIL — `ImportError: cannot import name 'JSONFormatter'`
+
+- [ ] **Step 3: Implement JSONFormatter and setup_logging**
+
+```python
+# src/orca/orchestrator/log.py
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+_STANDARD_LOG_RECORD_ATTRS = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys()
+)
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as single-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(
+                timespec="milliseconds"
+            ),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_RECORD_ATTRS and key not in entry:
+                entry[key] = value
+        return json.dumps(entry, default=str)
+
+
+def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
+    """Configure the 'orca' logger to write JSONL to a file."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_path)
+    handler.setFormatter(JSONFormatter())
+    orca_logger = logging.getLogger("orca")
+    orca_logger.setLevel(level)
+    orca_logger.addHandler(handler)
+    orca_logger.propagate = False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/orchestrator/test_log.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run linter and type checker**
+
+Run: `uv run ruff check . && uv run mypy src/orca/orchestrator/log.py`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/orchestrator/log.py tests/orchestrator/test_log.py
+git commit -m "feat: add JSONFormatter and setup_logging for structured JSONL logging"
+```
+
+---
+
+### Task 2: Add logging to runner.py
+
+**Files:**
+- Modify: `src/orca/orchestrator/runner.py`
+
+Add `setup_logging()` call early in `run()`, plus lifecycle log events (run started/resumed/completed/failed). Wrap `orchestrator.run()` in a try/except for the failure case.
+
+- [ ] **Step 1: Add imports**
+
+Add to the imports section of `runner.py`:
+
+```python
+import logging
+
+from orca.orchestrator.log import setup_logging
+```
+
+Add module-level logger after imports:
+
+```python
+logger = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Add setup_logging call**
+
+Inside `run()`, after `worktree_mgr` is created (after line 137), add:
+
+```python
+    log_path = repo_root / ".orca" / "runs" / branch_name / "orca.log.jsonl"
+    setup_logging(log_path)
+```
+
+- [ ] **Step 3: Add lifecycle log events**
+
+In the resume branch (after `branches.load()`, around line 147), add:
+
+```python
+    logger.info(
+        "Run resumed",
+        extra={"event": "run_resumed", "branch": branch_name},
+    )
+```
+
+In the fresh-start branch (after `persistence.save(state)`, around line 183), add:
+
+```python
+    logger.info(
+        "Run started",
+        extra={
+            "event": "run_started",
+            "branch": branch_name,
+            "task_file": str(task_file),
+            "root_issue_id": root_issue_id,
+        },
+    )
+```
+
+Replace the bare `await orchestrator.run(...)` call with:
+
+```python
+    try:
+        await orchestrator.run(root_issue_id, initial_effects)
+    except Exception:
+        logger.error(
+            "Run failed",
+            extra={"event": "run_failed", "branch": branch_name},
+            exc_info=True,
+        )
+        raise
+
+    logger.info(
+        "Run completed",
+        extra={"event": "run_completed", "branch": branch_name, "root_issue_id": root_issue_id},
+    )
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Run linter and type checker**
+
+Run: `uv run ruff check . && uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/orchestrator/runner.py
+git commit -m "feat: add structured logging setup and lifecycle events to runner"
+```
+
+---
+
+### Task 3: Add structured logging to orchestrator.py
+
+**Files:**
+- Modify: `src/orca/orchestrator/orchestrator.py`
+
+Add `extra={}` with `event` field to existing log calls. Add new log calls for worker dispatch, completion, state transitions, and decomposition detection.
+
+- [ ] **Step 1: Update existing log calls with event extra**
+
+Replace the four existing log calls with versions that include `extra`:
+
+```python
+# _spawn_worker — no worker definition
+logger.warning(
+    "No worker definition for state %r — skipping dispatch",
+    effect.state,
+    extra={"event": "no_worker_definition", "state": effect.state},
+)
+
+# _spawn_worker — unknown worker kind
+logger.warning(
+    "Unknown worker kind %r — skipping dispatch",
+    worker_kind,
+    extra={"event": "unknown_worker_kind", "worker_kind": worker_kind},
+)
+
+# _route_effects — error effect
+logger.error(
+    "ErrorEffect for issue %r: %s",
+    effect.issue_id,
+    effect.message,
+    extra={"event": "error_effect", "issue_id": effect.issue_id, "error": effect.message},
+)
+
+# run — deadlock
+logger.warning(
+    "Deadlock detected: no tasks in flight and no pending effects. Stopping.",
+    extra={"event": "deadlock_detected"},
+)
+```
+
+- [ ] **Step 2: Add worker dispatch log**
+
+In `_spawn_worker()`, after `self._in_flight[task] = effect.issue_id`:
+
+```python
+        logger.info(
+            "Worker dispatched for issue %s in state %s",
+            effect.issue_id,
+            effect.state,
+            extra={
+                "event": "worker_dispatched",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "worker_kind": worker_kind,
+            },
+        )
+```
+
+- [ ] **Step 3: Add state-diffing and completion logs**
+
+In the `for task in done:` loop, capture old state before `reduce()`, then log after:
+
+Before the `self.state, new_effects = reduce(...)` call, add:
+
+```python
+                old_issues = set(self.state.issues.keys())
+                old_issue_state = self.state.issues[issue_id].state if issue_id in self.state.issues else None
+```
+
+After `self.persistence.save(self.state)`, add:
+
+```python
+                # Log worker outcome
+                if isinstance(outcome, WorkerSuccess):
+                    logger.info(
+                        "Worker succeeded for issue %s",
+                        issue_id,
+                        extra={
+                            "event": "worker_succeeded",
+                            "issue_id": issue_id,
+                            "result_outcome": outcome.result.get("outcome"),
+                        },
+                    )
+                else:
+                    logger.warning(
+                        "Worker failed for issue %s: %s",
+                        issue_id,
+                        outcome.error,
+                        extra={"event": "worker_failed", "issue_id": issue_id, "error": outcome.error},
+                    )
+
+                # Detect state transition
+                new_issue_state = self.state.issues[issue_id].state if issue_id in self.state.issues else None
+                if old_issue_state and new_issue_state and old_issue_state != new_issue_state:
+                    logger.info(
+                        "Issue %s transitioned from %s to %s",
+                        issue_id,
+                        old_issue_state,
+                        new_issue_state,
+                        extra={
+                            "event": "state_transitioned",
+                            "issue_id": issue_id,
+                            "from_state": old_issue_state,
+                            "to_state": new_issue_state,
+                        },
+                    )
+
+                # Detect new issues (decomposition)
+                new_issues = set(self.state.issues.keys()) - old_issues
+                for new_id in new_issues:
+                    new_issue = self.state.issues[new_id]
+                    logger.info(
+                        "Issue %s created: %s",
+                        new_id,
+                        new_issue.fields.get("title", ""),
+                        extra={
+                            "event": "issue_created",
+                            "issue_id": new_id,
+                            "parent_id": new_issue.decomposed_from,
+                            "title": new_issue.fields.get("title", ""),
+                        },
+                    )
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Run linter and type checker**
+
+Run: `uv run ruff check . && uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orca/orchestrator/orchestrator.py
+git commit -m "feat: add structured log events to orchestrator"
+```
+
+---
+
+### Task 4: Add DEBUG logging to worker.py
+
+**Files:**
+- Modify: `src/orca/orchestrator/worker.py`
+
+Add two DEBUG log calls: subprocess started and subprocess exited.
+
+- [ ] **Step 1: Add logger and log calls**
+
+Add import and logger at top of `worker.py`:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+After `proc = await asyncio.create_subprocess_exec(...)` (after line 78):
+
+```python
+        logger.debug(
+            "Subprocess started for issue %s",
+            effect.issue_id,
+            extra={
+                "event": "subprocess_started",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "pid": proc.pid,
+                "workdir": str(workdir),
+            },
+        )
+```
+
+After `await proc.wait()` (after line 91):
+
+```python
+        logger.debug(
+            "Subprocess exited for issue %s with code %s",
+            effect.issue_id,
+            proc.returncode,
+            extra={
+                "event": "subprocess_exited",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "pid": proc.pid,
+                "returncode": proc.returncode,
+            },
+        )
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 3: Run linter and type checker**
+
+Run: `uv run ruff check . && uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/orca/orchestrator/worker.py
+git commit -m "feat: add DEBUG subprocess logging to worker"
+```
+
+---
+
+### Task 5: Update orchestrator exports
+
+**Files:**
+- Modify: `src/orca/orchestrator/__init__.py`
+
+- [ ] **Step 1: Add log module exports**
+
+Add to `__init__.py` imports:
+
+```python
+from orca.orchestrator.log import JSONFormatter, setup_logging
+```
+
+Add `"JSONFormatter"` and `"setup_logging"` to `__all__`.
+
+- [ ] **Step 2: Run type checker**
+
+Run: `uv run mypy src/orca/orchestrator/`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/orca/orchestrator/__init__.py
+git commit -m "chore: export JSONFormatter and setup_logging from orchestrator"
+```

--- a/docs/superpowers/specs/2026-03-22-structured-logging-design.md
+++ b/docs/superpowers/specs/2026-03-22-structured-logging-design.md
@@ -1,0 +1,155 @@
+# Structured Logging Design
+
+## Overview
+
+Add JSONL structured logging to the orca orchestrator so users can observe what's happening during a run. Each log entry is a single JSON line written to `.orca/runs/{branch}/orca.log.jsonl`. Uses Python stdlib `logging` with a custom `JSONFormatter` — no new dependencies.
+
+## Log Entry Format
+
+Every log entry is a JSON object on one line:
+
+```json
+{"timestamp": "2026-03-22T15:30:01.123Z", "level": "INFO", "logger": "orca.orchestrator.orchestrator", "message": "Worker dispatched", "event": "worker_dispatched", "issue_id": "abc-123", "state": "implementing"}
+```
+
+**Standard fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string | ISO 8601 with milliseconds, UTC |
+| `level` | string | DEBUG, INFO, WARNING, ERROR |
+| `logger` | string | Python logger name (e.g., `orca.orchestrator.worker`) |
+| `message` | string | Human-readable description |
+
+**Extra fields** are merged into the top-level JSON object from the `extra={}` kwarg on each log call. Common extras: `event`, `issue_id`, `state`, `branch`, `error`.
+
+## New Module: `src/orca/orchestrator/logging.py`
+
+### `JSONFormatter`
+
+A `logging.Formatter` subclass that outputs one JSON line per record:
+
+```python
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        entry = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Merge extra fields (skip standard LogRecord attributes)
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_RECORD_ATTRS and key not in entry:
+                entry[key] = value
+        return json.dumps(entry)
+```
+
+`_STANDARD_LOG_RECORD_ATTRS` is a frozenset of all default `LogRecord` attribute names (e.g., `name`, `msg`, `args`, `levelname`, `pathname`, etc.) — only user-supplied `extra` fields pass through.
+
+### `setup_logging(log_path: Path, level: int = logging.DEBUG) -> None`
+
+Configures the `"orca"` root logger:
+
+1. Create parent directories for `log_path`.
+2. Attach a `FileHandler` with `JSONFormatter` to the `"orca"` logger.
+3. Set level to `DEBUG` (capture everything; filter by level when reading).
+4. Called once from `runner.py` at startup.
+
+```python
+def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_path)
+    handler.setFormatter(JSONFormatter())
+    orca_logger = logging.getLogger("orca")
+    orca_logger.setLevel(level)
+    orca_logger.addHandler(handler)
+```
+
+## Log Points
+
+### `runner.py`
+
+| Event | Level | Extra fields | When |
+|-------|-------|-------------|------|
+| Run started | INFO | `event`, `branch`, `task_file`, `root_issue_id` | After state init, before orchestrator.run() |
+| Run completed | INFO | `event`, `branch`, `root_issue_id` | After orchestrator.run() returns |
+| Run failed | ERROR | `event`, `branch`, `error` | In exception handler wrapping orchestrator.run() |
+
+### `orchestrator.py`
+
+| Event | Level | Extra fields | When |
+|-------|-------|-------------|------|
+| Worker dispatched | INFO | `event`, `issue_id`, `state`, `worker_kind` | In `_spawn_worker()` after creating asyncio task |
+| Worker succeeded | INFO | `event`, `issue_id`, `state`, `result_outcome` | After receiving `WorkerSuccess` |
+| Worker failed | WARNING | `event`, `issue_id`, `state`, `error` | After receiving `WorkerFailure` |
+| State transitioned | INFO | `event`, `issue_id`, `from_state`, `to_state` | After reduce() produces a state change |
+| Issue created | INFO | `event`, `issue_id`, `parent_id`, `title` | After reduce() processes a decompose result with new CreateEvents |
+| Deadlock detected | ERROR | `event` | Existing log point, add `event` extra |
+| No worker definition | WARNING | `event`, `state` | Existing log point, add `event` extra |
+| Unknown worker kind | WARNING | `event`, `worker_kind` | Existing log point, add `event` extra |
+
+### `worker.py`
+
+| Event | Level | Extra fields | When |
+|-------|-------|-------------|------|
+| Subprocess started | DEBUG | `event`, `issue_id`, `state`, `pid`, `workdir` | After `create_subprocess_exec` |
+| Subprocess exited | DEBUG | `event`, `issue_id`, `state`, `pid`, `returncode` | After `proc.communicate()` |
+
+### `session_sync.py`
+
+Existing log calls are kept as-is. They already use `logger.info/warning/exception` and will automatically appear in the JSONL output once `setup_logging()` is called.
+
+## Changes to Existing Modules
+
+### `runner.py`
+
+Add `setup_logging()` call early in `run()`:
+
+```python
+from orca.orchestrator.logging import setup_logging
+
+log_path = repo_root / ".orca" / "runs" / branch_name / "orca.log.jsonl"
+setup_logging(log_path)
+```
+
+Add logger and log calls for run lifecycle (started/completed/failed).
+
+### `orchestrator.py`
+
+Add `extra={}` to existing log calls. Add new log calls for worker dispatch, completion, state transitions, and decomposition.
+
+### `worker.py`
+
+Add `logger = logging.getLogger(__name__)` and two DEBUG log calls for subprocess start/exit.
+
+## Log File Location
+
+```
+.orca/runs/{branch}/orca.log.jsonl
+```
+
+Alongside the existing `state.json` and `branches.json`. One log file per run. Appended to if the run is resumed (crash recovery).
+
+## Reading Logs
+
+```bash
+# Watch live
+tail -f .orca/runs/my-feature/orca.log.jsonl | jq .
+
+# Filter by level
+cat .orca/runs/my-feature/orca.log.jsonl | jq 'select(.level == "ERROR")'
+
+# Filter by event type
+cat .orca/runs/my-feature/orca.log.jsonl | jq 'select(.event == "worker_dispatched")'
+
+# Filter by issue
+cat .orca/runs/my-feature/orca.log.jsonl | jq 'select(.issue_id == "abc-123")'
+```
+
+## What This Does NOT Include
+
+- **Console output** — logs go only to file, not stderr/stdout.
+- **Log rotation** — single file per run, no size limits.
+- **Remote log shipping** — local files only.
+- **Engine logging** — the engine is pure and does no I/O; logging stays in the orchestrator layer.

--- a/docs/superpowers/specs/2026-03-22-structured-logging-design.md
+++ b/docs/superpowers/specs/2026-03-22-structured-logging-design.md
@@ -45,16 +45,23 @@ class JSONFormatter(logging.Formatter):
         return json.dumps(entry)
 ```
 
-`_STANDARD_LOG_RECORD_ATTRS` is a frozenset of all default `LogRecord` attribute names (e.g., `name`, `msg`, `args`, `levelname`, `pathname`, etc.) — only user-supplied `extra` fields pass through.
+`_STANDARD_LOG_RECORD_ATTRS` is built dynamically from a dummy `LogRecord` to stay compatible across Python versions:
+
+```python
+_STANDARD_LOG_RECORD_ATTRS = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys()
+)
+```
 
 ### `setup_logging(log_path: Path, level: int = logging.DEBUG) -> None`
 
 Configures the `"orca"` root logger:
 
 1. Create parent directories for `log_path`.
-2. Attach a `FileHandler` with `JSONFormatter` to the `"orca"` logger.
+2. Attach a `FileHandler` (mode `"a"` — append, supports crash recovery resume) with `JSONFormatter` to the `"orca"` logger.
 3. Set level to `DEBUG` (capture everything; filter by level when reading).
-4. Called once from `runner.py` at startup.
+4. Set `propagate = False` to prevent log records from flowing to the root logger (avoids duplicate output if someone calls `basicConfig()` elsewhere).
+5. Called once from `runner.py` at startup.
 
 ```python
 def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
@@ -64,27 +71,35 @@ def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
     orca_logger = logging.getLogger("orca")
     orca_logger.setLevel(level)
     orca_logger.addHandler(handler)
+    orca_logger.propagate = False
 ```
 
 ## Log Points
 
 ### `runner.py`
 
+A `try/except` block must be added around `orchestrator.run()` to catch and log failures — this is net-new control flow, not an existing handler.
+
 | Event | Level | Extra fields | When |
 |-------|-------|-------------|------|
 | Run started | INFO | `event`, `branch`, `task_file`, `root_issue_id` | After state init, before orchestrator.run() |
+| Run resumed | INFO | `event`, `branch`, `root_issue_id` | In crash-recovery path, after loading persisted state |
 | Run completed | INFO | `event`, `branch`, `root_issue_id` | After orchestrator.run() returns |
-| Run failed | ERROR | `event`, `branch`, `error` | In exception handler wrapping orchestrator.run() |
+| Run failed | ERROR | `event`, `branch`, `error` | In new try/except wrapping orchestrator.run() |
 
 ### `orchestrator.py`
+
+**Detecting state transitions and new issues:** The orchestrator must diff state before and after `reduce()`:
+- **State transitions:** Compare `old_state.issues[issue_id].state` vs `new_state.issues[issue_id].state` for the issue referenced in the event. Log when they differ.
+- **New issues (decomposition):** Compare `old_state.issues.keys()` vs `new_state.issues.keys()`. Any new keys represent child issues created by decomposition.
 
 | Event | Level | Extra fields | When |
 |-------|-------|-------------|------|
 | Worker dispatched | INFO | `event`, `issue_id`, `state`, `worker_kind` | In `_spawn_worker()` after creating asyncio task |
 | Worker succeeded | INFO | `event`, `issue_id`, `state`, `result_outcome` | After receiving `WorkerSuccess` |
 | Worker failed | WARNING | `event`, `issue_id`, `state`, `error` | After receiving `WorkerFailure` |
-| State transitioned | INFO | `event`, `issue_id`, `from_state`, `to_state` | After reduce() produces a state change |
-| Issue created | INFO | `event`, `issue_id`, `parent_id`, `title` | After reduce() processes a decompose result with new CreateEvents |
+| State transitioned | INFO | `event`, `issue_id`, `from_state`, `to_state` | After reduce(), when issue state differs |
+| Issue created | INFO | `event`, `issue_id`, `parent_id`, `title` | After reduce(), for each new issue key in state |
 | Deadlock detected | ERROR | `event` | Existing log point, add `event` extra |
 | No worker definition | WARNING | `event`, `state` | Existing log point, add `event` extra |
 | Unknown worker kind | WARNING | `event`, `worker_kind` | Existing log point, add `event` extra |
@@ -98,7 +113,7 @@ def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
 
 ### `session_sync.py`
 
-Existing log calls are kept as-is. They already use `logger.info/warning/exception` and will automatically appear in the JSONL output once `setup_logging()` is called.
+Existing log calls are kept as-is. They already use `logger.info/warning/exception` and will automatically appear in the JSONL output once `setup_logging()` is called. Note: these existing calls do not include `extra={"event": ...}` so they won't be filterable by event type — this is acceptable for now.
 
 ## Changes to Existing Modules
 
@@ -113,11 +128,11 @@ log_path = repo_root / ".orca" / "runs" / branch_name / "orca.log.jsonl"
 setup_logging(log_path)
 ```
 
-Add logger and log calls for run lifecycle (started/completed/failed).
+Add `logger = logging.getLogger(__name__)` and log calls for run lifecycle. Add `try/except` around `orchestrator.run()` for the run-failed event.
 
 ### `orchestrator.py`
 
-Add `extra={}` to existing log calls. Add new log calls for worker dispatch, completion, state transitions, and decomposition.
+Add `extra={}` with `event` field to existing log calls. Add new log calls for worker dispatch, completion, state transitions, and decomposition. Add state-diffing logic after `reduce()` calls.
 
 ### `worker.py`
 
@@ -129,7 +144,7 @@ Add `logger = logging.getLogger(__name__)` and two DEBUG log calls for subproces
 .orca/runs/{branch}/orca.log.jsonl
 ```
 
-Alongside the existing `state.json` and `branches.json`. One log file per run. Appended to if the run is resumed (crash recovery).
+Alongside the existing `state.json` and `branches.json`. One log file per run. FileHandler uses append mode — the file grows across crash-recovery resumes.
 
 ## Reading Logs
 

--- a/src/orca/orchestrator/__init__.py
+++ b/src/orca/orchestrator/__init__.py
@@ -1,6 +1,7 @@
 """Orca orchestrator — runs workers and manages the engine event loop."""
 
 from orca.orchestrator.branches import BranchMap
+from orca.orchestrator.log import JSONFormatter, setup_logging
 from orca.orchestrator.orchestrator import Orchestrator
 from orca.orchestrator.persistence import Persistence
 from orca.orchestrator.runner import main, parse_task_file, run
@@ -19,6 +20,7 @@ from orca.orchestrator.worktree import WorktreeManager
 __all__ = [
     "BranchMap",
     "ClaudeCodeWorker",
+    "JSONFormatter",
     "Orchestrator",
     "Persistence",
     "SessionManifest",
@@ -32,5 +34,6 @@ __all__ = [
     "parse_task_file",
     "render_prompt",
     "run",
+    "setup_logging",
     "validate_result",
 ]

--- a/src/orca/orchestrator/log.py
+++ b/src/orca/orchestrator/log.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+_STANDARD_LOG_RECORD_ATTRS = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys())
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as single-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_RECORD_ATTRS and key not in entry:
+                entry[key] = value
+        return json.dumps(entry, default=str)
+
+
+def setup_logging(log_path: Path, level: int = logging.DEBUG) -> None:
+    """Configure the 'orca' logger to write JSONL to a file."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_path)
+    handler.setFormatter(JSONFormatter())
+    orca_logger = logging.getLogger("orca")
+    orca_logger.setLevel(level)
+    orca_logger.addHandler(handler)
+    orca_logger.propagate = False

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -63,13 +63,21 @@ class Orchestrator:
         """Resolve the worker for the effect and spawn an asyncio task."""
         state_def = self.config.states.get(effect.state)
         if state_def is None or state_def.worker is None:
-            logger.warning("No worker definition for state %r — skipping dispatch", effect.state)
+            logger.warning(
+                "No worker definition for state %r — skipping dispatch",
+                effect.state,
+                extra={"event": "no_worker_definition", "state": effect.state},
+            )
             return
 
         worker_kind = state_def.worker.kind
         worker = self.workers.get(worker_kind)
         if worker is None:
-            logger.warning("Unknown worker kind %r — skipping dispatch", worker_kind)
+            logger.warning(
+                "Unknown worker kind %r — skipping dispatch",
+                worker_kind,
+                extra={"event": "unknown_worker_kind", "worker_kind": worker_kind},
+            )
             return
 
         workdir = self.worktree_resolver(effect.issue_id)
@@ -83,6 +91,17 @@ class Orchestrator:
             worker.execute(effect, workdir, result_path, prompt_path)
         )
         self._in_flight[task] = effect.issue_id
+        logger.info(
+            "Worker dispatched for issue %s in state %s",
+            effect.issue_id,
+            effect.state,
+            extra={
+                "event": "worker_dispatched",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "worker_kind": worker_kind,
+            },
+        )
 
     def _route_effects(self, effects: list[Effect], pending: list[DispatchWorkerEffect]) -> None:
         """Separate effects: dispatch workers immediately or log errors."""
@@ -90,7 +109,12 @@ class Orchestrator:
             if isinstance(effect, DispatchWorkerEffect):
                 pending.append(effect)
             elif isinstance(effect, ErrorEffect):
-                logger.error("ErrorEffect for issue %r: %s", effect.issue_id, effect.message)
+                logger.error(
+                    "ErrorEffect for issue %r: %s",
+                    effect.issue_id,
+                    effect.message,
+                    extra={"event": "error_effect", "issue_id": effect.issue_id, "error": effect.message},
+                )
 
     async def run(self, root_issue_id: str, initial_effects: list[Effect]) -> None:
         """Drive the orchestrator event loop until the root issue is terminal."""
@@ -105,7 +129,10 @@ class Orchestrator:
 
             # Deadlock protection: nothing running and nothing pending
             if not self._in_flight:
-                logger.warning("Deadlock detected: no tasks in flight and no pending effects. Stopping.")
+                logger.warning(
+                    "Deadlock detected: no tasks in flight and no pending effects. Stopping.",
+                    extra={"event": "deadlock_detected"},
+                )
                 break
 
             # Wait for at least one task to complete
@@ -137,6 +164,9 @@ class Orchestrator:
                         timestamp=ts,
                     )
 
+                old_issues = set(self.state.issues.keys())
+                old_issue_state = self.state.issues[issue_id].state if issue_id in self.state.issues else None
+
                 self.state, new_effects = reduce(
                     self.config,
                     self.state,
@@ -146,6 +176,58 @@ class Orchestrator:
                 )
 
                 self.persistence.save(self.state)
+
+                # Log worker outcome
+                if isinstance(outcome, WorkerSuccess):
+                    logger.info(
+                        "Worker succeeded for issue %s",
+                        issue_id,
+                        extra={
+                            "event": "worker_succeeded",
+                            "issue_id": issue_id,
+                            "result_outcome": outcome.result.get("outcome"),
+                        },
+                    )
+                else:
+                    logger.warning(
+                        "Worker failed for issue %s: %s",
+                        issue_id,
+                        outcome.error,
+                        extra={"event": "worker_failed", "issue_id": issue_id, "error": outcome.error},
+                    )
+
+                # Detect state transition
+                new_issue_state = self.state.issues[issue_id].state if issue_id in self.state.issues else None
+                if old_issue_state and new_issue_state and old_issue_state != new_issue_state:
+                    logger.info(
+                        "Issue %s transitioned from %s to %s",
+                        issue_id,
+                        old_issue_state,
+                        new_issue_state,
+                        extra={
+                            "event": "state_transitioned",
+                            "issue_id": issue_id,
+                            "from_state": old_issue_state,
+                            "to_state": new_issue_state,
+                        },
+                    )
+
+                # Detect new issues (decomposition)
+                new_issues = set(self.state.issues.keys()) - old_issues
+                for new_id in new_issues:
+                    new_issue = self.state.issues[new_id]
+                    logger.info(
+                        "Issue %s created: %s",
+                        new_id,
+                        new_issue.fields.get("title", ""),
+                        extra={
+                            "event": "issue_created",
+                            "issue_id": new_id,
+                            "parent_id": new_issue.decomposed_from,
+                            "title": new_issue.fields.get("title", ""),
+                        },
+                    )
+
                 self._route_effects(new_effects, pending)
 
         # Cancel any remaining in-flight tasks

--- a/src/orca/orchestrator/runner.py
+++ b/src/orca/orchestrator/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import subprocess
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -21,10 +22,13 @@ from orca.engine.types import (
     WorkerResultEvent,
 )
 from orca.orchestrator.branches import BranchMap
+from orca.orchestrator.log import setup_logging
 from orca.orchestrator.persistence import Persistence
 from orca.orchestrator.validation import validate_result
 from orca.orchestrator.worker import ClaudeCodeWorker
 from orca.orchestrator.worktree import WorktreeManager
+
+logger = logging.getLogger(__name__)
 
 
 def parse_task_file(path: Path) -> tuple[str, str]:
@@ -136,6 +140,9 @@ async def run(task_file: Path, branch_name: str) -> None:
     branches = BranchMap(repo_root, branch_name)
     worktree_mgr = WorktreeManager(repo_root, branch_name)
 
+    log_path = repo_root / ".orca" / "runs" / branch_name / "orca.log.jsonl"
+    setup_logging(log_path)
+
     initial_effects: list[Effect] = []
 
     if persistence.exists():
@@ -145,6 +152,11 @@ async def run(task_file: Path, branch_name: str) -> None:
             msg = "Failed to load state from persistence"
             raise RuntimeError(msg)
         branches.load()
+
+        logger.info(
+            "Run resumed",
+            extra={"event": "run_resumed", "branch": branch_name},
+        )
 
         recovered_events, recovered_effects = _recover_effects(
             config, state, branches, worktree_mgr, repo_root, _generate_id, _now
@@ -190,6 +202,16 @@ async def run(task_file: Path, branch_name: str) -> None:
         branches.save()
         persistence.save(state)
 
+        logger.info(
+            "Run started",
+            extra={
+                "event": "run_started",
+                "branch": branch_name,
+                "task_file": str(task_file),
+                "root_issue_id": root_issue_id,
+            },
+        )
+
     # Find root issue ID
     root_issue_id = _find_root_issue(state)
 
@@ -211,7 +233,20 @@ async def run(task_file: Path, branch_name: str) -> None:
         repo_root=repo_root,
     )
 
-    await orchestrator.run(root_issue_id, initial_effects)
+    try:
+        await orchestrator.run(root_issue_id, initial_effects)
+    except Exception:
+        logger.error(
+            "Run failed",
+            extra={"event": "run_failed", "branch": branch_name},
+            exc_info=True,
+        )
+        raise
+
+    logger.info(
+        "Run completed",
+        extra={"event": "run_completed", "branch": branch_name, "root_issue_id": root_issue_id},
+    )
 
 
 def main() -> None:

--- a/src/orca/orchestrator/worker.py
+++ b/src/orca/orchestrator/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -10,6 +11,8 @@ from typing import Any, Protocol
 from orca.engine.types import DispatchWorkerEffect
 from orca.orchestrator.template import render_prompt
 from orca.orchestrator.validation import validate_result
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -76,6 +79,18 @@ class ClaudeCodeWorker:
             cwd=workdir,
         )
 
+        logger.debug(
+            "Subprocess started for issue %s",
+            effect.issue_id,
+            extra={
+                "event": "subprocess_started",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "pid": proc.pid,
+                "workdir": str(workdir),
+            },
+        )
+
         # Write rendered prompt to stdin and close it
         if proc.stdin is not None:
             proc.stdin.write(prompt.encode())
@@ -88,6 +103,18 @@ class ClaudeCodeWorker:
 
         # f. Wait for process, check returncode
         await proc.wait()
+        logger.debug(
+            "Subprocess exited for issue %s with code %s",
+            effect.issue_id,
+            proc.returncode,
+            extra={
+                "event": "subprocess_exited",
+                "issue_id": effect.issue_id,
+                "state": effect.state,
+                "pid": proc.pid,
+                "returncode": proc.returncode,
+            },
+        )
         if proc.returncode != 0:
             return WorkerFailure(error=f"claude exited with non-zero exit code: {proc.returncode}")
 

--- a/tests/orchestrator/test_log.py
+++ b/tests/orchestrator/test_log.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from orca.orchestrator.log import JSONFormatter, setup_logging
+
+
+class TestJSONFormatter:
+    def setup_method(self) -> None:
+        self.formatter = JSONFormatter()
+
+    def test_formats_basic_record(self) -> None:
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello world",
+            args=(),
+            exc_info=None,
+        )
+        output = self.formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "orca.test"
+        assert parsed["message"] == "hello world"
+        assert "timestamp" in parsed
+
+    def test_includes_extra_fields(self) -> None:
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="dispatch",
+            args=(),
+            exc_info=None,
+        )
+        record.event = "worker_dispatched"
+        record.worker_id = "w-123"
+        output = self.formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["event"] == "worker_dispatched"
+        assert parsed["worker_id"] == "w-123"
+
+    def test_excludes_standard_log_record_attrs(self) -> None:
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="/some/path.py",
+            lineno=42,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+        output = self.formatter.format(record)
+        parsed = json.loads(output)
+        assert "pathname" not in parsed
+        assert "lineno" not in parsed
+        assert "args" not in parsed
+        assert "msg" not in parsed
+
+    def test_output_is_single_line(self) -> None:
+        record = logging.LogRecord(
+            name="orca.test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="line1\nline2\nline3",
+            args=(),
+            exc_info=None,
+        )
+        output = self.formatter.format(record)
+        assert "\n" not in output
+        parsed = json.loads(output)
+        assert parsed["message"] == "line1\nline2\nline3"
+
+
+class TestSetupLogging:
+    def teardown_method(self) -> None:
+        logger = logging.getLogger("orca")
+        for handler in logger.handlers[:]:
+            handler.close()
+            logger.removeHandler(handler)
+
+    def test_creates_log_file(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "logs" / "orca.jsonl"
+        setup_logging(log_file)
+        logger = logging.getLogger("orca")
+        logger.info("test message")
+
+        lines = log_file.read_text().strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["message"] == "test message"
+        assert parsed["level"] == "INFO"
+
+    def test_does_not_propagate(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "orca.jsonl"
+        setup_logging(log_file)
+        logger = logging.getLogger("orca")
+        assert logger.propagate is False


### PR DESCRIPTION
## Summary

- **Session sync**: `SessionManifest` + `SessionSync` — periodically render Claude Code transcripts to markdown at `.orca/transcripts/` via `claude-code-log`
- **Structured logging**: `JSONFormatter` + `setup_logging()` — JSONL log file at `.orca/runs/{branch}/orca.log.jsonl` with structured events across runner, orchestrator, and worker

## Log events

| Event | Level | Module |
|-------|-------|--------|
| run_started / run_resumed / run_completed / run_failed | INFO/ERROR | runner |
| worker_dispatched / worker_succeeded / worker_failed | INFO/WARNING | orchestrator |
| state_transitioned / issue_created | INFO | orchestrator |
| deadlock_detected / error_effect | ERROR | orchestrator |
| subprocess_started / subprocess_exited | DEBUG | worker |

## Test plan

- [x] 248 tests pass (25 new)
- [x] ruff lint + format clean
- [x] mypy strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)