### PR TITLE
fix: detect invalid result.json, send correction to worker, show in TUI

### DIFF
--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -331,6 +331,8 @@ class Orchestrator:
                 env=worker_env,
                 model=model,
                 extra_args=list(extra_args) if extra_args else None,
+                session_manifest=self._session_sync.manifest if self._session_sync else None,
+                session_id=tracking_id,
             )
         finally:
             # Final scrollback save before killing the session

--- a/src/orca/orchestrator/pty_session.py
+++ b/src/orca/orchestrator/pty_session.py
@@ -114,6 +114,23 @@ class TmuxSession:
                 return -1
         return 0
 
+    def send_keys(self, text: str) -> bool:
+        """Send literal text to the tmux session pane followed by Enter. Returns True on success."""
+        if not self.alive:
+            return False
+        result = subprocess.run(
+            ["tmux", "send-keys", "-t", self._session_name, "-l", text],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return False
+        # Send Enter to submit the message
+        subprocess.run(
+            ["tmux", "send-keys", "-t", self._session_name, "Enter"],
+            capture_output=True,
+        )
+        return True
+
     def kill(self) -> None:
         """Kill the tmux session."""
         subprocess.run(

--- a/src/orca/orchestrator/session_sync.py
+++ b/src/orca/orchestrator/session_sync.py
@@ -62,6 +62,19 @@ class SessionManifest:
             logger.warning("mark_completed: session %s not found in manifest", session_id)
         self._write(entries)
 
+    def update_result_error(self, session_id: str, error: str | None) -> None:
+        """Store or clear a result validation error on a session entry."""
+        entries = self.read()
+        for entry in entries:
+            if entry["session_id"] == session_id:
+                if error:
+                    entry["result_error"] = error
+                else:
+                    entry.pop("result_error", None)
+                self._write(entries)
+                return
+        logger.warning("update_result_error: session %s not found in manifest", session_id)
+
     def mark_orphans_completed(self, completed_at: str) -> int:
         """Mark all incomplete sessions as completed (orphans from a crashed run)."""
         entries = self.read()

--- a/src/orca/orchestrator/worker.py
+++ b/src/orca/orchestrator/worker.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 
 from orca.engine.types import DispatchWorkerEffect
 from orca.orchestrator.pty_session import PtySession
+from orca.orchestrator.session_sync import SessionManifest
 from orca.orchestrator.template import render_prompt
 from orca.orchestrator.validation import validate_result
 
@@ -50,6 +51,8 @@ class Worker(Protocol):
         env: dict[str, str] | None = None,
         model: str | None = None,
         extra_args: list[str] | None = None,
+        session_manifest: SessionManifest | None = None,
+        session_id: str | None = None,
     ) -> WorkerOutcome: ...
 
 
@@ -78,6 +81,17 @@ KIND_REGISTRY: dict[str, KindConfig] = {
 }
 
 
+def _build_correction_message(error: str, result_format: dict[str, Any], result_path: Path) -> str:
+    """Build a message telling the worker to fix its invalid result.json."""
+    format_json = json.dumps(result_format, indent=2)
+    return (
+        f"URGENT: Your result file at {result_path} is INVALID. "
+        f"Error: {error}. "
+        f"You MUST rewrite the file with the correct format. "
+        f"Required schema: {format_json}"
+    )
+
+
 class CliAgentWorker:
     """Spawns a CLI agent as a subprocess, streams output to a session log, reads/validates result."""
 
@@ -96,6 +110,8 @@ class CliAgentWorker:
         env: dict[str, str] | None = None,
         model: str | None = None,
         extra_args: list[str] | None = None,
+        session_manifest: SessionManifest | None = None,
+        session_id: str | None = None,
     ) -> WorkerOutcome:
         assert pty_session is not None, "pty_session is required"
 
@@ -146,6 +162,8 @@ class CliAgentWorker:
         elapsed = 0.0
         result_detected_at: float | None = None
         result_detected_while_alive = False
+        last_validation_error: str | None = None
+        correction_sent = False
 
         while True:
             await asyncio.sleep(_POLL_INTERVAL)
@@ -159,11 +177,38 @@ class CliAgentWorker:
                     if error is None:
                         result_detected_at = elapsed
                         result_detected_while_alive = pty_session.alive
+                        last_validation_error = None
+                        if session_manifest and session_id:
+                            session_manifest.update_result_error(session_id, None)
                         logger.info(
                             "Valid result detected for issue %s — grace period started",
                             effect.issue_id,
                             extra={"event": "result_detected", "issue_id": effect.issue_id},
                         )
+                    else:
+                        last_validation_error = error
+                        logger.warning(
+                            "Invalid result.json for issue %s: %s",
+                            effect.issue_id,
+                            error,
+                            extra={
+                                "event": "result_validation_failed",
+                                "issue_id": effect.issue_id,
+                                "validation_error": error,
+                            },
+                        )
+                        if session_manifest and session_id:
+                            session_manifest.update_result_error(session_id, error)
+                        # Send correction message to the worker (once)
+                        if not correction_sent and pty_session.alive:
+                            correction_msg = _build_correction_message(error, effect.result_format, result_path)
+                            if pty_session.send_keys(correction_msg):
+                                correction_sent = True
+                                logger.info(
+                                    "Sent result correction message to worker for issue %s",
+                                    effect.issue_id,
+                                    extra={"event": "correction_sent", "issue_id": effect.issue_id},
+                                )
                 except (json.JSONDecodeError, OSError):
                     pass
 
