### PR TITLE
feat: multi-agent backend — OpenCode + Claude Code per-state

### DIFF
--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -18,6 +18,8 @@ from orca.engine.types import (
     WorkerDef,
 )
 
+_ALLOWED_WORKER_KINDS = {"claude-code", "opencode"}
+
 
 class ConfigValidationError(Exception):
     pass
@@ -163,8 +165,9 @@ def _validate(config: StateMachineConfig) -> None:
     for name, state in config.states.items():
         # Validate worker fields
         if state.worker is not None:
-            if state.worker.kind != "claude-code":
-                msg = f"Worker for state '{name}': kind must be 'claude-code', got '{state.worker.kind}'"
+            if state.worker.kind not in _ALLOWED_WORKER_KINDS:
+                allowed_kinds = sorted(_ALLOWED_WORKER_KINDS)
+                msg = f"Worker for state '{name}': kind must be one of {allowed_kinds}, got '{state.worker.kind}'"
                 raise ConfigValidationError(msg)
             if not state.worker.prompt:
                 msg = f"Worker prompt for state '{name}' must be a non-empty string"

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -96,12 +96,17 @@ def _parse_state(name: str, raw_data: dict[str, Any] | None) -> StateDef:
         result_format: dict[str, ResultFormatField] = {}
         for field_name, field_data in rf_data.items():
             result_format[field_name] = _parse_result_format_field(field_name, field_data)
+        model: str | None = worker_data.get("model")
+        raw_args = worker_data.get("args")
+        args: tuple[str, ...] | None = tuple(str(a) for a in raw_args) if raw_args is not None else None
         worker = WorkerDef(
             kind=kind,
             prompt=prompt,
             result_format=result_format,
             timeout=timeout,
             inactivity_timeout=inactivity_timeout,
+            model=model,
+            args=args,
         )
 
     on: dict[str, OnRule] = {}

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -42,6 +42,8 @@ class WorkerDef:
     result_format: dict[str, ResultFormatField]
     timeout: int | None = None
     inactivity_timeout: int | None = None
+    model: str | None = None
+    args: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orca/orchestrator/__init__.py
+++ b/src/orca/orchestrator/__init__.py
@@ -9,7 +9,9 @@ from orca.orchestrator.session_sync import SessionManifest, SessionSync
 from orca.orchestrator.template import render_prompt
 from orca.orchestrator.validation import validate_result
 from orca.orchestrator.worker import (
-    ClaudeCodeWorker,
+    KIND_REGISTRY,
+    CliAgentWorker,
+    KindConfig,
     Worker,
     WorkerFailure,
     WorkerOutcome,
@@ -19,8 +21,10 @@ from orca.orchestrator.worktree import WorktreeManager
 
 __all__ = [
     "BranchMap",
-    "ClaudeCodeWorker",
+    "CliAgentWorker",
     "JSONFormatter",
+    "KIND_REGISTRY",
+    "KindConfig",
     "Orchestrator",
     "Persistence",
     "SessionManifest",

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -211,7 +211,15 @@ class Orchestrator:
         backoff = 5.0 * (2**failures) if failures > 0 else 0.0
 
         task: asyncio.Task[WorkerOutcome] = asyncio.create_task(
-            self._run_worker_with_backoff(effect, worker, state_def.worker.prompt, backoff, tracking_id)
+            self._run_worker_with_backoff(
+                effect,
+                worker,
+                state_def.worker.prompt,
+                backoff,
+                tracking_id,
+                model=state_def.worker.model,
+                extra_args=state_def.worker.args,
+            )
         )
         self._in_flight[task] = (effect.issue_id, tracking_id)
         logger.info(
@@ -242,6 +250,8 @@ class Orchestrator:
         prompt_template: str,
         backoff: float,
         tracking_id: str,
+        model: str | None = None,
+        extra_args: tuple[str, ...] | None = None,
     ) -> WorkerOutcome:
         """Wait for backoff delay, then run the worker."""
         if backoff > 0:
@@ -252,10 +262,16 @@ class Orchestrator:
                 extra={"event": "worker_backoff", "issue_id": effect.issue_id, "backoff_seconds": backoff},
             )
             await asyncio.sleep(backoff)
-        return await self._run_worker(effect, worker, prompt_template, tracking_id)
+        return await self._run_worker(effect, worker, prompt_template, tracking_id, model=model, extra_args=extra_args)
 
     async def _run_worker(
-        self, effect: DispatchWorkerEffect, worker: Worker, prompt_template: str, tracking_id: str
+        self,
+        effect: DispatchWorkerEffect,
+        worker: Worker,
+        prompt_template: str,
+        tracking_id: str,
+        model: str | None = None,
+        extra_args: tuple[str, ...] | None = None,
     ) -> WorkerOutcome:
         """Create worktree if needed, then execute the worker."""
         workdir = await self._ensure_worktree(effect.issue_id)
@@ -313,6 +329,8 @@ class Orchestrator:
                 inactivity_timeout,
                 pty_session=tmux_session,
                 env=worker_env,
+                model=model,
+                extra_args=list(extra_args) if extra_args else None,
             )
         finally:
             # Final scrollback save before killing the session

--- a/src/orca/orchestrator/runner.py
+++ b/src/orca/orchestrator/runner.py
@@ -30,7 +30,7 @@ from orca.orchestrator.config_types import SlackConfig, parse_integrations
 from orca.orchestrator.log import setup_logging
 from orca.orchestrator.persistence import Persistence
 from orca.orchestrator.validation import validate_result
-from orca.orchestrator.worker import ClaudeCodeWorker
+from orca.orchestrator.worker import KIND_REGISTRY, CliAgentWorker
 from orca.orchestrator.worktree import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -355,7 +355,7 @@ async def run(
         logger.info("Slack HITL MCP server started", extra={"event": "slack_mcp_started", "url": slack_mcp_url})
 
     # Set up worker, session sync, and orchestrator
-    worker = ClaudeCodeWorker(repo_root)
+    worker = CliAgentWorker(repo_root, KIND_REGISTRY["claude-code"])
 
     from orca.orchestrator.orchestrator import Orchestrator
     from orca.orchestrator.session_sync import SessionSync

--- a/src/orca/orchestrator/runner.py
+++ b/src/orca/orchestrator/runner.py
@@ -354,8 +354,8 @@ async def run(
         slack_mcp_proc, slack_mcp_url = await _start_slack_mcp_server(integrations.slack)
         logger.info("Slack HITL MCP server started", extra={"event": "slack_mcp_started", "url": slack_mcp_url})
 
-    # Set up worker, session sync, and orchestrator
-    worker = CliAgentWorker(repo_root, KIND_REGISTRY["claude-code"])
+    # Set up workers, session sync, and orchestrator
+    workers = {name: CliAgentWorker(repo_root, kc) for name, kc in KIND_REGISTRY.items()}
 
     from orca.orchestrator.orchestrator import Orchestrator
     from orca.orchestrator.session_sync import SessionSync
@@ -369,7 +369,7 @@ async def run(
         root_branch=branch_name,
         persistence=persistence,
         branches=branches,
-        workers={"claude-code": worker},
+        workers=workers,
         generate_id=_generate_id,
         now=_now,
         worktree_mgr=worktree_mgr,

--- a/src/orca/orchestrator/worker.py
+++ b/src/orca/orchestrator/worker.py
@@ -48,14 +48,42 @@ class Worker(Protocol):
         inactivity_timeout: int | None = None,
         pty_session: PtySession | None = None,
         env: dict[str, str] | None = None,
+        model: str | None = None,
+        extra_args: list[str] | None = None,
     ) -> WorkerOutcome: ...
 
 
-class ClaudeCodeWorker:
-    """Spawns claude CLI as a subprocess, streams output to a session log, reads/validates result."""
+@dataclass(frozen=True)
+class KindConfig:
+    """Describes how to invoke a specific CLI agent."""
 
-    def __init__(self, repo_root: Path) -> None:
+    bin: str
+    prompt_via: str  # "stdin" or "arg"
+    subcommand: str | None = None
+    default_args: tuple[str, ...] = ()
+
+
+KIND_REGISTRY: dict[str, KindConfig] = {
+    "claude-code": KindConfig(
+        bin="claude",
+        prompt_via="stdin",
+        default_args=("--dangerously-skip-permissions", "--max-turns", "50"),
+    ),
+    "opencode": KindConfig(
+        bin="opencode",
+        prompt_via="arg",
+        subcommand="run",
+        default_args=(),
+    ),
+}
+
+
+class CliAgentWorker:
+    """Spawns a CLI agent as a subprocess, streams output to a session log, reads/validates result."""
+
+    def __init__(self, repo_root: Path, kind_config: KindConfig) -> None:
         self._repo_root = repo_root
+        self._kind_config = kind_config
 
     async def execute(
         self,
@@ -66,6 +94,8 @@ class ClaudeCodeWorker:
         inactivity_timeout: int | None = None,
         pty_session: PtySession | None = None,
         env: dict[str, str] | None = None,
+        model: str | None = None,
+        extra_args: list[str] | None = None,
     ) -> WorkerOutcome:
         assert pty_session is not None, "pty_session is required"
 
@@ -78,12 +108,24 @@ class ClaudeCodeWorker:
         else:
             prompt = ""
 
-        # c. Spawn claude in a tmux session — prompt piped via file
+        # c. Build command
+        cmd_parts: list[str] = [self._kind_config.bin]
+        if self._kind_config.subcommand:
+            cmd_parts.append(self._kind_config.subcommand)
+        if self._kind_config.prompt_via == "arg":
+            cmd_parts.append(prompt)
+        cmd_parts.extend(self._kind_config.default_args)
+        if extra_args:
+            cmd_parts.extend(extra_args)
+        if model:
+            cmd_parts.extend(["-m", model])
+
+        # d. Spawn in tmux session
         await pty_session.spawn(
-            "claude",
-            ["--dangerously-skip-permissions", "--max-turns", "50"],
+            cmd_parts[0],
+            cmd_parts[1:],
             cwd=workdir,
-            stdin_data=prompt.encode(),
+            stdin_data=prompt.encode() if self._kind_config.prompt_via == "stdin" else None,
             env=env,
         )
 
@@ -99,7 +141,7 @@ class ClaudeCodeWorker:
             },
         )
 