@@ -196,10 +241,14 @@ class CliAgentWorker:
 
             # Timeout — no result produced in time
             if result_detected_at is None and elapsed >= effective_timeout:
+                error_detail = f"no valid result after {int(effective_timeout)}s"
+                if last_validation_error:
+                    error_detail += f" (result.json invalid: {last_validation_error})"
                 logger.warning(
-                    "Worker for issue %s timed out with no result",
+                    "Worker for issue %s timed out: %s",
                     effect.issue_id,
+                    error_detail,
                     extra={"event": "worker_timeout", "issue_id": effect.issue_id},
                 )
                 pty_session.kill()
-                return WorkerFailure(error=f"no valid result after {int(effective_timeout)}s")
+                return WorkerFailure(error=error_detail)

--- a/src/orca/tui/widgets/issue_tree.py
+++ b/src/orca/tui/widgets/issue_tree.py
@@ -210,10 +210,18 @@ class IssueTree(Tree[str]):
         if is_active:
             frame = _SPINNER[self._tick % len(_SPINNER)]
             elapsed = _elapsed_str(str(session.get("started_at", "")))
-            label.append(f"{frame} ", style="bold yellow")
-            label.append(state_name)
-            if elapsed:
-                label.append(f" {elapsed}", style="dim")
+            result_error = session.get("result_error")
+            if result_error:
+                label.append(f"{frame} ", style="bold red")
+                label.append(state_name)
+                if elapsed:
+                    label.append(f" {elapsed}", style="dim")
+                label.append("  invalid result", style="bold red")
+            else:
+                label.append(f"{frame} ", style="bold yellow")
+                label.append(state_name)
+                if elapsed:
+                    label.append(f" {elapsed}", style="dim")
             # Visit count badge
             if visit_counts and visit_counts.get(state_name, 0) > 1:
                 label.append(f"  visit {visit_counts[state_name]}", style="dim")
@@ -336,8 +344,13 @@ class IssueTree(Tree[str]):
                 session_id = str(session.get("session_id", ""))
                 node.add_leaf(run_label, data=f"session:{session_id}")
 
-                # Add inline failure error below the last completed session for a failed state
-                if is_last_completed and sname in failed_states and failure_errors and sname in failure_errors:
+                # Add inline error: validation error for active sessions, failure error for completed
+                result_error = session.get("result_error")
+                if result_error and session.get("completed_at") is None:
+                    err_label = Text()
+                    err_label.append(f"  {result_error}", style="dim red")
+                    node.add_leaf(err_label, data=f"error:{session_id}")
+                elif is_last_completed and sname in failed_states and failure_errors and sname in failure_errors:
                     err_label = Text()
                     err_label.append(f"  {failure_errors[sname]}", style="dim red")
                     node.add_leaf(err_label, data=f"error:{session_id}")

--- a/tests/orchestrator/test_integration.py
+++ b/tests/orchestrator/test_integration.py
@@ -44,6 +44,8 @@ class ScriptedWorker:
         env: dict[str, str] | None = None,
         model: str | None = None,
         extra_args: list[str] | None = None,
+        session_manifest: Any = None,
+        session_id: str | None = None,
     ) -> WorkerOutcome:
         key = (effect.issue_id, effect.state)
         self.calls.append(key)

--- a/tests/orchestrator/test_orchestrator.py
+++ b/tests/orchestrator/test_orchestrator.py
@@ -44,6 +44,8 @@ class MockWorker:
         env: dict[str, str] | None = None,
         model: str | None = None,
         extra_args: list[str] | None = None,
+        session_manifest: Any = None,
+        session_id: str | None = None,
     ) -> WorkerOutcome:
         self.calls.append((effect.issue_id, effect.state))
         return self.outcomes.get(effect.state, WorkerFailure(error="no mock"))
@@ -173,6 +175,8 @@ class TestOrchestrator:
                 env: dict[str, str] | None = None,
                 model: str | None = None,
                 extra_args: list[str] | None = None,
+                session_manifest: Any = None,
+                session_id: str | None = None,
             ) -> WorkerOutcome:
                 self.calls.append((effect.issue_id, effect.state))
                 count = call_count.get(effect.state, 0)


### PR DESCRIPTION
## Summary
- Workers that wrote `result.json` with wrong outcome values were silently timed out because `validate_result` errors were never logged or acted on
- Now logs validation errors, sends a correction message to the worker session via `tmux send-keys` so it can fix the file, and shows "invalid result" badge in TUI
- Timeout failure message now includes the validation error detail (e.g. `no valid result after 600s (result.json invalid: Invalid outcome 'done', expected one of ['ready', 'needs_revision'])`)

## Test plan
- [x] All 346 tests pass
- [x] ruff + mypy clean
- [ ] Manual test: run a workflow where worker writes wrong outcome value — verify correction message appears in session, TUI shows red badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)