-        # d. Poll for result file or session exit
+        # e. Poll for result file or session exit
         effective_timeout = float(inactivity_timeout) if inactivity_timeout is not None else _INACTIVITY_TIMEOUT
         elapsed = 0.0
         result_detected_at: float | None = None

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -538,7 +538,7 @@ states:
     terminal: true
 initial: todo
 """
-        with pytest.raises(ConfigValidationError, match="kind must be 'claude-code'"):
+        with pytest.raises(ConfigValidationError, match="kind must be one of"):
             parse_config(yaml_str)
 
     def test_missing_prompt_rejected(self) -> None:
@@ -664,3 +664,29 @@ initial: todo
         assert worker is not None
         assert worker.model is None
         assert worker.args is None
+
+    def test_opencode_kind_accepted(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      kind: opencode
+      prompt: prompts/work.md
+      model: anthropic/claude-sonnet-4-5
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.states["todo"].worker
+        assert worker is not None
+        assert worker.kind == "opencode"

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -586,3 +586,81 @@ initial: todo
 """
         with pytest.raises(ConfigValidationError, match="timeout"):
             parse_config(yaml_str)
+
+    def test_parse_worker_with_model(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      kind: claude-code
+      prompt: prompts/work.md
+      model: anthropic/claude-sonnet-4-5
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.states["todo"].worker
+        assert worker is not None
+        assert worker.model == "anthropic/claude-sonnet-4-5"
+
+    def test_parse_worker_with_args(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      kind: claude-code
+      prompt: prompts/work.md
+      args: ["--max-turns", "100"]
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.states["todo"].worker
+        assert worker is not None
+        assert worker.args == ("--max-turns", "100")
+
+    def test_parse_worker_model_and_args_default_none(self) -> None:
+        yaml_str = """\
+issue:
+  fields: {}
+states:
+  todo:
+    worker:
+      kind: claude-code
+      prompt: prompts/work.md
+      result_format:
+        outcome:
+          type: enum
+          values: [go]
+          description: d
+    on:
+      go: done
+  done:
+    terminal: true
+initial: todo
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.states["todo"].worker
+        assert worker is not None
+        assert worker.model is None
+        assert worker.args is None

--- a/tests/orchestrator/test_integration.py
+++ b/tests/orchestrator/test_integration.py
@@ -42,6 +42,8 @@ class ScriptedWorker:
         inactivity_timeout: int | None = None,
         pty_session: Any = None,
         env: dict[str, str] | None = None,
+        model: str | None = None,
+        extra_args: list[str] | None = None,
     ) -> WorkerOutcome:
         key = (effect.issue_id, effect.state)
         self.calls.append(key)

--- a/tests/orchestrator/test_orchestrator.py
+++ b/tests/orchestrator/test_orchestrator.py
@@ -42,6 +42,8 @@ class MockWorker:
         inactivity_timeout: int | None = None,
         pty_session: Any = None,
         env: dict[str, str] | None = None,
+        model: str | None = None,
+        extra_args: list[str] | None = None,
     ) -> WorkerOutcome:
         self.calls.append((effect.issue_id, effect.state))
         return self.outcomes.get(effect.state, WorkerFailure(error="no mock"))
@@ -169,6 +171,8 @@ class TestOrchestrator:
                 inactivity_timeout: int | None = None,
                 pty_session: Any = None,
                 env: dict[str, str] | None = None,
+                model: str | None = None,
+                extra_args: list[str] | None = None,
             ) -> WorkerOutcome:
                 self.calls.append((effect.issue_id, effect.state))
                 count = call_count.get(effect.state, 0)

--- a/tests/orchestrator/test_worker.py
+++ b/tests/orchestrator/test_worker.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from orca.engine.types import DispatchWorkerEffect
-from orca.orchestrator.worker import ClaudeCodeWorker, WorkerFailure, WorkerSuccess
+from orca.orchestrator.worker import KIND_REGISTRY, CliAgentWorker, KindConfig, WorkerFailure, WorkerSuccess
 
 
 def _make_effect(state: str = "implementing") -> DispatchWorkerEffect:
@@ -90,7 +90,79 @@ def _make_mock_pty(
 
 
 @pytest.mark.asyncio()
-class TestClaudeCodeWorker:
+class TestCommandAssembly:
+    """Verify CliAgentWorker builds the correct CLI command per kind."""
+
+    async def _spawn_and_capture(
+        self,
+        kind_config: KindConfig,
+        tmp_path: Path,
+        model: str | None = None,
+        extra_args: list[str] | None = None,
+    ) -> tuple[str, list[str], bytes | None]:
+        """Run worker with a mock pty that captures spawn args. Returns (cmd, args, stdin_data)."""
+        effect = _make_effect()
+        result_path = tmp_path / "result.json"
+        prompt_path = tmp_path / "prompt.md"
+        prompt_path.write_text("Do the thing")
+        valid_result: dict[str, Any] = {"outcome": "done", "summary": "All done"}
+        pty = _make_mock_pty(exit_code=0, write_result=valid_result, result_path=result_path)
+
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=kind_config)
+        await worker.execute(
+            effect,
+            tmp_path,
+            result_path,
+            prompt_path,
+            pty_session=pty,
+            model=model,
+            extra_args=extra_args,
+        )
+        call_args = pty.spawn.call_args
+        return call_args[0][0], list(call_args[0][1]), call_args[1].get("stdin_data")
+
+    async def test_claude_code_command(self, tmp_path: Path) -> None:
+        kind_config = KIND_REGISTRY["claude-code"]
+        cmd, args, stdin_data = await self._spawn_and_capture(kind_config, tmp_path)
+        assert cmd == "claude"
+        assert "--dangerously-skip-permissions" in args
+        assert "--max-turns" in args
+        assert "50" in args
+        assert stdin_data is not None
+        assert len(stdin_data) > 0
+
+    async def test_opencode_command(self, tmp_path: Path) -> None:
+        kind_config = KIND_REGISTRY["opencode"]
+        cmd, args, stdin_data = await self._spawn_and_capture(
+            kind_config, tmp_path, model="anthropic/claude-sonnet-4-5"
+        )
+        assert cmd == "opencode"
+        assert args[0] == "run"
+        # Prompt is the second arg (positional after subcommand)
+        assert len(args[1]) > 0  # prompt text
+        assert "-m" in args
+        assert "anthropic/claude-sonnet-4-5" in args
+        assert stdin_data is None
+
+    async def test_extra_args_appended(self, tmp_path: Path) -> None:
+        kind_config = KIND_REGISTRY["claude-code"]
+        cmd, args, stdin_data = await self._spawn_and_capture(
+            kind_config,
+            tmp_path,
+            extra_args=["--verbose"],
+        )
+        assert "--verbose" in args
+        # Default args still present
+        assert "--dangerously-skip-permissions" in args
+
+    async def test_model_ignored_when_none(self, tmp_path: Path) -> None:
+        kind_config = KIND_REGISTRY["claude-code"]
+        cmd, args, stdin_data = await self._spawn_and_capture(kind_config, tmp_path, model=None)
+        assert "-m" not in args
+
+
+@pytest.mark.asyncio()
+class TestCliAgentWorker:
     async def test_result_detected_while_alive(self, tmp_path: Path) -> None:
         """Result file appears while session is alive -> WorkerSuccess, session killed."""
         effect = _make_effect()
@@ -107,7 +179,7 @@ class TestClaudeCodeWorker:
             write_after_spawns=1,
         )
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         outcome = await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty)
 
         assert isinstance(outcome, WorkerSuccess)
@@ -124,7 +196,7 @@ class TestClaudeCodeWorker:
         # Session stays alive forever (high alive_count), no result written
         pty = _make_polling_pty(alive_count=9999)
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         # Use inactivity_timeout=0 for immediate timeout
         outcome = await worker.execute(
             effect, tmp_path, result_path, prompt_path, inactivity_timeout=0, pty_session=pty
@@ -142,7 +214,7 @@ class TestClaudeCodeWorker:
         # Session exits immediately (alive_count=0), no result written
         pty = _make_polling_pty(alive_count=0)
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         outcome = await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty)
 
         assert isinstance(outcome, WorkerFailure)
@@ -158,7 +230,7 @@ class TestClaudeCodeWorker:
         # Session exits immediately, result written on spawn
         pty = _make_polling_pty(alive_count=0, write_result=invalid_result, result_path=result_path)
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         outcome = await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty)
 
         assert isinstance(outcome, WorkerFailure)
@@ -178,7 +250,7 @@ class TestClaudeCodeWorker:
         # Session exits immediately, writes nothing new — stale file was deleted by worker
         pty = _make_polling_pty(alive_count=0)
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         outcome = await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty)
 
         assert isinstance(outcome, WorkerFailure)
@@ -194,7 +266,7 @@ class TestClaudeCodeWorker:
         # Session exits immediately (alive_count=0), result written on spawn
         pty = _make_polling_pty(alive_count=0, write_result=valid_result, result_path=result_path)
 
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         outcome = await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty)
 
         assert isinstance(outcome, WorkerSuccess)
@@ -212,7 +284,7 @@ class TestClaudeCodeWorker:
         pty = _make_mock_pty(exit_code=0, write_result=valid_result, result_path=result_path)
 
         env = {"SLACK_HITL_MCP_URL": "http://127.0.0.1:9999/sse"}
-        worker = ClaudeCodeWorker(repo_root=tmp_path)
+        worker = CliAgentWorker(repo_root=tmp_path, kind_config=KIND_REGISTRY["claude-code"])
         await worker.execute(effect, tmp_path, result_path, prompt_path, pty_session=pty, env=env)
 
         # Verify env was passed to spawn


### PR DESCRIPTION
## Summary

- Replace hardcoded `ClaudeCodeWorker` with generic `CliAgentWorker` driven by a `KindConfig` registry
- Add `model` and `args` fields to `WorkerDef` for per-state configuration
- Accept `opencode` as a valid worker kind alongside `claude-code`
- Build all registered worker kinds at startup from `KIND_REGISTRY`

**Example usage in orca.yml:**
```yaml
states:
  scoping:
    worker:
      kind: opencode
      model: anthropic/claude-sonnet-4-5
      prompt: prompts/scoping.md
  implement:
    worker:
      kind: claude-code
      args: ["--max-turns", "100"]
      prompt: prompts/implement.md
```

## Test plan

- [x] New tests for `model` and `args` config parsing (3 tests)
- [x] New test for `opencode` kind acceptance
- [x] New `TestCommandAssembly` class verifying CLI command generation for both kinds (4 tests)
- [x] All existing worker tests updated and passing under `CliAgentWorker`
- [x] 330 tests pass, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)