### PR TITLE
feat: typed issue flows for decomposition

### DIFF
--- a/docs/superpowers/plans/2026-03-26-typed-issue-flows.md
+++ b/docs/superpowers/plans/2026-03-26-typed-issue-flows.md
@@ -1,0 +1,1860 @@
+# Typed Issue Flows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add issue types to the state machine so decomposed children can follow different flows than their parent.
+
+**Architecture:** Replace the single flat `StateMachineConfig` (one `initial`, one `states` dict, one `issue_fields`) with a `types` map where each type defines its own fields, initial state, and state machine. The `OnDecompose` rule gains a `child_type` default, and workers can override the type per-child. Queue keys change from `state_name` to `(type, state)`.
+
+**Tech Stack:** Python 3.12, dataclasses, PyYAML, pytest, ruff, mypy
+
+---
+
+## File Map
+
+- **Modify:** `src/orca/engine/types.py` — Add `TypeDef`, `type` field on `Issue`, `issue_type` on `DispatchWorkerEffect`, change `StateMachineConfig` shape, update `State.worker_queues` key type
+- **Modify:** `src/orca/engine/config.py` — Parse `types`/`root_type` from YAML, validate per-type state machines, validate `child_type` references
+- **Modify:** `src/orca/engine/dispatch.py` — Type-aware state lookups, `(type, state)` queue keys
+- **Modify:** `src/orca/engine/reducer.py` — Type-aware state lookups, type-aware decomposition, type-aware field merging
+- **Modify:** `src/orca/engine/formatting.py` — Show `[type:state]` in ASCII tree
+- **Modify:** `src/orca/orchestrator/orchestrator.py` — Use `issue_type` from effect for state lookups
+- **Modify:** `src/orca/orchestrator/runner.py` — Use `config.root_type` for root issue creation, type-aware `build_result_format`/`_recover_effects`
+- **Modify:** `tests/engine/conftest.py` — Update fixture configs to typed format
+- **Modify:** `tests/engine/test_config.py` — Update all config tests for typed format
+- **Modify:** `tests/engine/test_scenario_decompose.py` — Update decompose tests for typed children
+- **Modify:** Multiple other test files that use `config.states` or `config.initial` directly
+
+---
+
+### Task 1: Add `TypeDef` and reshape `StateMachineConfig` in types.py
+
+**Files:**
+- Modify: `src/orca/engine/types.py`
+- Test: `tests/engine/test_types.py`
+
+- [ ] **Step 1: Write failing test for TypeDef and new StateMachineConfig shape**
+
+In `tests/engine/test_types.py`, add:
+
+```python
+from orca.engine.types import TypeDef, StateMachineConfig, FieldDef, StateDef
+
+
+class TestTypeDef:
+    def test_type_def_holds_fields_initial_states(self) -> None:
+        td = TypeDef(
+            fields={"title": FieldDef(type="string", description="t")},
+            initial="todo",
+            states={"todo": StateDef(terminal=True)},
+        )
+        assert td.initial == "todo"
+        assert "title" in td.fields
+        assert "todo" in td.states
+
+
+class TestStateMachineConfigWithTypes:
+    def test_config_has_root_type_and_types(self) -> None:
+        td = TypeDef(
+            fields={},
+            initial="done",
+            states={"done": StateDef(terminal=True)},
+        )
+        cfg = StateMachineConfig(
+            root_type="epic",
+            types={"epic": td},
+            max_hops=None,
+            max_worker_retries=5,
+        )
+        assert cfg.root_type == "epic"
+        assert "epic" in cfg.types
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_types.py::TestTypeDef -v`
+Expected: FAIL — `TypeDef` does not exist, `StateMachineConfig` has wrong fields
+
+- [ ] **Step 3: Add TypeDef, reshape StateMachineConfig, add child_type to OnDecompose**
+
+In `src/orca/engine/types.py`:
+
+Add `TypeDef` after `StateDef`:
+
+```python
+@dataclass(frozen=True)
+class TypeDef:
+    fields: dict[str, FieldDef]
+    initial: str
+    states: dict[str, StateDef]
+```
+
+Replace `StateMachineConfig` with:
+
+```python
+@dataclass(frozen=True)
+class StateMachineConfig:
+    root_type: str
+    types: dict[str, TypeDef]
+    max_hops: int | None = None
+    max_worker_retries: int = 5
+```
+
+Add `child_type` to `OnDecompose`:
+
+```python
+@dataclass(frozen=True)
+class OnDecompose:
+    child_type: str | None = None
+    then: str | None = None
+```
+
+Add `type` field to `Issue` (first field, before `fields`):
+
+```python
+@dataclass
+class Issue:
+    type: str
+    fields: dict[str, Any]
+    state: str
+    worker_active: bool
+    decomposed_from: str | None
+    depends_on: list[str]
+    event_log: list[EventLogEntry]
+    visit_counts: dict[str, int] = field(default_factory=dict)
+    hop_count: int = 0
+    failure_count: int = 0
+```
+
+Update `Issue.to_dict` to include `"type": self.type`.
+
+Update `Issue.from_dict` to read `type=data["type"]`.
+
+Add `issue_type` field to `DispatchWorkerEffect`:
+
+```python
+@dataclass(frozen=True)
+class DispatchWorkerEffect:
+    issue_id: str
+    issue_type: str
+    state: str
+    result_format: dict[str, Any]
+    issue: dict[str, Any]
+```
+
+Change `State.worker_queues` key type from `str` to a serializable format. Since dict keys must be strings in JSON, use `str` keys with format `"{type}:{state}"`:
+
+```python
+@dataclass
+class State:
+    issues: dict[str, Issue]
+    worker_queues: dict[str, list[str]]  # key = "{type}:{state}"
+```
+
+(The key format changes but the type annotation stays `dict[str, list[str]]` for JSON compatibility. The semantic change is in how keys are constructed.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_types.py::TestTypeDef tests/engine/test_types.py::TestStateMachineConfigWithTypes -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orca/engine/types.py tests/engine/test_types.py
+git commit -m "feat: add TypeDef, reshape StateMachineConfig for typed issue flows"
+```
+
+---
+
+### Task 2: Add helper methods to StateMachineConfig for type-aware lookups
+
+**Files:**
+- Modify: `src/orca/engine/types.py`
+- Test: `tests/engine/test_types.py`
+
+To avoid scattering `config.types[issue.type].states[issue.state]` everywhere, add helper methods on `StateMachineConfig`. Since it's frozen, these are read-only methods.
+
+- [ ] **Step 1: Write failing test**
+
+In `tests/engine/test_types.py`, add:
+
+```python
+class TestConfigHelpers:
+    def _make_config(self) -> StateMachineConfig:
+        from orca.engine.types import WorkerDef, EnumFieldDef, OnTransition
+
+        worker = WorkerDef(
+            kind="claude-code",
+            prompt="p.md",
+            result_format={"outcome": EnumFieldDef(values=["done"], description="d")},
+        )
+        epic = TypeDef(
+            fields={"title": FieldDef(type="string", description="t")},
+            initial="todo",
+            states={
+                "todo": StateDef(worker=worker, on={"done": OnTransition(target="done")}),
+                "done": StateDef(terminal=True),
+            },
+        )
+        return StateMachineConfig(root_type="epic", types={"epic": epic})
+
+    def test_get_type_def(self) -> None:
+        cfg = self._make_config()
+        td = cfg.get_type("epic")
+        assert td.initial == "todo"
+
+    def test_get_state_def(self) -> None:
+        cfg = self._make_config()
+        sd = cfg.get_state("epic", "todo")
+        assert sd.worker is not None
+
+    def test_get_state_def_unknown_type_raises(self) -> None:
+        cfg = self._make_config()
+        with pytest.raises(KeyError):
+            cfg.get_state("unknown", "todo")
+
+    def test_root_type_def(self) -> None:
+        cfg = self._make_config()
+        td = cfg.root_type_def
+        assert td.initial == "todo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_types.py::TestConfigHelpers -v`
+Expected: FAIL — methods don't exist
+
+- [ ] **Step 3: Add helper methods to StateMachineConfig**
+
+In `src/orca/engine/types.py`, add methods to `StateMachineConfig`:
+
+```python
+@dataclass(frozen=True)
+class StateMachineConfig:
+    root_type: str
+    types: dict[str, TypeDef]
+    max_hops: int | None = None
+    max_worker_retries: int = 5
+
+    def get_type(self, type_name: str) -> TypeDef:
+        return self.types[type_name]
+
+    def get_state(self, type_name: str, state_name: str) -> StateDef:
+        return self.types[type_name].states[state_name]
+
+    @property
+    def root_type_def(self) -> TypeDef:
+        return self.types[self.root_type]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_types.py::TestConfigHelpers -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orca/engine/types.py tests/engine/test_types.py
+git commit -m "feat: add helper methods to StateMachineConfig for type-aware lookups"
+```
+
+---
+
+### Task 3: Update config parser for typed format
+
+**Files:**
+- Modify: `src/orca/engine/config.py`
+- Test: `tests/engine/test_config.py`
+
+- [ ] **Step 1: Write failing test for multi-type config parsing**
+
+In `tests/engine/test_config.py`, add a new test class:
+
+```python
+class TestParseTypedConfig:
+    TYPED_YAML = """\
+root_type: epic
+max_hops: 15
+
+types:
+  epic:
+    fields:
+      title: {type: string, description: "Title"}
+      scope: {type: string, description: "Scope"}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: prompts/scope.md
+          result_format:
+            outcome:
+              type: enum
+              values: [ready, decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          ready: done
+          decompose:
+            action: decompose
+            child_type: task
+            then: done
+      done:
+        terminal: true
+
+  task:
+    fields:
+      title: {type: string, description: "Title"}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: prompts/impl.md
+          result_format:
+            outcome:
+              type: enum
+              values: [done]
+              description: d
+        on:
+          done: done
+      done:
+        terminal: true
+"""
+
+    def test_root_type(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.root_type == "epic"
+
+    def test_types_parsed(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert set(cfg.types.keys()) == {"epic", "task"}
+
+    def test_epic_fields(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert "title" in cfg.types["epic"].fields
+        assert "scope" in cfg.types["epic"].fields
+
+    def test_task_initial(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.types["task"].initial == "implementing"
+
+    def test_decompose_child_type(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        rule = cfg.types["epic"].states["scoping"].on["decompose"]
+        assert isinstance(rule, OnDecompose)
+        assert rule.child_type == "task"
+
+    def test_max_hops(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.max_hops == 15
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_config.py::TestParseTypedConfig -v`
+Expected: FAIL — parser doesn't understand `types` key
+
+- [ ] **Step 3: Rewrite config parser for typed format**
+
+In `src/orca/engine/config.py`:
+
+Update `_parse_on_rule` to pass through `child_type`:
+
+```python
+def _parse_on_rule(key: str, value: Any) -> OnRule:
+    if isinstance(value, str):
+        return OnTransition(target=value)
+    if isinstance(value, dict):
+        action = value.get("action")
+        if action == "decompose":
+            then = value.get("then")
+            child_type = value.get("child_type")
+            return OnDecompose(child_type=child_type, then=then)
+        msg = f"Unknown action '{action}' in on.{key}"
+        raise ConfigValidationError(msg)
+    msg = f"Invalid on rule for key '{key}': expected string or dict"
+    raise ConfigValidationError(msg)
+```
+
+Add `TypeDef` to imports and add a `_parse_type` function:
+
+```python
+from orca.engine.types import TypeDef
+
+def _parse_type(name: str, raw: dict[str, Any]) -> TypeDef:
+    fields_data = raw.get("fields")
+    fields = _parse_issue_fields(fields_data)
+    initial = raw.get("initial", "")
+    states_data: dict[str, Any] = raw.get("states", {})
+    states: dict[str, StateDef] = {}
+    for state_name, state_data in states_data.items():
+        states[state_name] = _parse_state(state_name, state_data)
+    return TypeDef(fields=fields, initial=initial, states=states)
+```
+
+Rewrite `parse_config` to detect typed vs legacy format:
+
+```python
+def parse_config(yaml_str: str) -> StateMachineConfig:
+    raw: Any = yaml.safe_load(yaml_str)
+    if not isinstance(raw, dict):
+        msg = "Config must be a YAML mapping"
+        raise ConfigValidationError(msg)
+
+    if "types" in raw:
+        return _parse_typed_config(raw)
+    return _parse_legacy_config(raw)
+```
+
+Add `_parse_typed_config`:
+
+```python
+def _parse_typed_config(raw: dict[str, Any]) -> StateMachineConfig:
+    root_type = raw.get("root_type", "")
+    max_hops = raw.get("max_hops")
+    max_worker_retries = raw.get("max_worker_retries", 5)
+
+    types_data: dict[str, Any] = raw.get("types", {})
+    types: dict[str, TypeDef] = {}
+    for name, type_data in types_data.items():
+        types[name] = _parse_type(name, type_data)
+
+    config = StateMachineConfig(
+        root_type=root_type,
+        types=types,
+        max_hops=max_hops,
+        max_worker_retries=max_worker_retries,
+    )
+    _validate(config)
+    return config
+```
+
+Move the old `parse_config` body into `_parse_legacy_config` which wraps the single state machine into a `TypeDef` named `"default"`:
+
+```python
+def _parse_legacy_config(raw: dict[str, Any]) -> StateMachineConfig:
+    issue_data = raw.get("issue", {})
+    fields_data = issue_data.get("fields") if isinstance(issue_data, dict) else None
+    issue_fields = _parse_issue_fields(fields_data)
+
+    states_data: dict[str, Any] = raw.get("states", {})
+    states: dict[str, StateDef] = {}
+    for name, state_data in states_data.items():
+        states[name] = _parse_state(name, state_data)
+
+    initial: str = raw.get("initial", "")
+    max_hops = raw.get("max_hops")
+    max_worker_retries = raw.get("max_worker_retries", 5)
+
+    type_def = TypeDef(fields=issue_fields, initial=initial, states=states)
+
+    config = StateMachineConfig(
+        root_type="default",
+        types={"default": type_def},
+        max_hops=max_hops,
+        max_worker_retries=max_worker_retries,
+    )
+    _validate(config)
+    return config
+```
+
+- [ ] **Step 4: Update `_validate` for typed config**
+
+Rewrite `_validate` to iterate over all types:
+
+```python
+def _validate(config: StateMachineConfig) -> None:
+    # root_type must exist
+    if config.root_type not in config.types:
+        msg = f"root_type '{config.root_type}' does not reference an existing type"
+        raise ConfigValidationError(msg)
+
+    if config.max_hops is not None and (not isinstance(config.max_hops, int) or config.max_hops < 1):
+        msg = f"max_hops must be a positive integer, got {config.max_hops}"
+        raise ConfigValidationError(msg)
+
+    for type_name, type_def in config.types.items():
+        _validate_type(config, type_name, type_def)
+
+
+def _validate_type(config: StateMachineConfig, type_name: str, type_def: TypeDef) -> None:
+    state_names = set(type_def.states.keys())
+
+    # initial references an existing state within this type
+    if type_def.initial not in state_names:
+        msg = f"Type '{type_name}': initial state '{type_def.initial}' does not exist"
+        raise ConfigValidationError(msg)
+
+    # At least one terminal state
+    terminal_states = {name for name, s in type_def.states.items() if s.terminal}
+    if not terminal_states:
+        msg = f"Type '{type_name}': at least one terminal state is required"
+        raise ConfigValidationError(msg)
+
+    reachable: set[str] = {type_def.initial}
+
+    for name, state in type_def.states.items():
+        # Worker validation
+        if state.worker is not None:
+            if state.worker.kind not in _ALLOWED_WORKER_KINDS:
+                allowed_kinds = sorted(_ALLOWED_WORKER_KINDS)
+                msg = f"Type '{type_name}', state '{name}': kind must be one of {allowed_kinds}, got '{state.worker.kind}'"
+                raise ConfigValidationError(msg)
+            if not state.worker.prompt:
+                msg = f"Type '{type_name}', state '{name}': prompt must be non-empty"
+                raise ConfigValidationError(msg)
+            if state.worker.timeout is not None and (
+                not isinstance(state.worker.timeout, int) or state.worker.timeout < 1
+            ):
+                msg = f"Type '{type_name}', state '{name}': timeout must be positive integer, got {state.worker.timeout}"
+                raise ConfigValidationError(msg)
+
+        if state.max_workers is not None and (not isinstance(state.max_workers, int) or state.max_workers < 1):
+            msg = f"Type '{type_name}', state '{name}': max_workers must be positive integer, got {state.max_workers}"
+            raise ConfigValidationError(msg)
+
+        if state.max_visits is not None and (not isinstance(state.max_visits, int) or state.max_visits < 1):
+            msg = f"Type '{type_name}', state '{name}': max_visits must be positive integer, got {state.max_visits}"
+            raise ConfigValidationError(msg)
+
+        if state.terminal:
+            if state.worker is not None or state.on:
+                msg = f"Type '{type_name}': terminal state '{name}' must not have worker or on rules"
+                raise ConfigValidationError(msg)
+            continue
+
+        if state.worker is not None and state.on:
+            outcome = state.worker.result_format.get("outcome")
+            if not isinstance(outcome, EnumFieldDef):
+                msg = f"Type '{type_name}', state '{name}': must have 'outcome' enum in result_format"
+                raise ConfigValidationError(msg)
+            for key in state.on:
+                if key not in outcome.values:
+                    msg = f"Type '{type_name}', state '{name}': on key '{key}' not in outcome values ({outcome.values})"
+                    raise ConfigValidationError(msg)
+
+        # on targets must be within the same type
+        for key, rule in state.on.items():
+            if isinstance(rule, OnTransition):
+                if rule.target not in state_names:
+                    msg = f"Type '{type_name}', state '{name}': on.{key} target '{rule.target}' does not exist"
+                    raise ConfigValidationError(msg)
+                reachable.add(rule.target)
+            elif isinstance(rule, OnDecompose):
+                if rule.then is not None and rule.then not in state_names:
+                    msg = f"Type '{type_name}', state '{name}': decompose then '{rule.then}' does not exist"
+                    raise ConfigValidationError(msg)
+                if rule.then is not None:
+                    reachable.add(rule.then)
+                # child_type must reference an existing type
+                if rule.child_type is not None and rule.child_type not in config.types:
+                    msg = f"Type '{type_name}', state '{name}': child_type '{rule.child_type}' does not exist"
+                    raise ConfigValidationError(msg)
+
+        # decompose requires sub_issues field
+        for _key, rule in state.on.items():
+            if isinstance(rule, OnDecompose):
+                if state.worker is None:
+                    msg = f"Type '{type_name}', state '{name}': decompose action but no worker"
+                    raise ConfigValidationError(msg)
+                sub = state.worker.result_format.get("sub_issues")
+                if not isinstance(sub, ListFieldDef) or sub.items != "$issue":
+                    msg = f"Type '{type_name}', state '{name}': decompose requires sub_issues with items: $issue"
+                    raise ConfigValidationError(msg)
+
+    # Reachability check
+    for name, state in type_def.states.items():
+        if name in reachable:
+            continue
+        is_passive = state.worker is None and not state.on and not state.terminal
+        if is_passive:
+            continue
+        msg = f"Type '{type_name}', state '{name}': not reachable from any on rule"
+        raise ConfigValidationError(msg)
+```
+
+- [ ] **Step 5: Run tests to verify typed parsing works**
+
+Run: `uv run pytest tests/engine/test_config.py::TestParseTypedConfig -v`
+Expected: PASS
+
+- [ ] **Step 6: Update existing config tests for legacy compatibility**
+
+The existing tests use legacy format (no `types` key). With `_parse_legacy_config`, they should still parse but the config shape changes. Update test assertions:
+
+In `tests/engine/test_config.py`, update `TestParseSimpleConfig`:
+
+```python
+class TestParseSimpleConfig:
+    def test_states_exist(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert set(cfg.types["default"].states.keys()) == {"todo", "implementing", "done"}
+
+    def test_initial_state(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.types["default"].initial == "todo"
+
+    def test_terminal_state(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.types["default"].states["done"].terminal is True
+
+    def test_active_state_worker(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        state = cfg.types["default"].states["todo"]
+        assert state.worker is not None
+        assert "outcome" in state.worker.result_format
+        outcome = state.worker.result_format["outcome"]
+        assert isinstance(outcome, EnumFieldDef)
+        assert outcome.values == ["start"]
+
+    def test_on_rules(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.types["default"].states["todo"].on == {"start": OnTransition(target="implementing")}
+        assert cfg.types["default"].states["implementing"].on == {
+            "complete": OnTransition(target="done"),
+            "reject": OnTransition(target="todo"),
+        }
+
+    def test_string_result_format_field(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        rf = cfg.types["default"].states["implementing"].worker
+        assert rf is not None
+        reason = rf.result_format["reason"]
+        assert isinstance(reason, StringFieldDef)
+
+    def test_required_when_normalization(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        rf = cfg.types["default"].states["implementing"].worker
+        assert rf is not None
+        reason = rf.result_format["reason"]
+        assert isinstance(reason, StringFieldDef)
+        assert reason.required_when == ["reject"]
+```
+
+Similarly update `TestParseDecomposeConfig`, `TestParseMaxWorkersConfig`, `TestParseIssueFields`, and all `TestValidationErrors` tests to use `cfg.types["default"]` or `cfg.root_type_def` where they previously used `cfg.states` / `cfg.initial` / `cfg.issue_fields`.
+
+Update all validation error tests — they should still raise the same errors but error messages may now include "Type 'default'" prefix.
+
+- [ ] **Step 7: Add validation tests for typed config errors**
+
+```python
+class TestTypedConfigValidation:
+    def test_root_type_must_exist(self) -> None:
+        yaml_str = """\
+root_type: ghost
+types:
+  epic:
+    fields: {}
+    initial: done
+    states:
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="root_type.*ghost"):
+            parse_config(yaml_str)
+
+    def test_child_type_must_exist(self) -> None:
+        yaml_str = """\
+root_type: epic
+types:
+  epic:
+    fields: {}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [decompose], description: d}
+            sub_issues: {type: list, items: "$issue", required_when: [decompose], description: s}
+        on:
+          decompose:
+            action: decompose
+            child_type: ghost
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="child_type.*ghost"):
+            parse_config(yaml_str)
+
+    def test_cross_type_transition_rejected(self) -> None:
+        """on targets must reference states within the same type."""
+        yaml_str = """\
+root_type: epic
+types:
+  epic:
+    fields: {}
+    initial: todo
+    states:
+      todo:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [go], description: d}
+        on:
+          go: implementing
+      done: {terminal: true}
+  task:
+    fields: {}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [done], description: d}
+        on:
+          done: done
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="implementing.*does not exist"):
+            parse_config(yaml_str)
+```
+
+- [ ] **Step 8: Run all config tests**
+
+Run: `uv run pytest tests/engine/test_config.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/orca/engine/config.py tests/engine/test_config.py
+git commit -m "feat: config parser supports typed format with legacy backward compat"
+```
+
+---
+
+### Task 4: Update dispatch.py for type-aware lookups
+
+**Files:**
+- Modify: `src/orca/engine/dispatch.py`
+- Test: `tests/engine/test_dispatch.py`
+
+Every function in dispatch.py that does `config.states[...]` must become type-aware. The issue's `type` field determines which type's states to look up.
+
+- [ ] **Step 1: Write failing test for type-aware dispatch**
+
+In `tests/engine/test_dispatch.py`, add:
+
+```python
+from orca.engine.types import (
+    DispatchWorkerEffect,
+    EnumFieldDef,
+    FieldDef,
+    Issue,
+    OnTransition,
+    State,
+    StateDef,
+    StateMachineConfig,
+    TypeDef,
+    WorkerDef,
+)
+from orca.engine.dispatch import is_blocked, try_dispatch, build_result_format, build_issue_context
+
+
+def _typed_config() -> StateMachineConfig:
+    """Config with two types: epic (scoping->done) and task (implementing->done)."""
+    worker_scope = WorkerDef(
+        kind="claude-code",
+        prompt="p.md",
+        result_format={"outcome": EnumFieldDef(values=["done"], description="d")},
+    )
+    worker_impl = WorkerDef(
+        kind="claude-code",
+        prompt="q.md",
+        result_format={"outcome": EnumFieldDef(values=["done"], description="d")},
+    )
+    epic = TypeDef(
+        fields={"title": FieldDef(type="string", description="t")},
+        initial="scoping",
+        states={
+            "scoping": StateDef(worker=worker_scope, on={"done": OnTransition(target="done")}),
+            "done": StateDef(terminal=True),
+        },
+    )
+    task = TypeDef(
+        fields={"title": FieldDef(type="string", description="t")},
+        initial="implementing",
+        states={
+            "implementing": StateDef(worker=worker_impl, on={"done": OnTransition(target="done")}),
+            "done": StateDef(terminal=True),
+        },
+    )
+    return StateMachineConfig(root_type="epic", types={"epic": epic, "task": task})
+
+
+class TestTypedDispatch:
+    def test_dispatch_uses_issue_type(self) -> None:
+        config = _typed_config()
+        issue = Issue(
+            type="task",
+            fields={"title": "t"},
+            state="implementing",
+            worker_active=False,
+            decomposed_from=None,
+            depends_on=[],
+            event_log=[],
+        )
+        state = State(issues={"T1": issue}, worker_queues={})
+        effects: list[DispatchWorkerEffect] = []
+        try_dispatch(config, state, "T1", effects)
+        assert len(effects) == 1
+        assert effects[0].issue_type == "task"
+        assert effects[0].state == "implementing"
+
+    def test_build_result_format_type_aware(self) -> None:
+        config = _typed_config()
+        rf = build_result_format(config, "task", "implementing")
+        assert "outcome" in rf
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_dispatch.py::TestTypedDispatch -v`
+Expected: FAIL — functions don't accept type parameter / Issue missing type
+
+- [ ] **Step 3: Update all dispatch.py functions for type-aware lookups**
+
+In `src/orca/engine/dispatch.py`:
+
+Update `is_blocked` — child state lookup needs the child's type:
+
+```python
+def is_blocked(state: State, config: StateMachineConfig, issue_id: str) -> bool:
+    issue = state.issues[issue_id]
+    children = get_children(state, issue_id)
+    if children:
+        for child_id in children:
+            child = state.issues[child_id]
+            child_state_def = config.get_state(child.type, child.state)
+            if not child_state_def.terminal:
+                return True
+    for dep_id in issue.depends_on:
+        dep = state.issues[dep_id]
+        dep_state_def = config.get_state(dep.type, dep.state)
+        if not dep_state_def.terminal:
+            return True
+    return False
+```
+
+Update `build_result_format` to take `type_name` parameter:
+
+```python
+def build_result_format(config: StateMachineConfig, type_name: str, state_name: str) -> dict[str, Any]:
+    state_def = config.get_state(type_name, state_name)
+    if state_def.worker is None:
+        return {}
+    # ... rest unchanged
+```
+
+Update `try_dispatch` — look up state via issue type, use `(type, state)` queue key, include `issue_type` in effect:
+
+```python
+def try_dispatch(config: StateMachineConfig, state: State, issue_id: str, effects: list[Effect]) -> None:
+    issue = state.issues[issue_id]
+    state_name = issue.state
+    state_def = config.get_state(issue.type, state_name)
+
+    if is_blocked(state, config, issue_id):
+        return
+    if state_def.worker is None:
+        return
+
+    if state_def.max_workers is not None:
+        active_count = sum(
+            1 for iss in state.issues.values()
+            if iss.type == issue.type and iss.state == state_name and iss.worker_active
+        )
+        if active_count >= state_def.max_workers:
+            queue_key = f"{issue.type}:{state_name}"
+            queue = state.worker_queues.setdefault(queue_key, [])
+            queue.append(issue_id)
+            return
+
+    issue.worker_active = True
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=issue_id,
+            issue_type=issue.type,
+            state=state_name,
+            result_format=build_result_format(config, issue.type, state_name),
+            issue=build_issue_context(state, issue_id),
+        )
+    )
+```
+
+Update `backfill_queue` — the `state_name` parameter becomes a queue key (already `"{type}:{state}"`):
+
+```python
+def backfill_queue(config: StateMachineConfig, state: State, queue_key: str, effects: list[Effect]) -> None:
+    queue = state.worker_queues.get(queue_key)
+    if not queue:
+        return
+    for i, issue_id in enumerate(queue):
+        if not is_blocked(state, config, issue_id):
+            queue.pop(i)
+            try_dispatch(config, state, issue_id, effects)
+            return
+```
+
+Update `remove_from_queue` — caller passes queue key:
+
+```python
+def remove_from_queue(state: State, queue_key: str, issue_id: str) -> None:
+    queue = state.worker_queues.get(queue_key)
+    if queue is None:
+        return
+    with contextlib.suppress(ValueError):
+        queue.remove(issue_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_dispatch.py::TestTypedDispatch -v`
+Expected: PASS
+
+- [ ] **Step 5: Update existing dispatch tests**
+
+Update existing tests in `tests/engine/test_dispatch.py` to construct configs with the new `StateMachineConfig` shape (using `TypeDef`) and pass `type="default"` on Issue objects. All Issues created in tests need the `type` field.
+
+- [ ] **Step 6: Run all dispatch tests**
+
+Run: `uv run pytest tests/engine/test_dispatch.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/orca/engine/dispatch.py tests/engine/test_dispatch.py
+git commit -m "feat: type-aware dispatch with (type, state) queue keys"
+```
+
+---
+
+### Task 5: Update reducer.py for type-aware state machine
+
+**Files:**
+- Modify: `src/orca/engine/reducer.py`
+
+This is the largest change. Every `config.states[...]` becomes `config.get_state(issue.type, ...)`, and decomposition creates typed children.
+
+- [ ] **Step 1: Update `_handle_create`**
+
+Use `config.root_type` and `config.root_type_def`:
+
+```python
+def _handle_create(config, state, event, effects, ts):
+    if event.issue_id in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' already exists"))
+        return
+
+    root_td = config.root_type_def
+    issue = Issue(
+        type=config.root_type,
+        fields=event.fields,
+        state=root_td.initial,
+        worker_active=False,
+        decomposed_from=None,
+        depends_on=[],
+        event_log=[],
+        visit_counts={root_td.initial: 1},
+        hop_count=0,
+    )
+    state.issues[event.issue_id] = issue
+    append_log(issue, event.timestamp, "created", {"state": root_td.initial})
+
+    state_def = config.get_state(config.root_type, root_td.initial)
+    if state_def.worker is not None:
+        prev_len = len(effects)
+        try_dispatch(config, state, event.issue_id, effects)
+        if len(effects) > prev_len:
+            append_log(issue, ts, "worker_dispatched", {"state": issue.state})
+```
+
+- [ ] **Step 2: Update `_handle_advance`**
+
+All `config.states[...]` → `config.get_state(issue.type, ...)`:
+
+```python
+def _handle_advance(config, state, event, effects, ts):
+    if event.issue_id not in state.issues:
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' does not exist"))
+        return
+
+    issue = state.issues[event.issue_id]
+    current_state_def = config.get_state(issue.type, issue.state)
+
+    if current_state_def.worker is not None or current_state_def.terminal:
+        effects.append(ErrorEffect(
+            issue_id=event.issue_id,
+            message=f"Issue '{event.issue_id}' is not in a passive state (current: '{issue.state}')",
+        ))
+        return
+
+    if is_blocked(state, config, event.issue_id):
+        effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' is blocked"))
+        return
+
+    # Target state must exist within the issue's type
+    type_def = config.get_type(issue.type)
+    if event.target_state not in type_def.states:
+        effects.append(ErrorEffect(
+            issue_id=event.issue_id,
+            message=f"State '{event.target_state}' does not exist in type '{issue.type}'",
+        ))
+        return
+
+    # ... rest follows same pattern, replacing config.states[x] with config.get_state(issue.type, x)
+```
+
+- [ ] **Step 3: Update `_handle_worker_result`**
+
+Replace `config.states[issue.state]` with `config.get_state(issue.type, issue.state)`.
+
+Replace field merging: instead of `key in config.issue_fields`, use `key in config.get_type(issue.type).fields`:
+
+```python
+    # Merge result fields back into issue fields
+    type_fields = config.get_type(issue.type).fields
+    for key, value in event.result.items():
+        if key != "outcome" and key in type_fields:
+            issue.fields[key] = value
+```
+
+Update queue key for backfill:
+
+```python
+    if state_def.max_workers is not None:
+        queue_key = f"{issue.type}:{old_state_name}"
+        backfill_queue(config, state, queue_key, dispatch_effects)
+```
+
+- [ ] **Step 4: Update `_apply_transition`**
+
+Replace `config.states[target_state]` with `config.get_state(issue.type, target_state)`.
+
+Update `remove_from_queue` call to use queue key:
+
+```python
+    queue_key = f"{issue.type}:{old_state_name}"
+    remove_from_queue(state, queue_key, issue_id)
+```
+
+- [ ] **Step 5: Update `_apply_decompose` for typed children**
+
+This is the key change. Children get their type from the decompose rule's `child_type` (default) or the worker's per-child `type` override:
+
+```python
+def _apply_decompose(config, state, event, _parent_issue, generate_id, effects, ts):
+    sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
+
+    append_log(_parent_issue, ts, "decomposition_blocked", {})
+    _parent_issue.hop_count += 1
+
+    # Find the decompose rule to get default child_type
+    parent_state_def = config.get_state(_parent_issue.type, _parent_issue.state)
+    outcome = event.result.get("outcome")
+    rule = parent_state_def.on[outcome]
+    assert isinstance(rule, OnDecompose)
+    default_child_type = rule.child_type
+
+    key_to_id: dict[str, str] = {}
+    for sub in sub_issues:
+        key = str(sub.get("key", ""))
+        real_id = generate_id()
+        key_to_id[key] = real_id
+
+    for sub in sub_issues:
+        key = str(sub.get("key", ""))
+        real_id = key_to_id[key]
+        fields: dict[str, object] = sub.get("fields", {})
+
+        # Resolve child type
+        child_type_name = str(sub.get("type", "")) if "type" in sub else None
+        if child_type_name is None or child_type_name == "":
+            child_type_name = default_child_type
+        if child_type_name is None or child_type_name == "":
+            effects.append(ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"No type for child '{key}': decompose rule has no child_type and worker didn't specify one",
+            ))
+            return
+
+        if child_type_name not in config.types:
+            effects.append(ErrorEffect(
+                issue_id=event.issue_id,
+                message=f"Unknown type '{child_type_name}' for child '{key}'",
+            ))
+            return
+
+        child_type_def = config.get_type(child_type_name)
+
+        raw_depends: list[str] = sub.get("depends_on", [])
+        resolved_depends: list[str] = []
+        for dep_key in raw_depends:
+            if dep_key in key_to_id:
+                resolved_depends.append(key_to_id[dep_key])
+
+        child = Issue(
+            type=child_type_name,
+            fields=dict(fields),
+            state=child_type_def.initial,
+            worker_active=False,
+            decomposed_from=event.issue_id,
+            depends_on=resolved_depends,
+            event_log=[],
+            visit_counts={child_type_def.initial: 1},
+            hop_count=0,
+        )
+        state.issues[real_id] = child
+        append_log(child, ts, "created", {"state": child_type_def.initial})
+
+        if resolved_depends:
+            append_log(child, ts, "dependency_blocked", {"depends_on": resolved_depends})
+
+    # Dispatch non-blocked children
+    for _key, real_id in key_to_id.items():
+        child = state.issues[real_id]
+        child_type_def = config.get_type(child.type)
+        initial_def = child_type_def.states[child_type_def.initial]
+        if initial_def.worker is not None and not is_blocked(state, config, real_id):
+            prev_len = len(effects)
+            try_dispatch(config, state, real_id, effects)
+            if len(effects) > prev_len:
+                append_log(child, ts, "worker_dispatched", {"state": child.state})
+```
+
+- [ ] **Step 6: Update `_find_decompose_rule`**
+
+This needs the issue type to find the right state:
+
+```python
+def _find_decompose_rule(config: StateMachineConfig, type_name: str, state_name: str) -> OnDecompose | None:
+    state_def = config.types.get(type_name, TypeDef(fields={}, initial="", states={})).states.get(state_name)
+    if state_def is None:
+        return None
+    for rule in state_def.on.values():
+        if isinstance(rule, OnDecompose):
+            return rule
+    return None
+```
+
+- [ ] **Step 7: Update `_cascading_unblock`**
+
+Use issue type for state lookups:
+
+```python
+def _cascading_unblock(config, state, terminal_issue_id, effects, ts):
+    terminal_issue = state.issues[terminal_issue_id]
+
+    if terminal_issue.decomposed_from is not None:
+        parent_id = terminal_issue.decomposed_from
+        parent = state.issues[parent_id]
+        children = get_children(state, parent_id)
+        all_terminal = all(
+            config.get_state(state.issues[cid].type, state.issues[cid].state).terminal
+            for cid in children
+        )
+        if all_terminal and not parent.worker_active:
+            append_log(parent, ts, "unblocked", {"reason": "decomposition"})
+            decompose_rule = _find_decompose_rule(config, parent.type, parent.state)
+            if decompose_rule is not None and decompose_rule.then is not None:
+                old_state = parent.state
+                _apply_transition(config, state, parent_id, parent, old_state, decompose_rule.then, effects, ts)
+            else:
+                prev_len = len(effects)
+                try_dispatch(config, state, parent_id, effects)
+                if len(effects) > prev_len:
+                    append_log(parent, ts, "worker_dispatched", {"state": parent.state})
+
+    for iid, iss in state.issues.items():
+        if terminal_issue_id in iss.depends_on:
+            all_deps_terminal = all(
+                config.get_state(state.issues[dep_id].type, state.issues[dep_id].state).terminal
+                for dep_id in iss.depends_on
+            )
+            if (
+                all_deps_terminal
+                and not is_blocked(state, config, iid)
+                and not iss.worker_active
+                and config.get_state(iss.type, iss.state).worker is not None
+            ):
+                append_log(iss, ts, "unblocked", {"reason": "dependency"})
+                prev_len = len(effects)
+                try_dispatch(config, state, iid, effects)
+                if len(effects) > prev_len:
+                    append_log(iss, ts, "worker_dispatched", {"state": iss.state})
+```
+
+- [ ] **Step 8: Update `_handle_worker_failed`**
+
+Replace `config.states[issue.state]` with `config.get_state(issue.type, issue.state)`.
+
+Replace `config.issue_fields` with `config.get_type(issue.type).fields` for the `failure_context` field check.
+
+Update the retry dispatch to include `issue_type`:
+
+```python
+    effects.append(
+        DispatchWorkerEffect(
+            issue_id=event.issue_id,
+            issue_type=issue.type,
+            state=issue.state,
+            result_format=build_result_format(config, issue.type, issue.state),
+            issue=build_issue_context(state, event.issue_id),
+        )
+    )
+```
+
+- [ ] **Step 9: Run type checker**
+
+Run: `uv run mypy src/orca/engine/reducer.py`
+Expected: PASS (no type errors)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/orca/engine/reducer.py
+git commit -m "feat: type-aware reducer with typed decomposition"
+```
+
+---
+
+### Task 6: Update conftest fixtures and all engine tests
+
+**Files:**
+- Modify: `tests/engine/conftest.py`
+- Modify: All `tests/engine/test_*.py` files
+
+All test configs use legacy format and will be auto-wrapped as `type: "default"`. But all Issue construction in tests must include `type="default"`. Every direct `config.states[...]` or `config.initial` access must be updated.
+
+- [ ] **Step 1: Update conftest.py fixtures**
+
+No changes needed to the YAML fixtures themselves — `_parse_legacy_config` wraps them. But verify they still parse correctly.
+
+- [ ] **Step 2: Update test_reducer_create.py**
+
+Add `type="default"` to all Issue constructions. Update `config.states[...]` to `config.get_state("default", ...)` or `config.types["default"].states[...]`.
+
+- [ ] **Step 3: Update test_reducer_advance.py**
+
+Same pattern.
+
+- [ ] **Step 4: Update test_reducer_worker_result.py**
+
+Same pattern.
+
+- [ ] **Step 5: Update test_reducer_worker_failed.py**
+
+Same pattern.
+
+- [ ] **Step 6: Update test_scenario_decompose.py**
+
+Issues created by decompose will have `type="default"` (since legacy configs have no `child_type` on `OnDecompose`). Update assertions to check `issue.type == "default"`.
+
+- [ ] **Step 7: Update test_scenario_pipeline.py, test_scenario_kanban.py, test_scenario_edge_cases.py, test_scenario_queuing.py**
+
+Same pattern — add `type` to Issues, update config lookups.
+
+- [ ] **Step 8: Update test_hop_limits.py, test_event_log.py, test_dispatch.py, test_formatting.py, test_types.py, test_scenario_serialization.py**
+
+Same pattern.
+
+- [ ] **Step 9: Run all engine tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tests/engine/
+git commit -m "test: update all engine tests for typed config shape"
+```
+
+---
+
+### Task 7: Update formatting.py to show type:state
+
+**Files:**
+- Modify: `src/orca/engine/formatting.py`
+- Test: `tests/engine/test_formatting.py`
+
+- [ ] **Step 1: Write failing test**
+
+In `tests/engine/test_formatting.py`, add:
+
+```python
+class TestTypedFormatting:
+    def test_shows_type_and_state(self) -> None:
+        """When type is not 'default', display [type:state]."""
+        # Build a typed config and state with an epic issue
+        # ... (construct config with TypeDef for "epic")
+        issue = Issue(
+            type="epic",
+            fields={"title": "Big task"},
+            state="scoping",
+            worker_active=True,
+            decomposed_from=None,
+            depends_on=[],
+            event_log=[EventLogEntry(timestamp="2026-01-01T00:00:00Z", type="created", data={"state": "scoping"})],
+        )
+        state = State(issues={"ROOT": issue}, worker_queues={})
+        output = format_issues(state, config, "2026-01-01T01:00:00Z")
+        assert "[epic:scoping]" in output
+
+    def test_default_type_shows_state_only(self) -> None:
+        """Legacy configs with type='default' show just [state]."""
+        # ... construct issue with type="default"
+        output = format_issues(state, config, "2026-01-01T01:00:00Z")
+        assert "[scoping]" in output
+        assert "[default:" not in output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_formatting.py::TestTypedFormatting -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update formatting.py**
+
+In `_render_issue`, update state label:
+
+```python
+    state_def = config.get_state(issue.type, issue.state)
+    is_terminal = state_def.terminal
+
+    # Show [type:state] unless type is "default"
+    if issue.type == "default":
+        state_label = f"[{issue.state}]"
+    else:
+        state_label = f"[{issue.type}:{issue.state}]"
+
+    marker = "" if is_terminal else " ..."
+    line = f"{prefix}{connector}{issue_id} {state_label}{marker} {elapsed}"
+```
+
+Same change in the root rendering section of `format_issues`.
+
+Update the worker queue section — queue keys are now `"{type}:{state}"`:
+
+```python
+    for queue_key in sorted(state.worker_queues.keys()):
+        queue = state.worker_queues[queue_key]
+        if queue:
+            lines.append(f"Queued in '{queue_key}': {', '.join(queue)}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_formatting.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orca/engine/formatting.py tests/engine/test_formatting.py
+git commit -m "feat: formatting shows [type:state] for typed issues"
+```
+
+---
+
+### Task 8: Update orchestrator.py for typed effects
+
+**Files:**
+- Modify: `src/orca/orchestrator/orchestrator.py`
+
+- [ ] **Step 1: Update `_is_terminal` to use issue type**
+
+```python
+    def _is_terminal(self, issue_id: str) -> bool:
+        issue = self.state.issues.get(issue_id)
+        if issue is None:
+            return False
+        state_def = self.config.types.get(issue.type, TypeDef(fields={}, initial="", states={})).states.get(issue.state)
+        if state_def is None:
+            return False
+        return state_def.terminal
+```
+
+- [ ] **Step 2: Update `_spawn_worker` to use `effect.issue_type`**
+
+```python
+    def _spawn_worker(self, effect: DispatchWorkerEffect) -> None:
+        state_def = self.config.get_state(effect.issue_type, effect.state)
+        # ... rest uses state_def.worker as before
+```
+
+- [ ] **Step 3: Update `_process_retry_signals`**
+
+The retry code builds `DispatchWorkerEffect` manually — add `issue_type`:
+
+```python
+            pending.append(
+                DispatchWorkerEffect(
+                    issue_id=issue_id,
+                    issue_type=issue.type,
+                    state=issue.state,
+                    result_format=build_result_format(self.config, issue.type, issue.state),
+                    issue=build_issue_context(self.state, issue_id),
+                )
+            )
+```
+
+- [ ] **Step 4: Run type checker on orchestrator**
+
+Run: `uv run mypy src/orca/orchestrator/orchestrator.py`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orca/orchestrator/orchestrator.py
+git commit -m "feat: orchestrator uses issue_type from effects"
+```
+
+---
+
+### Task 9: Update runner.py for typed config
+
+**Files:**
+- Modify: `src/orca/orchestrator/runner.py`
+
+- [ ] **Step 1: Update `_recover_effects` for type-aware lookups**
+
+Replace `config.states.get(issue.state)` with `config.types.get(issue.type, ...)...`:
+
+```python
+    for issue_id, issue in state.issues.items():
+        type_def = config.types.get(issue.type)
+        if type_def is None:
+            continue
+        state_def = type_def.states.get(issue.state)
+        if state_def is None or state_def.terminal:
+            continue
+        # ...
+        result_format = build_result_format(config, issue.type, issue.state)
+        # ...
+        recovered_effects.append(
+            DispatchWorkerEffect(
+                issue_id=issue_id,
+                issue_type=issue.type,
+                state=issue.state,
+                result_format=result_format,
+                issue=issue_context,
+            )
+        )
+```
+
+- [ ] **Step 2: Run type checker**
+
+Run: `uv run mypy src/orca/orchestrator/runner.py`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/orca/orchestrator/runner.py
+git commit -m "feat: runner uses type-aware config lookups"
+```
+
+---
+
+### Task 10: Update orchestrator tests
+
+**Files:**
+- Modify: `tests/orchestrator/test_orchestrator.py`
+- Modify: `tests/orchestrator/test_runner.py`
+- Modify: `tests/orchestrator/test_worker.py`
+- Modify: `tests/orchestrator/test_persistence.py`
+- Modify: Other orchestrator tests that construct State/Issue/Config objects
+
+- [ ] **Step 1: Add `type` field to all Issue constructions in orchestrator tests**
+
+Every `Issue(fields=..., state=..., ...)` must become `Issue(type="default", fields=..., state=..., ...)`.
+
+Every `DispatchWorkerEffect(issue_id=..., state=..., ...)` must become `DispatchWorkerEffect(issue_id=..., issue_type="default", state=..., ...)`.
+
+Every `StateMachineConfig(issue_fields=..., initial=..., states=...)` must be replaced with the new shape using `TypeDef`.
+
+- [ ] **Step 2: Run all orchestrator tests**
+
+Run: `uv run pytest tests/orchestrator/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/orchestrator/
+git commit -m "test: update orchestrator tests for typed config shape"
+```
+
+---
+
+### Task 11: Update TUI tests
+
+**Files:**
+- Modify: `tests/tui/test_*.py` — any tests that construct Issue/State/Config objects
+
+- [ ] **Step 1: Add `type` field to all Issue constructions in TUI tests**
+
+Same mechanical change as Task 10.
+
+- [ ] **Step 2: Run all TUI tests**
+
+Run: `uv run pytest tests/tui/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/tui/
+git commit -m "test: update TUI tests for typed config shape"
+```
+
+---
+
+### Task 12: Add typed decomposition scenario test
+
+**Files:**
+- Create: `tests/engine/test_scenario_typed_decompose.py`
+
+End-to-end test: epic decomposes into tasks with a different flow, tasks complete, parent unblocks.
+
+- [ ] **Step 1: Write the scenario test**
+
+```python
+"""Typed decomposition scenario: epic -> task with different flows."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    State,
+    WorkerResultEvent,
+)
+
+TYPED_CONFIG = """\
+root_type: epic
+max_hops: 20
+
+types:
+  epic:
+    fields:
+      title: {type: string, description: Title}
+      scope: {type: string, description: Scope}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: prompts/scope.md
+          result_format:
+            outcome:
+              type: enum
+              values: [ready, decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          ready: done
+          decompose:
+            action: decompose
+            child_type: task
+            then: done
+      done:
+        terminal: true
+
+  task:
+    fields:
+      title: {type: string, description: Title}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: prompts/impl.md
+          result_format:
+            outcome:
+              type: enum
+              values: [done]
+              description: d
+        on:
+          done: done
+      done:
+        terminal: true
+"""
+
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+class TestTypedDecomposition:
+    def test_epic_decomposes_into_tasks_with_different_flow(self) -> None:
+        config = parse_config(TYPED_CONFIG)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        # Create epic
+        state, effects = reduce(
+            config, state,
+            CreateEvent(issue_id="EPIC-1", fields={"title": "Big feature", "scope": "all"}, timestamp=TS),
+            gen, _clock(),
+        )
+        assert state.issues["EPIC-1"].type == "epic"
+        assert state.issues["EPIC-1"].state == "scoping"
+        assert len([e for e in effects if isinstance(e, DispatchWorkerEffect)]) == 1
+
+        # Epic decomposes into 2 tasks
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="EPIC-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "api", "fields": {"title": "Build API"}},
+                        {"key": "ui", "fields": {"title": "Build UI"}},
+                    ],
+                },
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        # Epic moves to done (then: done)
+        assert state.issues["EPIC-1"].state == "done"
+
+        # Children are tasks starting at implementing (not scoping!)
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "EPIC-1"]
+        assert len(child_ids) == 2
+        for cid in child_ids:
+            assert state.issues[cid].type == "task"
+            assert state.issues[cid].state == "implementing"
+            assert state.issues[cid].worker_active is True
+
+        # Complete both tasks
+        for cid in child_ids:
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id=cid, result={"outcome": "done"}, timestamp=TS),
+                gen, _clock(),
+            )
+            assert state.issues[cid].state == "done"
+
+    def test_worker_overrides_child_type(self) -> None:
+        config = parse_config(TYPED_CONFIG)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="EPIC-1", fields={"title": "Feature", "scope": "all"}, timestamp=TS),
+            gen, _clock(),
+        )
+
+        # Worker overrides one child to be an epic (recursive decomposition)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="EPIC-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "sub-epic", "type": "epic", "fields": {"title": "Sub-epic", "scope": "sub"}},
+                        {"key": "task", "fields": {"title": "Simple task"}},
+                    ],
+                },
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        children = {
+            state.issues[iid].fields["title"]: state.issues[iid]
+            for iid in state.issues
+            if state.issues[iid].decomposed_from == "EPIC-1"
+        }
+        assert children["Sub-epic"].type == "epic"
+        assert children["Sub-epic"].state == "scoping"
+        assert children["Simple task"].type == "task"
+        assert children["Simple task"].state == "implementing"
+
+    def test_missing_child_type_errors(self) -> None:
+        """If decompose rule has no child_type and worker doesn't specify, error."""
+        no_child_type_config = """\
+root_type: epic
+types:
+  epic:
+    fields:
+      title: {type: string, description: Title}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome:
+              type: enum
+              values: [decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          decompose:
+            action: decompose
+      done:
+        terminal: true
+"""
+        config = parse_config(no_child_type_config)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="E1", fields={"title": "X"}, timestamp=TS),
+            gen, _clock(),
+        )
+
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="E1",
+                result={"outcome": "decompose", "sub_issues": [{"key": "a", "fields": {"title": "A"}}]},
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        from orca.engine.types import ErrorEffect
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) >= 1
+        assert "type" in error_effects[0].message.lower() or "child_type" in error_effects[0].message.lower()
+```
+
+- [ ] **Step 2: Run the scenario test**
+
+Run: `uv run pytest tests/engine/test_scenario_typed_decompose.py -v`
+Expected: ALL PASS (implementation was done in earlier tasks)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/engine/test_scenario_typed_decompose.py
+git commit -m "test: add typed decomposition scenario tests"
+```
+
+---
+
+### Task 13: Update example orca.yml
+
+**Files:**
+- Modify: `example/orca.yml`
+
+- [ ] **Step 1: Convert to typed format**
+
+Wrap the existing config in a `types.default` block with `root_type: default`. This maintains the current behavior while demonstrating the new format.
+
+```yaml
+root_type: default
+max_hops: 15
+
+types:
+  default:
+    fields:
+      title:
+        type: string
+        description: "Short title for the issue"
+      description:
+        type: string
+        description: "Detailed description of what needs to be done"
+      scope_boundary:
+        type: string
+        description: "Files and directories this issue owns"
+    initial: scoping
+    states:
+      scoping:
+        # ... (same as before, but add child_type: default to decompose rule)
+      planning:
+        # ... (same as before)
+      implementing:
+        # ... (same as before)
+      applying:
+        # ... (same as before)
+      done:
+        terminal: true
+```
+
+- [ ] **Step 2: Verify config parses**
+
+Run: `uv run python -c "from orca.engine.config import parse_config; parse_config(open('example/orca.yml').read()); print('OK')"`
+Expected: OK
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add example/orca.yml
+git commit -m "docs: convert example orca.yml to typed format"
+```
+
+---
+
+### Task 14: Full lint, type-check, and test pass
+
+- [ ] **Step 1: Run ruff lint**
+
+Run: `uv run ruff check .`
+Expected: PASS
+
+- [ ] **Step 2: Run ruff format check**
+
+Run: `uv run ruff format --check .`
+Expected: PASS
+
+- [ ] **Step 3: Run mypy**
+
+Run: `uv run mypy src/`
+Expected: PASS
+
+- [ ] **Step 4: Run all tests**
+
+Run: `uv run pytest`
+Expected: ALL PASS
+
+- [ ] **Step 5: Fix any failures and commit**
+
+```bash
+git add -A
+git commit -m "fix: resolve lint/type/test issues from typed issue flows"
+```

--- a/docs/superpowers/specs/2026-03-26-typed-issue-flows-design.md
+++ b/docs/superpowers/specs/2026-03-26-typed-issue-flows-design.md
@@ -1,0 +1,243 @@
+# Typed Issue Flows
+
+## Problem
+
+All issues — including children from decomposition — follow the same state machine flow. When an epic decomposes into subtasks, those subtasks pass through stages (e.g. scoping, planning) that the parent already completed. This is wasteful and sometimes wrong — different kinds of work need different flows.
+
+## Solution
+
+Introduce **issue types**. Each type defines its own fields schema, initial state, and state machine. Decomposition rules specify what type children should be, and workers can override the type per-child.
+
+## Config Structure
+
+The top-level orca.yml changes from a single implicit type to a `types` map plus a `root_type`:
+
+```yaml
+root_type: epic
+max_hops: 15
+max_worker_retries: 5
+
+types:
+  epic:
+    fields:
+      title: {type: string}
+      description: {type: string}
+      scope_boundary: {type: string}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: prompts/scope.md
+          result_format:
+            outcome: {type: enum, values: [ready, decompose]}
+            sub_issues: {type: list, required_when: [decompose]}
+        on:
+          ready: planning
+          decompose:
+            action: decompose
+            child_type: task
+            then: integrating
+      planning: ...
+      integrating:
+        worker: {kind: claude-code, prompt: prompts/integrate.md}
+        on:
+          done: done
+      done: {terminal: true}
+
+  task:
+    fields:
+      title: {type: string}
+      description: {type: string}
+    initial: implementing
+    states:
+      implementing: ...
+      applying: ...
+      done: {terminal: true}
+
+  subtask:
+    fields:
+      title: {type: string}
+      description: {type: string}
+    initial: coding
+    states:
+      coding: ...
+      done: {terminal: true}
+```
+
+- `root_type` determines the type of the issue created by the initial `CreateEvent`
+- Each type is fully self-contained: own fields, own initial state, own state machine
+- `child_type` on decompose rules sets the default type for children
+- Workers can override the type per-child in their result
+
+## Type-Aware Issue Model
+
+The `Issue` dataclass gains a `type` field:
+
+```python
+@dataclass
+class Issue:
+    type: str                        # e.g. "epic", "task", "subtask"
+    fields: dict[str, Any]
+    state: str
+    worker_active: bool
+    decomposed_from: str | None
+    depends_on: list[str]
+    event_log: list[EventLogEntry]
+    visit_counts: dict[str, int]
+    hop_count: int
+    failure_count: int
+```
+
+Every reducer lookup that currently does `config.states[issue.state]` becomes `config.types[issue.type].states[issue.state]`:
+
+```python
+# Before
+state_def = config.states[issue.state]
+initial = config.initial
+
+# After
+type_def = config.types[issue.type]
+state_def = type_def.states[issue.state]
+initial = type_def.initial
+```
+
+`CreateEvent` uses `config.root_type` for top-level issues. Decomposition uses the child's assigned type.
+
+Fields are validated against `config.types[type].fields` at issue creation time (both top-level and children).
+
+## Decomposition With Types
+
+Worker result format gains an optional `type` per child:
+
+```json
+{
+  "outcome": "decompose",
+  "sub_issues": [
+    {"key": "api", "fields": {"title": "Build API"}, "depends_on": []},
+    {"key": "db", "type": "subtask", "fields": {"title": "Setup DB"}, "depends_on": []}
+  ]
+}
+```
+
+- `type` is optional — defaults to `child_type` from the decompose rule
+- If provided, overrides the default
+
+In `_apply_decompose`:
+
+```python
+decompose_rule = state_def.on[outcome]  # OnDecompose
+default_child_type = decompose_rule.child_type
+
+for sub in result["sub_issues"]:
+    child_type = sub.get("type", default_child_type)
+
+    # Validate type exists
+    if child_type not in config.types:
+        # ErrorEffect — unknown type
+
+    type_def = config.types[child_type]
+
+    # Validate child fields against type's field schema
+    validate_fields(sub["fields"], type_def.fields)
+
+    # Create issue with type's initial state
+    child = Issue(
+        type=child_type,
+        fields=sub["fields"],
+        state=type_def.initial,
+        ...
+    )
+```
+
+Validation rules:
+- `child_type` in decompose rule must reference an existing type
+- Worker-provided `type` override must also exist in config
+- If neither the decompose rule has `child_type` nor the worker provides `type` for a child, emit an ErrorEffect (no implicit default)
+- Child fields validated against the target type's field schema, not the parent's
+
+## Config Data Model
+
+```python
+@dataclass
+class TypeDef:
+    fields: dict[str, FieldDef]
+    initial: str
+    states: dict[str, StateDef]
+
+@dataclass
+class StateMachineConfig:
+    root_type: str
+    types: dict[str, TypeDef]
+    max_hops: int
+    max_worker_retries: int
+```
+
+### Config Validation (at load time)
+
+1. `root_type` must exist in `types`
+2. For each type:
+   - `initial` must reference a state within that type's `states`
+   - Each state's `on` transitions must reference states within the same type (no cross-type transitions)
+   - Each `on.decompose.child_type` must reference an existing type in `types`
+   - At least one terminal state must exist
+3. No circular type decomposition without a terminal escape path
+
+This is a breaking config change. Existing single-type orca.yml files must be wrapped in a `types` block. Acceptable given the project is pre-1.0.
+
+## Dispatch and Queueing
+
+`max_workers` becomes scoped per `(type, state)` pair. Two types sharing a state name (e.g. both have `done`) are independent:
+
+```python
+# Before
+worker_queues: dict[str, list[str]]                # state_name -> [issue_ids]
+
+# After
+worker_queues: dict[tuple[str, str], list[str]]    # (type, state) -> [issue_ids]
+```
+
+This prevents a `task` in `implementing` from being blocked by an unrelated `subtask` in its own `implementing` state.
+
+## DispatchWorkerEffect
+
+The effect gains `issue_type` so the orchestrator knows which prompt template to render:
+
+```python
+@dataclass
+class DispatchWorkerEffect:
+    issue_id: str
+    issue_type: str          # new
+    state: str
+    result_format: dict
+    issue: dict
+```
+
+## Formatting
+
+The ASCII tree shows issue type alongside state:
+
+```
+ROOT-1 [epic:scoping] ... 2h 15m
+├── CHILD-1 [task:done] 20m
+├── CHILD-2 [task:implementing] ... 1h 30m
+└── CHILD-3 [subtask:coding] ... 45m
+```
+
+## Testing Strategy
+
+### Engine tests (unit, pure)
+
+- **Config validation:** Multi-type configs parse correctly; invalid configs (missing type refs, cross-type transitions, missing child_type) raise clear errors
+- **Reducer:** Create with root_type, decompose producing typed children, type override per-child, field validation against type schema
+- **Dispatch:** Queue keys are `(type, state)`, max_workers scoped per type
+- **Cascading unblock:** Parent (epic) unblocks when typed children (task) all reach their own terminal states
+- **Hop/visit limits:** Counted per-issue as today, unaffected by types
+
+### Integration tests (orchestrator)
+
+- End-to-end: epic decomposes into tasks with different flows, both complete, parent unblocks
+- Worker type override: one child gets a different type than the default
+- Error cases: worker returns unknown type, fields don't match target type schema
+
+No changes needed to worktree, persistence, or worker protocol tests — those layers are type-agnostic.

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -281,13 +281,16 @@ def _validate(config: StateMachineConfig) -> None:
                         )
                         raise ConfigValidationError(msg)
 
-        # Rule 8: every non-initial, non-passive state must be reachable
+        # Rule 8: every non-initial, non-passive, non-terminal state must be reachable
         for name, state in type_def.states.items():
             if name in reachable:
                 continue
             # Passive states (no worker, no on, not terminal) are exempt
             is_passive = state.worker is None and not state.on and not state.terminal
             if is_passive:
+                continue
+            # Terminal states are exempt: they can be reached via cascading unblock (`then` on decompose)
+            if state.terminal:
                 continue
             msg = f"Type '{type_name}', state '{name}' is not reachable from any on rule"
             raise ConfigValidationError(msg)

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -325,6 +325,12 @@ def _parse_legacy_config(raw: dict[str, Any]) -> StateMachineConfig:
     max_hops = raw.get("max_hops")
     max_worker_retries = raw.get("max_worker_retries", 5)
 
+    # For legacy single-type configs, default decompose child_type to "default"
+    for state_def in states.values():
+        for key, rule in state_def.on.items():
+            if isinstance(rule, OnDecompose) and rule.child_type is None:
+                state_def.on[key] = OnDecompose(child_type="default", then=rule.then)
+
     type_def = TypeDef(fields=issue_fields, initial=initial, states=states)
     config = StateMachineConfig(
         root_type="default",

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -15,6 +15,7 @@ from orca.engine.types import (
     StateDef,
     StateMachineConfig,
     StringFieldDef,
+    TypeDef,
     WorkerDef,
 )
 
@@ -69,7 +70,8 @@ def _parse_on_rule(key: str, value: Any) -> OnRule:
         action = value.get("action")
         if action == "decompose":
             then = value.get("then")
-            return OnDecompose(then=then)
+            child_type = value.get("child_type")
+            return OnDecompose(child_type=child_type, then=then)
         msg = f"Unknown action '{action}' in on.{key}"
         raise ConfigValidationError(msg)
     msg = f"Invalid on rule for key '{key}': expected string or dict"
@@ -140,129 +142,180 @@ def _parse_issue_fields(data: dict[str, Any] | None) -> dict[str, FieldDef]:
     return result
 
 
-def _validate(config: StateMachineConfig) -> None:
-    state_names = set(config.states.keys())
+def _parse_type(name: str, raw: dict[str, Any]) -> TypeDef:
+    fields_data = raw.get("fields")
+    fields = _parse_issue_fields(fields_data)
+    initial = raw.get("initial", "")
+    states_data: dict[str, Any] = raw.get("states", {})
+    states: dict[str, StateDef] = {}
+    for state_name, state_data in states_data.items():
+        states[state_name] = _parse_state(state_name, state_data)
+    return TypeDef(fields=fields, initial=initial, states=states)
 
+
+def _validate(config: StateMachineConfig) -> None:
     # Validate max_hops if present
     if config.max_hops is not None and (not isinstance(config.max_hops, int) or config.max_hops < 1):
         msg = f"max_hops must be a positive integer, got {config.max_hops}"
         raise ConfigValidationError(msg)
 
-    # Rule 1: initial references an existing state
-    if config.initial not in state_names:
-        msg = f"initial state '{config.initial}' does not reference an existing state"
+    # Validate root_type exists in types
+    if config.root_type not in config.types:
+        msg = f"root_type '{config.root_type}' does not exist in types"
         raise ConfigValidationError(msg)
 
-    # Rule 6: at least one terminal state
-    terminal_states = {name for name, s in config.states.items() if s.terminal}
-    if not terminal_states:
-        msg = "At least one terminal state is required"
-        raise ConfigValidationError(msg)
+    all_type_names = set(config.types.keys())
 
-    # Collect reachable targets for rule 8
-    reachable: set[str] = {config.initial}
+    for type_name, type_def in config.types.items():
+        state_names = set(type_def.states.keys())
 
-    for name, state in config.states.items():
-        # Validate worker fields
-        if state.worker is not None:
-            if state.worker.kind not in _ALLOWED_WORKER_KINDS:
-                allowed_kinds = sorted(_ALLOWED_WORKER_KINDS)
-                msg = f"Worker for state '{name}': kind must be one of {allowed_kinds}, got '{state.worker.kind}'"
-                raise ConfigValidationError(msg)
-            if not state.worker.prompt:
-                msg = f"Worker prompt for state '{name}' must be a non-empty string"
-                raise ConfigValidationError(msg)
-            if state.worker.timeout is not None and (
-                not isinstance(state.worker.timeout, int) or state.worker.timeout < 1
-            ):
-                msg = f"Worker timeout for state '{name}' must be a positive integer, got {state.worker.timeout}"
-                raise ConfigValidationError(msg)
-
-        # Rule 9: max_workers must be positive integer
-        if state.max_workers is not None and (not isinstance(state.max_workers, int) or state.max_workers < 1):
-            msg = f"max_workers for state '{name}' must be a positive integer, got {state.max_workers}"
+        # Rule 1: initial references an existing state
+        if type_def.initial not in state_names:
+            msg = f"Type '{type_name}', initial state '{type_def.initial}' does not exist in states"
             raise ConfigValidationError(msg)
 
-        # max_visits must be positive integer
-        if state.max_visits is not None and (not isinstance(state.max_visits, int) or state.max_visits < 1):
-            msg = f"max_visits for state '{name}' must be a positive integer, got {state.max_visits}"
+        # Rule 6: at least one terminal state
+        terminal_states = {name for name, s in type_def.states.items() if s.terminal}
+        if not terminal_states:
+            msg = f"Type '{type_name}': at least one terminal state is required"
             raise ConfigValidationError(msg)
 
-        # Rule 5: terminal states have no worker or on
-        if state.terminal:
-            if state.worker is not None or state.on:
-                msg = f"Terminal state '{name}' must not have worker or on rules"
-                raise ConfigValidationError(msg)
-            continue
+        # Collect reachable targets for rule 8
+        reachable: set[str] = {type_def.initial}
 
-        # Rule 4: active states (with worker+on) must have outcome enum in result_format
-        if state.worker is not None and state.on:
-            outcome = state.worker.result_format.get("outcome")
-            if not isinstance(outcome, EnumFieldDef):
-                msg = f"Active state '{name}' must have 'outcome' of type enum in result_format"
-                raise ConfigValidationError(msg)
-
-            # Rule 3: every on key matches a value in outcome.values
-            for key in state.on:
-                if key not in outcome.values:
-                    msg = f"on key '{key}' in state '{name}' does not match any outcome value ({outcome.values})"
-                    raise ConfigValidationError(msg)
-
-        # Rule 2: every on target references an existing state
-        for key, rule in state.on.items():
-            if isinstance(rule, OnTransition):
-                if rule.target not in state_names:
-                    msg = f"on.{key} target '{rule.target}' in state '{name}' does not reference an existing state"
-                    raise ConfigValidationError(msg)
-                reachable.add(rule.target)
-            elif isinstance(rule, OnDecompose) and rule.then is not None:
-                if rule.then not in state_names:
+        for name, state in type_def.states.items():
+            # Validate worker fields
+            if state.worker is not None:
+                if state.worker.kind not in _ALLOWED_WORKER_KINDS:
+                    allowed_kinds = sorted(_ALLOWED_WORKER_KINDS)
                     msg = (
-                        f"on.{key} decompose 'then' target '{rule.then}' in state '{name}' "
-                        f"does not reference an existing state"
+                        f"Type '{type_name}', worker for state '{name}': "
+                        f"kind must be one of {allowed_kinds}, got '{state.worker.kind}'"
                     )
                     raise ConfigValidationError(msg)
-                reachable.add(rule.then)
-
-        # Rule 7: action decompose requires sub_issues with items=$issue
-        for _key, rule in state.on.items():
-            if isinstance(rule, OnDecompose):
-                if state.worker is None:
-                    msg = f"State '{name}' has decompose action but no worker"
+                if not state.worker.prompt:
+                    msg = f"Type '{type_name}', worker prompt for state '{name}' must be a non-empty string"
                     raise ConfigValidationError(msg)
-                sub = state.worker.result_format.get("sub_issues")
-                if not isinstance(sub, ListFieldDef) or sub.items != "$issue":
+                if state.worker.timeout is not None and (
+                    not isinstance(state.worker.timeout, int) or state.worker.timeout < 1
+                ):
                     msg = (
-                        f"State '{name}' has action: decompose but result_format is missing "
-                        f"'sub_issues' field with items: $issue"
+                        f"Type '{type_name}', worker timeout for state '{name}' "
+                        f"must be a positive integer, got {state.worker.timeout}"
                     )
                     raise ConfigValidationError(msg)
 
-    # Rule 8: every non-initial, non-passive state must be reachable
-    for name, state in config.states.items():
-        if name in reachable:
-            continue
-        # Passive states (no worker, no on, not terminal) are exempt
-        is_passive = state.worker is None and not state.on and not state.terminal
-        if is_passive:
-            continue
-        msg = f"State '{name}' is not reachable from any on rule"
-        raise ConfigValidationError(msg)
+            # Rule 9: max_workers must be positive integer
+            if state.max_workers is not None and (not isinstance(state.max_workers, int) or state.max_workers < 1):
+                msg = (
+                    f"Type '{type_name}', max_workers for state '{name}' "
+                    f"must be a positive integer, got {state.max_workers}"
+                )
+                raise ConfigValidationError(msg)
+
+            # max_visits must be positive integer
+            if state.max_visits is not None and (not isinstance(state.max_visits, int) or state.max_visits < 1):
+                msg = (
+                    f"Type '{type_name}', max_visits for state '{name}' "
+                    f"must be a positive integer, got {state.max_visits}"
+                )
+                raise ConfigValidationError(msg)
+
+            # Rule 5: terminal states have no worker or on
+            if state.terminal:
+                if state.worker is not None or state.on:
+                    msg = f"Type '{type_name}', terminal state '{name}' must not have worker or on rules"
+                    raise ConfigValidationError(msg)
+                continue
+
+            # Rule 4: active states (with worker+on) must have outcome enum in result_format
+            if state.worker is not None and state.on:
+                outcome = state.worker.result_format.get("outcome")
+                if not isinstance(outcome, EnumFieldDef):
+                    msg = f"Type '{type_name}', active state '{name}' must have 'outcome' of type enum in result_format"
+                    raise ConfigValidationError(msg)
+
+                # Rule 3: every on key matches a value in outcome.values
+                for key in state.on:
+                    if key not in outcome.values:
+                        msg = (
+                            f"Type '{type_name}', on key '{key}' in state '{name}' "
+                            f"does not match any outcome value ({outcome.values})"
+                        )
+                        raise ConfigValidationError(msg)
+
+            # Rule 2: every on target references an existing state within same type
+            for key, rule in state.on.items():
+                if isinstance(rule, OnTransition):
+                    if rule.target not in state_names:
+                        msg = (
+                            f"Type '{type_name}', on.{key} target '{rule.target}' in state '{name}' "
+                            f"does not exist in states"
+                        )
+                        raise ConfigValidationError(msg)
+                    reachable.add(rule.target)
+                elif isinstance(rule, OnDecompose):
+                    if rule.child_type is not None and rule.child_type not in all_type_names:
+                        msg = f"Type '{type_name}', on.{key} child_type '{rule.child_type}' does not exist in types"
+                        raise ConfigValidationError(msg)
+                    if rule.then is not None:
+                        if rule.then not in state_names:
+                            msg = (
+                                f"Type '{type_name}', on.{key} decompose 'then' target '{rule.then}' "
+                                f"in state '{name}' does not exist in states"
+                            )
+                            raise ConfigValidationError(msg)
+                        reachable.add(rule.then)
+
+            # Rule 7: action decompose requires sub_issues with items=$issue
+            for _key, rule in state.on.items():
+                if isinstance(rule, OnDecompose):
+                    if state.worker is None:
+                        msg = f"Type '{type_name}', state '{name}' has decompose action but no worker"
+                        raise ConfigValidationError(msg)
+                    sub = state.worker.result_format.get("sub_issues")
+                    if not isinstance(sub, ListFieldDef) or sub.items != "$issue":
+                        msg = (
+                            f"Type '{type_name}', state '{name}' has action: decompose but result_format "
+                            f"is missing 'sub_issues' field with items: $issue"
+                        )
+                        raise ConfigValidationError(msg)
+
+        # Rule 8: every non-initial, non-passive state must be reachable
+        for name, state in type_def.states.items():
+            if name in reachable:
+                continue
+            # Passive states (no worker, no on, not terminal) are exempt
+            is_passive = state.worker is None and not state.on and not state.terminal
+            if is_passive:
+                continue
+            msg = f"Type '{type_name}', state '{name}' is not reachable from any on rule"
+            raise ConfigValidationError(msg)
 
 
-def parse_config(yaml_str: str) -> StateMachineConfig:
-    """Parse a YAML string into a StateMachineConfig."""
-    raw: Any = yaml.safe_load(yaml_str)
-    if not isinstance(raw, dict):
-        msg = "Config must be a YAML mapping"
-        raise ConfigValidationError(msg)
+def _parse_typed_config(raw: dict[str, Any]) -> StateMachineConfig:
+    root_type = raw.get("root_type", "")
+    max_hops = raw.get("max_hops")
+    max_worker_retries = raw.get("max_worker_retries", 5)
+    types_data: dict[str, Any] = raw.get("types", {})
+    types: dict[str, TypeDef] = {}
+    for name, type_data in types_data.items():
+        types[name] = _parse_type(name, type_data)
+    config = StateMachineConfig(
+        root_type=root_type,
+        types=types,
+        max_hops=max_hops,
+        max_worker_retries=max_worker_retries,
+    )
+    _validate(config)
+    return config
 
-    # Parse issue fields
+
+def _parse_legacy_config(raw: dict[str, Any]) -> StateMachineConfig:
     issue_data = raw.get("issue", {})
     fields_data = issue_data.get("fields") if isinstance(issue_data, dict) else None
     issue_fields = _parse_issue_fields(fields_data)
 
-    # Parse states
     states_data: dict[str, Any] = raw.get("states", {})
     states: dict[str, StateDef] = {}
     for name, state_data in states_data.items():
@@ -272,14 +325,23 @@ def parse_config(yaml_str: str) -> StateMachineConfig:
     max_hops = raw.get("max_hops")
     max_worker_retries = raw.get("max_worker_retries", 5)
 
+    type_def = TypeDef(fields=issue_fields, initial=initial, states=states)
     config = StateMachineConfig(
-        issue_fields=issue_fields,
-        initial=initial,
-        states=states,
+        root_type="default",
+        types={"default": type_def},
         max_hops=max_hops,
         max_worker_retries=max_worker_retries,
     )
-
     _validate(config)
-
     return config
+
+
+def parse_config(yaml_str: str) -> StateMachineConfig:
+    """Parse a YAML string into a StateMachineConfig."""
+    raw: Any = yaml.safe_load(yaml_str)
+    if not isinstance(raw, dict):
+        msg = "Config must be a YAML mapping"
+        raise ConfigValidationError(msg)
+    if "types" in raw:
+        return _parse_typed_config(raw)
+    return _parse_legacy_config(raw)

--- a/src/orca/engine/dispatch.py
+++ b/src/orca/engine/dispatch.py
@@ -30,14 +30,14 @@ def is_blocked(state: State, config: StateMachineConfig, issue_id: str) -> bool:
     if children:
         for child_id in children:
             child = state.issues[child_id]
-            child_state_def = config.states[child.state]
+            child_state_def = config.get_state(child.type, child.state)
             if not child_state_def.terminal:
                 return True
 
     # Dependency-blocked: has depends_on entries not all in terminal states
     for dep_id in issue.depends_on:
         dep = state.issues[dep_id]
-        dep_state_def = config.states[dep.state]
+        dep_state_def = config.get_state(dep.type, dep.state)
         if not dep_state_def.terminal:
             return True
 
@@ -68,9 +68,9 @@ def build_issue_context(state: State, issue_id: str) -> dict[str, Any]:
     }
 
 
-def build_result_format(config: StateMachineConfig, state_name: str) -> dict[str, Any]:
+def build_result_format(config: StateMachineConfig, type_name: str, state_name: str) -> dict[str, Any]:
     """Serializes the result_format from config into a plain dict."""
-    state_def = config.states[state_name]
+    state_def = config.get_state(type_name, state_name)
     if state_def.worker is None:
         return {}
     result: dict[str, Any] = {}
@@ -112,7 +112,7 @@ def try_dispatch(
     """Core dispatch protocol."""
     issue = state.issues[issue_id]
     state_name = issue.state
-    state_def = config.states[state_name]
+    state_def = config.get_state(issue.type, state_name)
 
     # 1. If issue is blocked, don't dispatch
     if is_blocked(state, config, issue_id):
@@ -124,9 +124,15 @@ def try_dispatch(
 
     # 3. If state has max_workers and active count >= limit, queue the issue
     if state_def.max_workers is not None:
-        active_count = sum(1 for iss in state.issues.values() if iss.state == state_name and iss.worker_active)
+        # Count active workers matching BOTH type and state
+        active_count = sum(
+            1
+            for iss in state.issues.values()
+            if iss.type == issue.type and iss.state == state_name and iss.worker_active
+        )
         if active_count >= state_def.max_workers:
-            queue = state.worker_queues.setdefault(state_name, [])
+            queue_key = f"{issue.type}:{state_name}"
+            queue = state.worker_queues.setdefault(queue_key, [])
             queue.append(issue_id)
             return
 
@@ -135,8 +141,9 @@ def try_dispatch(
     effects.append(
         DispatchWorkerEffect(
             issue_id=issue_id,
+            issue_type=issue.type,
             state=state_name,
-            result_format=build_result_format(config, state_name),
+            result_format=build_result_format(config, issue.type, state_name),
             issue=build_issue_context(state, issue_id),
         )
     )
@@ -145,11 +152,11 @@ def try_dispatch(
 def backfill_queue(
     config: StateMachineConfig,
     state: State,
-    state_name: str,
+    queue_key: str,
     effects: list[Effect],
 ) -> None:
     """When a slot frees up in a capped state, pop next non-blocked issue from queue and dispatch."""
-    queue = state.worker_queues.get(state_name)
+    queue = state.worker_queues.get(queue_key)
     if not queue:
         return
 
@@ -161,9 +168,9 @@ def backfill_queue(
             return
 
 
-def remove_from_queue(state: State, state_name: str, issue_id: str) -> None:
+def remove_from_queue(state: State, queue_key: str, issue_id: str) -> None:
     """Remove an issue from a state's queue."""
-    queue = state.worker_queues.get(state_name)
+    queue = state.worker_queues.get(queue_key)
     if queue is None:
         return
     with contextlib.suppress(ValueError):

--- a/src/orca/engine/formatting.py
+++ b/src/orca/engine/formatting.py
@@ -54,7 +54,7 @@ def _render_issue(
 ) -> list[str]:
     """Render a single issue and its children recursively."""
     issue = state.issues[issue_id]
-    state_def = config.states[issue.state]
+    state_def = config.get_state(issue.type, issue.state)
     is_terminal = state_def.terminal
 
     # Elapsed time
@@ -64,7 +64,9 @@ def _render_issue(
     # State marker
     marker = "" if is_terminal else " ..."
 
-    line = f"{prefix}{connector}{issue_id} [{issue.state}]{marker} {elapsed}"
+    state_label = f"[{issue.state}]" if issue.type == "default" else f"[{issue.type}:{issue.state}]"
+
+    line = f"{prefix}{connector}{issue_id} {state_label}{marker} {elapsed}"
     lines: list[str] = [line]
 
     # Determine the continuation prefix for children/annotations
@@ -109,12 +111,13 @@ def format_issues(state: State, config: StateMachineConfig, now: str) -> str:
         else:
             # Root with children: render root, then children with tree connectors
             issue = state.issues[root_id]
-            state_def = config.states[issue.state]
+            state_def = config.get_state(issue.type, issue.state)
             is_terminal = state_def.terminal
             created_ts = _get_created_timestamp(issue)
             elapsed = _format_elapsed(created_ts, now) if created_ts is not None else "?"
             marker = "" if is_terminal else " ..."
-            lines.append(f"{root_id} [{issue.state}]{marker} {elapsed}")
+            state_label = f"[{issue.state}]" if issue.type == "default" else f"[{issue.type}:{issue.state}]"
+            lines.append(f"{root_id} {state_label}{marker} {elapsed}")
 
             # depends_on for root
             if issue.depends_on:

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -65,23 +65,25 @@ def _handle_create(
         effects.append(ErrorEffect(issue_id=event.issue_id, message=f"Issue '{event.issue_id}' already exists"))
         return
 
+    root_td = config.root_type_def
     issue = Issue(
+        type=config.root_type,
         fields=event.fields,
-        state=config.initial,
+        state=root_td.initial,
         worker_active=False,
         decomposed_from=None,
         depends_on=[],
         event_log=[],
-        visit_counts={config.initial: 1},
+        visit_counts={root_td.initial: 1},
         hop_count=0,
     )
     state.issues[event.issue_id] = issue
 
     # Log the creation
-    append_log(issue, event.timestamp, "created", {"state": config.initial})
+    append_log(issue, event.timestamp, "created", {"state": root_td.initial})
 
     # If initial state is active (has a worker), dispatch
-    state_def = config.states[config.initial]
+    state_def = config.get_state(config.root_type, root_td.initial)
     if state_def.worker is not None:
         prev_len = len(effects)
         try_dispatch(config, state, event.issue_id, effects)
@@ -102,7 +104,7 @@ def _handle_advance(
         return
 
     issue = state.issues[event.issue_id]
-    current_state_def = config.states[issue.state]
+    current_state_def = config.get_state(issue.type, issue.state)
 
     # Must be in a passive state (no worker and not terminal)
     if current_state_def.worker is not None or current_state_def.terminal:
@@ -124,8 +126,9 @@ def _handle_advance(
         )
         return
 
-    # Target state must exist
-    if event.target_state not in config.states:
+    # Target state must exist in the issue's type
+    type_def = config.get_type(issue.type)
+    if event.target_state not in type_def.states:
         effects.append(
             ErrorEffect(
                 issue_id=event.issue_id,
@@ -137,7 +140,7 @@ def _handle_advance(
     old_state = issue.state
 
     # Hop limit checks before moving
-    target_state_def = config.states[event.target_state]
+    target_state_def = config.get_state(issue.type, event.target_state)
     if target_state_def.max_visits is not None:
         current_visits = issue.visit_counts.get(event.target_state, 0)
         if current_visits + 1 > target_state_def.max_visits:
@@ -196,7 +199,7 @@ def _handle_worker_result(
         return
 
     issue = state.issues[event.issue_id]
-    state_def = config.states[issue.state]
+    state_def = config.get_state(issue.type, issue.state)
 
     # Issue must not be in terminal state
     if state_def.terminal:
@@ -257,19 +260,20 @@ def _handle_worker_result(
     append_log(issue, event.timestamp, "worker_result", event.result)
 
     # 3. Merge result fields (except outcome) back into issue fields
+    issue_fields = config.get_type(issue.type).fields
     for key, value in event.result.items():
-        if key != "outcome" and key in config.issue_fields:
+        if key != "outcome" and key in issue_fields:
             issue.fields[key] = value
 
     # Slot backfill: if old state has max_workers, backfill
     dispatch_effects: list[Effect] = []
     if state_def.max_workers is not None:
-        backfill_queue(config, state, old_state_name, dispatch_effects)
+        backfill_queue(config, state, f"{issue.type}:{old_state_name}", dispatch_effects)
 
     # 3. Hop limit checks before transition/decompose
     if isinstance(rule, OnTransition):
         target = rule.target
-        target_def = config.states[target]
+        target_def = config.get_state(issue.type, target)
         if target_def.max_visits is not None:
             current_visits = issue.visit_counts.get(target, 0)
             if current_visits + 1 > target_def.max_visits:
@@ -328,7 +332,7 @@ def _handle_worker_failed(
         return
 
     issue = state.issues[event.issue_id]
-    state_def = config.states[issue.state]
+    state_def = config.get_state(issue.type, issue.state)
 
     # Issue must have worker_active == True
     if not issue.worker_active:
@@ -347,7 +351,8 @@ def _handle_worker_failed(
     append_log(issue, event.timestamp, "worker_failed", {"state": issue.state, "error": event.error})
 
     # Store the failure error in issue fields so retry prompts can reference it
-    if "failure_context" in config.issue_fields:
+    issue_fields = config.get_type(issue.type).fields
+    if "failure_context" in issue_fields:
         issue.fields["failure_context"] = event.error
 
     # Check retry limit
@@ -374,8 +379,9 @@ def _handle_worker_failed(
     effects.append(
         DispatchWorkerEffect(
             issue_id=event.issue_id,
+            issue_type=issue.type,
             state=issue.state,
-            result_format=build_result_format(config, issue.state),
+            result_format=build_result_format(config, issue.type, issue.state),
             issue=build_issue_context(state, event.issue_id),
         )
     )
@@ -392,11 +398,11 @@ def _apply_transition(
     ts: str,
 ) -> None:
     # Remove issue from old state's worker queue
-    remove_from_queue(state, old_state_name, issue_id)
+    remove_from_queue(state, f"{issue.type}:{old_state_name}", issue_id)
 
     # Move issue to target state
     issue.state = target_state
-    target_def = config.states[target_state]
+    target_def = config.get_state(issue.type, target_state)
 
     # Log the transition
     append_log(issue, ts, "transitioned", {"from": old_state_name, "to": target_state})
@@ -433,6 +439,13 @@ def _apply_decompose(
     # Increment parent hop count
     _parent_issue.hop_count += 1
 
+    # Get default child_type from decompose rule
+    parent_state_def = config.get_state(_parent_issue.type, _parent_issue.state)
+    outcome: str = event.result["outcome"]
+    rule = parent_state_def.on[outcome]
+    assert isinstance(rule, OnDecompose)
+    default_child_type = rule.child_type
+
     # Generate IDs and build key -> real_id mapping
     key_to_id: dict[str, str] = {}
     for sub in sub_issues:
@@ -446,50 +459,72 @@ def _apply_decompose(
         real_id = key_to_id[key]
         fields: dict[str, object] = sub.get("fields", {})  # type: ignore[assignment]
 
+        # Resolve child type: worker override > rule default
+        child_type_name = str(sub.get("type", "")) if "type" in sub else None
+        if not child_type_name:
+            child_type_name = default_child_type
+        if not child_type_name:
+            effects.append(
+                ErrorEffect(
+                    issue_id=event.issue_id,
+                    message=f"No type for child '{key}': decompose rule has no child_type "
+                    "and worker didn't specify one",
+                )
+            )
+            return
+        if child_type_name not in config.types:
+            effects.append(
+                ErrorEffect(
+                    issue_id=event.issue_id,
+                    message=f"Unknown type '{child_type_name}' for child '{key}'",
+                )
+            )
+            return
+
+        child_type_def = config.get_type(child_type_name)
+
         # Resolve depends_on keys to real IDs
         raw_depends: list[str] = sub.get("depends_on", [])  # type: ignore[assignment]
-        resolved_depends: list[str] = []
-        for dep_key in raw_depends:
-            if dep_key not in key_to_id:
-                # This shouldn't happen if spec is followed, but handle it
-                pass
-            else:
-                resolved_depends.append(key_to_id[dep_key])
+        resolved_depends: list[str] = [key_to_id[dk] for dk in raw_depends if dk in key_to_id]
 
         child = Issue(
+            type=child_type_name,
             fields=dict(fields),
-            state=config.initial,
+            state=child_type_def.initial,
             worker_active=False,
             decomposed_from=event.issue_id,
             depends_on=resolved_depends,
             event_log=[],
-            visit_counts={config.initial: 1},
+            visit_counts={child_type_def.initial: 1},
             hop_count=0,
         )
         state.issues[real_id] = child
 
         # Log creation on child
-        append_log(child, ts, "created", {"state": config.initial})
+        append_log(child, ts, "created", {"state": child_type_def.initial})
 
         # If child has dependencies, log dependency_blocked
         if resolved_depends:
             append_log(child, ts, "dependency_blocked", {"depends_on": resolved_depends})
 
-    # Dispatch each child that is not blocked and whose initial state is active
-    initial_def = config.states[config.initial]
-    if initial_def.worker is not None:
-        for _key, real_id in key_to_id.items():
-            if not is_blocked(state, config, real_id):
-                prev_len = len(effects)
-                try_dispatch(config, state, real_id, effects)
-                if len(effects) > prev_len:
-                    child_issue = state.issues[real_id]
-                    append_log(child_issue, ts, "worker_dispatched", {"state": child_issue.state})
+    # Dispatch non-blocked children
+    for _key, real_id in key_to_id.items():
+        child = state.issues[real_id]
+        child_type_def = config.get_type(child.type)
+        initial_def = child_type_def.states[child_type_def.initial]
+        if initial_def.worker is not None and not is_blocked(state, config, real_id):
+            prev_len = len(effects)
+            try_dispatch(config, state, real_id, effects)
+            if len(effects) > prev_len:
+                append_log(child, ts, "worker_dispatched", {"state": child.state})
 
 
-def _find_decompose_rule(config: StateMachineConfig, state_name: str) -> OnDecompose | None:
+def _find_decompose_rule(config: StateMachineConfig, type_name: str, state_name: str) -> OnDecompose | None:
     """Find the OnDecompose rule in the given state's on-rules, if any."""
-    state_def = config.states.get(state_name)
+    type_def = config.types.get(type_name)
+    if type_def is None:
+        return None
+    state_def = type_def.states.get(state_name)
     if state_def is None:
         return None
     for rule in state_def.on.values():
@@ -512,13 +547,15 @@ def _cascading_unblock(
         parent_id = terminal_issue.decomposed_from
         parent = state.issues[parent_id]
         children = get_children(state, parent_id)
-        all_terminal = all(config.states[state.issues[cid].state].terminal for cid in children)
+        all_terminal = all(
+            config.get_state(state.issues[cid].type, state.issues[cid].state).terminal for cid in children
+        )
         if all_terminal and not parent.worker_active:
             # Log unblocked on parent
             append_log(parent, ts, "unblocked", {"reason": "decomposition"})
 
             # Find the decompose rule that created these children to check for `then`
-            decompose_rule = _find_decompose_rule(config, parent.state)
+            decompose_rule = _find_decompose_rule(config, parent.type, parent.state)
             if decompose_rule is not None and decompose_rule.then is not None:
                 # Transition parent to the `then` target
                 old_state = parent.state
@@ -534,12 +571,15 @@ def _cascading_unblock(
     for iid, iss in state.issues.items():
         if terminal_issue_id in iss.depends_on:
             # Check if all depends_on are now terminal
-            all_deps_terminal = all(config.states[state.issues[dep_id].state].terminal for dep_id in iss.depends_on)
+            all_deps_terminal = all(
+                config.get_state(state.issues[dep_id].type, state.issues[dep_id].state).terminal
+                for dep_id in iss.depends_on
+            )
             if (
                 all_deps_terminal
                 and not is_blocked(state, config, iid)
                 and not iss.worker_active
-                and config.states[iss.state].worker is not None
+                and config.get_state(iss.type, iss.state).worker is not None
             ):
                 # Log unblocked on the dependent issue
                 append_log(iss, ts, "unblocked", {"reason": "dependency"})

--- a/src/orca/engine/reducer.py
+++ b/src/orca/engine/reducer.py
@@ -433,9 +433,6 @@ def _apply_decompose(
 ) -> None:
     sub_issues: list[dict[str, object]] = event.result.get("sub_issues", [])
 
-    # Log decomposition blocked on parent
-    append_log(_parent_issue, ts, "decomposition_blocked", {})
-
     # Increment parent hop count
     _parent_issue.hop_count += 1
 
@@ -445,6 +442,7 @@ def _apply_decompose(
     rule = parent_state_def.on[outcome]
     assert isinstance(rule, OnDecompose)
     default_child_type = rule.child_type
+    parent_old_state = _parent_issue.state
 
     # Generate IDs and build key -> real_id mapping
     key_to_id: dict[str, str] = {}
@@ -517,6 +515,14 @@ def _apply_decompose(
             try_dispatch(config, state, real_id, effects)
             if len(effects) > prev_len:
                 append_log(child, ts, "worker_dispatched", {"state": child.state})
+
+    # If decompose rule has a `then` target, transition parent immediately (children run independently)
+    if rule.then is not None:
+        remove_from_queue(state, f"{_parent_issue.type}:{parent_old_state}", event.issue_id)
+        _apply_transition(config, state, event.issue_id, _parent_issue, parent_old_state, rule.then, effects, ts)
+    else:
+        # No `then` — parent is blocked until all children complete
+        append_log(_parent_issue, ts, "decomposition_blocked", {})
 
 
 def _find_decompose_rule(config: StateMachineConfig, type_name: str, state_name: str) -> OnDecompose | None:

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -53,6 +53,7 @@ class OnTransition:
 
 @dataclass(frozen=True)
 class OnDecompose:
+    child_type: str | None = None
     then: str | None = None
 
 
@@ -69,12 +70,28 @@ class StateDef:
 
 
 @dataclass(frozen=True)
-class StateMachineConfig:
-    issue_fields: dict[str, FieldDef]
+class TypeDef:
+    fields: dict[str, FieldDef]
     initial: str
     states: dict[str, StateDef]
+
+
+@dataclass(frozen=True)
+class StateMachineConfig:
+    root_type: str
+    types: dict[str, TypeDef]
     max_hops: int | None = None
     max_worker_retries: int = 5
+
+    def get_type(self, type_name: str) -> TypeDef:
+        return self.types[type_name]
+
+    def get_state(self, type_name: str, state_name: str) -> StateDef:
+        return self.types[type_name].states[state_name]
+
+    @property
+    def root_type_def(self) -> TypeDef:
+        return self.types[self.root_type]
 
 
 # --- Runtime state types (mutable, with serialization) ---
@@ -96,6 +113,7 @@ class EventLogEntry:
 
 @dataclass
 class Issue:
+    type: str
     fields: dict[str, Any]
     state: str
     worker_active: bool
@@ -108,6 +126,7 @@ class Issue:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "type": self.type,
             "fields": self.fields,
             "state": self.state,
             "worker_active": self.worker_active,
@@ -122,6 +141,7 @@ class Issue:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Issue:
         return cls(
+            type=data["type"],
             fields=data["fields"],
             state=data["state"],
             worker_active=data["worker_active"],
@@ -193,6 +213,7 @@ Event = CreateEvent | AdvanceEvent | WorkerResultEvent | WorkerFailedEvent
 @dataclass(frozen=True)
 class DispatchWorkerEffect:
     issue_id: str
+    issue_type: str
     state: str
     result_format: dict[str, Any]
     issue: dict[str, Any]

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -107,7 +107,10 @@ class Orchestrator:
         issue = self.state.issues.get(issue_id)
         if issue is None:
             return False
-        state_def = self.config.states.get(issue.state)
+        type_def = self.config.types.get(issue.type)
+        if type_def is None:
+            return False
+        state_def = type_def.states.get(issue.state)
         if state_def is None:
             return False
         return state_def.terminal
@@ -169,7 +172,15 @@ class Orchestrator:
 
     def _spawn_worker(self, effect: DispatchWorkerEffect) -> None:
         """Resolve the worker for the effect and spawn an asyncio task."""
-        state_def = self.config.states.get(effect.state)
+        type_def = self.config.types.get(effect.issue_type)
+        if type_def is None:
+            logger.warning(
+                "No type definition for type %r — skipping dispatch",
+                effect.issue_type,
+                extra={"event": "no_type_definition", "issue_type": effect.issue_type},
+            )
+            return
+        state_def = type_def.states.get(effect.state)
         if state_def is None or state_def.worker is None:
             logger.warning(
                 "No worker definition for state %r — skipping dispatch",
@@ -296,12 +307,14 @@ class Orchestrator:
         base_branch = self._resolve_base_branch(effect.issue_id)
         enriched_effect = DispatchWorkerEffect(
             issue_id=effect.issue_id,
+            issue_type=effect.issue_type,
             state=effect.state,
             result_format=effect.result_format,
             issue={**effect.issue, "base_branch": base_branch},
         )
 
-        state_def = self.config.states.get(effect.state)
+        type_def = self.config.types.get(effect.issue_type)
+        state_def = type_def.states.get(effect.state) if type_def is not None else None
         inactivity_timeout = (
             state_def.worker.inactivity_timeout or state_def.worker.timeout if state_def and state_def.worker else None
         )
@@ -371,7 +384,10 @@ class Orchestrator:
             issue.failure_count = 0
             issue.worker_active = True
 
-            state_def = self.config.states.get(issue.state)
+            type_def = self.config.types.get(issue.type)
+            if type_def is None:
+                continue
+            state_def = type_def.states.get(issue.state)
             if state_def is None or state_def.worker is None:
                 continue
 
@@ -380,8 +396,9 @@ class Orchestrator:
             pending.append(
                 DispatchWorkerEffect(
                     issue_id=issue_id,
+                    issue_type=issue.type,
                     state=issue.state,
-                    result_format=build_result_format(self.config, issue.state),
+                    result_format=build_result_format(self.config, issue.type, issue.state),
                     issue=build_issue_context(self.state, issue_id),
                 )
             )

--- a/src/orca/orchestrator/runner.py
+++ b/src/orca/orchestrator/runner.py
@@ -182,7 +182,10 @@ def _recover_effects(
     recovered_effects: list[DispatchWorkerEffect] = []
 
     for issue_id, issue in state.issues.items():
-        state_def = config.states.get(issue.state)
+        type_def = config.types.get(issue.type)
+        if type_def is None:
+            continue
+        state_def = type_def.states.get(issue.state)
         if state_def is None or state_def.terminal:
             continue
 
@@ -211,7 +214,7 @@ def _recover_effects(
         # doesn't exist — result.json lives in the run directory instead.
         result_path = worktree_path / ".orca" / "result.json" if worktree_path.exists() else run_dir / "result.json"
 
-        result_format = build_result_format(config, issue.state)
+        result_format = build_result_format(config, issue.type, issue.state)
         issue_context = build_issue_context(state, issue_id)
 
         # Try to read and validate the result file
@@ -236,6 +239,7 @@ def _recover_effects(
             recovered_effects.append(
                 DispatchWorkerEffect(
                     issue_id=issue_id,
+                    issue_type=issue.type,
                     state=issue.state,
                     result_format=result_format,
                     issue=issue_context,

--- a/src/orca/tui/app.py
+++ b/src/orca/tui/app.py
@@ -221,7 +221,7 @@ class OrcaApp(App[None]):
         root_id = self._find_root_issue()
         if root_id and root_id in self._state.issues:
             root = self._state.issues[root_id]
-            if self._config and root.state in self._config.states and self._config.states[root.state].terminal:
+            if self._config and root.state in self._config.root_type_def.states and self._config.root_type_def.states[root.state].terminal:
                 self.sub_title = "completed"
                 return
         elapsed = time.time() - self._reader.last_mtime if self._reader.last_mtime > 0 else 0

--- a/src/orca/tui/app.py
+++ b/src/orca/tui/app.py
@@ -221,9 +221,11 @@ class OrcaApp(App[None]):
         root_id = self._find_root_issue()
         if root_id and root_id in self._state.issues:
             root = self._state.issues[root_id]
-            if self._config and root.state in self._config.root_type_def.states and self._config.root_type_def.states[root.state].terminal:
-                self.sub_title = "completed"
-                return
+            if self._config:
+                type_states = self._config.root_type_def.states
+                if root.state in type_states and type_states[root.state].terminal:
+                    self.sub_title = "completed"
+                    return
         elapsed = time.time() - self._reader.last_mtime if self._reader.last_mtime > 0 else 0
         if elapsed < _STALE_THRESHOLD:
             self.sub_title = "running"

--- a/src/orca/tui/widgets/header.py
+++ b/src/orca/tui/widgets/header.py
@@ -107,7 +107,7 @@ class OrcaHeader(Static):
         if self._state is None or self._config is None:
             return False
         for issue in self._state.issues.values():
-            state_def = self._config.states.get(issue.state)
+            state_def = self._config.root_type_def.states.get(issue.state)
             if state_def is None or not state_def.terminal:
                 return False
         return True
@@ -122,7 +122,7 @@ class OrcaHeader(Static):
             return None
 
         root_issue = self._state.issues[root]
-        non_terminal_states = [name for name, sdef in self._config.states.items() if not sdef.terminal]
+        non_terminal_states = [name for name, sdef in self._config.root_type_def.states.items() if not sdef.terminal]
         total_steps = len(non_terminal_states)
         if total_steps == 0:
             return None

--- a/src/orca/tui/widgets/issue_tree.py
+++ b/src/orca/tui/widgets/issue_tree.py
@@ -79,7 +79,9 @@ def _progress_bar_text(
 
 def _pending_steps(config: StateMachineConfig, visit_counts: dict[str, int]) -> list[str]:
     """Return non-terminal states not yet visited."""
-    return [name for name, sdef in config.root_type_def.states.items() if not sdef.terminal and name not in visit_counts]
+    return [
+        name for name, sdef in config.root_type_def.states.items() if not sdef.terminal and name not in visit_counts
+    ]
 
 
 def _extract_result_outcomes(event_log: list[EventLogEntry]) -> dict[str, str]:

--- a/src/orca/tui/widgets/issue_tree.py
+++ b/src/orca/tui/widgets/issue_tree.py
@@ -61,7 +61,7 @@ def _progress_bar_text(
     failed_states: set[str],
 ) -> Text | None:
     """Return a Rich Text with colored block segments for each non-terminal state."""
-    non_terminal = [name for name, sdef in config.states.items() if not sdef.terminal]
+    non_terminal = [name for name, sdef in config.root_type_def.states.items() if not sdef.terminal]
     if not non_terminal:
         return None
     bar = Text()
@@ -79,7 +79,7 @@ def _progress_bar_text(
 
 def _pending_steps(config: StateMachineConfig, visit_counts: dict[str, int]) -> list[str]:
     """Return non-terminal states not yet visited."""
-    return [name for name, sdef in config.states.items() if not sdef.terminal and name not in visit_counts]
+    return [name for name, sdef in config.root_type_def.states.items() if not sdef.terminal and name not in visit_counts]
 
 
 def _extract_result_outcomes(event_log: list[EventLogEntry]) -> dict[str, str]:
@@ -357,7 +357,7 @@ class IssueTree(Tree[str]):
 
             # Active current state (shown when no session exists for it yet)
             if self._config is not None:
-                current_state_def = self._config.states.get(issue.state)
+                current_state_def = self._config.root_type_def.states.get(issue.state)
                 has_session_for_current = any(str(s.get("state", "")) == issue.state for s in issue_sessions)
                 if (
                     current_state_def is not None

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -15,21 +15,21 @@ from orca.engine.types import (
 class TestParseSimpleConfig:
     def test_states_exist(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        assert set(cfg.states.keys()) == {"todo", "implementing", "done"}
+        assert set(cfg.types["default"].states.keys()) == {"todo", "implementing", "done"}
 
     def test_initial_state(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        assert cfg.initial == "todo"
+        assert cfg.types["default"].initial == "todo"
 
     def test_terminal_state(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        assert cfg.states["done"].terminal is True
-        assert cfg.states["done"].worker is None
-        assert cfg.states["done"].on == {}
+        assert cfg.types["default"].states["done"].terminal is True
+        assert cfg.types["default"].states["done"].worker is None
+        assert cfg.types["default"].states["done"].on == {}
 
     def test_active_state_worker(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        state = cfg.states["todo"]
+        state = cfg.types["default"].states["todo"]
         assert state.worker is not None
         assert "outcome" in state.worker.result_format
         outcome = state.worker.result_format["outcome"]
@@ -38,15 +38,15 @@ class TestParseSimpleConfig:
 
     def test_on_rules(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        assert cfg.states["todo"].on == {"start": OnTransition(target="implementing")}
-        assert cfg.states["implementing"].on == {
+        assert cfg.types["default"].states["todo"].on == {"start": OnTransition(target="implementing")}
+        assert cfg.types["default"].states["implementing"].on == {
             "complete": OnTransition(target="done"),
             "reject": OnTransition(target="todo"),
         }
 
     def test_string_result_format_field(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        rf = cfg.states["implementing"].worker
+        rf = cfg.types["default"].states["implementing"].worker
         assert rf is not None
         reason = rf.result_format["reason"]
         assert isinstance(reason, StringFieldDef)
@@ -54,25 +54,29 @@ class TestParseSimpleConfig:
 
     def test_required_when_normalization(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        rf = cfg.states["implementing"].worker
+        rf = cfg.types["default"].states["implementing"].worker
         assert rf is not None
         reason = rf.result_format["reason"]
         assert isinstance(reason, StringFieldDef)
         assert reason.required_when == ["reject"]
 
+    def test_root_type_is_default(self, simple_config_yaml: str) -> None:
+        cfg = parse_config(simple_config_yaml)
+        assert cfg.root_type == "default"
+
 
 class TestParseDecomposeConfig:
     def test_on_decompose_rule(self, decompose_config_yaml: str) -> None:
         cfg = parse_config(decompose_config_yaml)
-        assert isinstance(cfg.states["scoping"].on["decompose"], OnDecompose)
+        assert isinstance(cfg.types["default"].states["scoping"].on["decompose"], OnDecompose)
 
     def test_on_transition_rule(self, decompose_config_yaml: str) -> None:
         cfg = parse_config(decompose_config_yaml)
-        assert cfg.states["scoping"].on["implement"] == OnTransition(target="implementing")
+        assert cfg.types["default"].states["scoping"].on["implement"] == OnTransition(target="implementing")
 
     def test_list_field_def_with_issue_items(self, decompose_config_yaml: str) -> None:
         cfg = parse_config(decompose_config_yaml)
-        worker = cfg.states["scoping"].worker
+        worker = cfg.types["default"].states["scoping"].worker
         assert worker is not None
         sub = worker.result_format["sub_issues"]
         assert isinstance(sub, ListFieldDef)
@@ -83,21 +87,22 @@ class TestParseDecomposeConfig:
 class TestParseMaxWorkersConfig:
     def test_max_workers(self, max_workers_config_yaml: str) -> None:
         cfg = parse_config(max_workers_config_yaml)
-        assert cfg.states["apply"].max_workers == 1
+        assert cfg.types["default"].states["apply"].max_workers == 1
 
     def test_no_max_workers_default(self, max_workers_config_yaml: str) -> None:
         cfg = parse_config(max_workers_config_yaml)
-        assert cfg.states["todo"].max_workers is None
+        assert cfg.types["default"].states["todo"].max_workers is None
 
 
 class TestParseIssueFields:
     def test_issue_fields(self, simple_config_yaml: str) -> None:
         cfg = parse_config(simple_config_yaml)
-        assert "title" in cfg.issue_fields
-        assert cfg.issue_fields["title"].type == "string"
-        assert cfg.issue_fields["title"].description == "Issue title"
-        assert "priority" in cfg.issue_fields
-        assert cfg.issue_fields["priority"].type == "enum"
+        fields = cfg.types["default"].fields
+        assert "title" in fields
+        assert fields["title"].type == "string"
+        assert fields["title"].description == "Issue title"
+        assert "priority" in fields
+        assert fields["priority"].type == "enum"
 
 
 class TestValidationErrors:
@@ -461,7 +466,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        assert cfg.states["todo"].max_visits == 5
+        assert cfg.types["default"].states["todo"].max_visits == 5
 
 
 class TestWorkerDefFields:
@@ -486,7 +491,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.kind == "claude-code"
         assert worker.prompt == "prompts/work.md"
@@ -514,7 +519,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.timeout == 300
 
@@ -609,7 +614,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.model == "anthropic/claude-sonnet-4-5"
 
@@ -635,7 +640,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.args == ("--max-turns", "100")
 
@@ -660,7 +665,7 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.model is None
         assert worker.args is None
@@ -687,6 +692,160 @@ states:
 initial: todo
 """
         cfg = parse_config(yaml_str)
-        worker = cfg.states["todo"].worker
+        worker = cfg.types["default"].states["todo"].worker
         assert worker is not None
         assert worker.kind == "opencode"
+
+
+class TestParseTypedConfig:
+    TYPED_YAML = """\
+root_type: epic
+max_hops: 15
+types:
+  epic:
+    fields:
+      title: {type: string, description: "Title"}
+      scope: {type: string, description: "Scope"}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: prompts/scope.md
+          result_format:
+            outcome:
+              type: enum
+              values: [ready, decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          ready: done
+          decompose:
+            action: decompose
+            child_type: task
+            then: done
+      done:
+        terminal: true
+  task:
+    fields:
+      title: {type: string, description: "Title"}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: prompts/impl.md
+          result_format:
+            outcome:
+              type: enum
+              values: [done]
+              description: d
+        on:
+          done: done
+      done:
+        terminal: true
+"""
+
+    def test_root_type(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.root_type == "epic"
+
+    def test_types_parsed(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert set(cfg.types.keys()) == {"epic", "task"}
+
+    def test_epic_fields(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert "title" in cfg.types["epic"].fields
+        assert "scope" in cfg.types["epic"].fields
+
+    def test_task_initial(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.types["task"].initial == "implementing"
+
+    def test_decompose_child_type(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        rule = cfg.types["epic"].states["scoping"].on["decompose"]
+        assert isinstance(rule, OnDecompose)
+        assert rule.child_type == "task"
+
+    def test_max_hops(self) -> None:
+        cfg = parse_config(self.TYPED_YAML)
+        assert cfg.max_hops == 15
+
+
+class TestTypedConfigValidation:
+    def test_root_type_must_exist(self) -> None:
+        yaml_str = """\
+root_type: ghost
+types:
+  epic:
+    fields: {}
+    initial: done
+    states:
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="root_type.*ghost"):
+            parse_config(yaml_str)
+
+    def test_child_type_must_exist(self) -> None:
+        yaml_str = """\
+root_type: epic
+types:
+  epic:
+    fields: {}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [decompose], description: d}
+            sub_issues: {type: list, items: "$issue", required_when: [decompose], description: s}
+        on:
+          decompose:
+            action: decompose
+            child_type: ghost
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="child_type.*ghost"):
+            parse_config(yaml_str)
+
+    def test_cross_type_transition_rejected(self) -> None:
+        yaml_str = """\
+root_type: epic
+types:
+  epic:
+    fields: {}
+    initial: todo
+    states:
+      todo:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [go], description: d}
+        on:
+          go: implementing
+      done: {terminal: true}
+  task:
+    fields: {}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome: {type: enum, values: [done], description: d}
+        on:
+          done: done
+      done: {terminal: true}
+"""
+        with pytest.raises(ConfigValidationError, match="implementing.*does not exist"):
+            parse_config(yaml_str)

--- a/tests/engine/test_dispatch.py
+++ b/tests/engine/test_dispatch.py
@@ -21,6 +21,7 @@ from orca.engine.types import (
     StateDef,
     StateMachineConfig,
     StringFieldDef,
+    TypeDef,
     WorkerDef,
 )
 
@@ -65,9 +66,14 @@ def _make_config(
             "done": StateDef(terminal=True),
         }
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial=initial,
-        states=states,
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial=initial,
+                states=states,
+            )
+        },
     )
 
 
@@ -82,6 +88,7 @@ def _make_issue(
     hop_count: int = 0,
 ) -> Issue:
     return Issue(
+        type="default",
         fields=fields or {"title": "Test"},
         state=state,
         worker_active=worker_active,
@@ -201,7 +208,7 @@ class TestBuildIssueContext:
 class TestBuildResultFormat:
     def test_enum_field(self) -> None:
         config = _make_config()
-        result = build_result_format(config, "todo")
+        result = build_result_format(config, "default", "todo")
         assert result["outcome"] == {
             "type": "enum",
             "values": ["start"],
@@ -225,7 +232,7 @@ class TestBuildResultFormat:
             "done": StateDef(terminal=True),
         }
         config = _make_config(states=states, initial="review")
-        result = build_result_format(config, "review")
+        result = build_result_format(config, "default", "review")
         assert result["reason"] == {
             "type": "string",
             "description": "Explanation",
@@ -250,7 +257,7 @@ class TestBuildResultFormat:
             "done": StateDef(terminal=True),
         }
         config = _make_config(states=states, initial="scoping")
-        result = build_result_format(config, "scoping")
+        result = build_result_format(config, "default", "scoping")
         assert result["sub_issues"] == {
             "type": "list",
             "description": "Sub-issues",
@@ -297,7 +304,7 @@ class TestTryDispatch:
         try_dispatch(config, state, "B", effects)
         assert len(effects) == 0
         assert state.issues["B"].worker_active is False
-        assert state.worker_queues["apply"] == ["B"]
+        assert state.worker_queues["default:apply"] == ["B"]
 
     def test_blocked_issue_not_dispatched(self) -> None:
         config = _make_config()
@@ -329,15 +336,15 @@ class TestBackfillQueue:
                 "A": _make_issue(state="apply"),
                 "B": _make_issue(state="apply"),
             },
-            worker_queues={"apply": ["A", "B"]},
+            worker_queues={"default:apply": ["A", "B"]},
         )
         effects: list[Effect] = []
-        backfill_queue(config, state, "apply", effects)
+        backfill_queue(config, state, "default:apply", effects)
         assert len(effects) == 1
         assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "A"
         assert state.issues["A"].worker_active is True
-        assert state.worker_queues["apply"] == ["B"]
+        assert state.worker_queues["default:apply"] == ["B"]
 
     def test_backfill_skips_blocked_decomposition(self) -> None:
         config = _make_config()
@@ -347,14 +354,14 @@ class TestBackfillQueue:
                 "B": _make_issue(state="apply"),
                 "C": _make_issue(state="implementing", decomposed_from="A"),
             },
-            worker_queues={"apply": ["A", "B"]},
+            worker_queues={"default:apply": ["A", "B"]},
         )
         effects: list[Effect] = []
-        backfill_queue(config, state, "apply", effects)
+        backfill_queue(config, state, "default:apply", effects)
         assert len(effects) == 1
         assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "B"
-        assert state.worker_queues["apply"] == ["A"]
+        assert state.worker_queues["default:apply"] == ["A"]
 
     def test_backfill_skips_blocked_dependency(self) -> None:
         config = _make_config()
@@ -364,27 +371,27 @@ class TestBackfillQueue:
                 "B": _make_issue(state="apply"),
                 "C": _make_issue(state="implementing"),
             },
-            worker_queues={"apply": ["A", "B"]},
+            worker_queues={"default:apply": ["A", "B"]},
         )
         effects: list[Effect] = []
-        backfill_queue(config, state, "apply", effects)
+        backfill_queue(config, state, "default:apply", effects)
         assert len(effects) == 1
         assert isinstance(effects[0], DispatchWorkerEffect)
         assert effects[0].issue_id == "B"
-        assert state.worker_queues["apply"] == ["A"]
+        assert state.worker_queues["default:apply"] == ["A"]
 
 
 class TestRemoveFromQueue:
     def test_remove_existing(self) -> None:
-        state = State(issues={}, worker_queues={"apply": ["A", "B", "C"]})
-        remove_from_queue(state, "apply", "B")
-        assert state.worker_queues["apply"] == ["A", "C"]
+        state = State(issues={}, worker_queues={"default:apply": ["A", "B", "C"]})
+        remove_from_queue(state, "default:apply", "B")
+        assert state.worker_queues["default:apply"] == ["A", "C"]
 
     def test_remove_nonexistent_no_error(self) -> None:
-        state = State(issues={}, worker_queues={"apply": ["A"]})
-        remove_from_queue(state, "apply", "Z")
-        assert state.worker_queues["apply"] == ["A"]
+        state = State(issues={}, worker_queues={"default:apply": ["A"]})
+        remove_from_queue(state, "default:apply", "Z")
+        assert state.worker_queues["default:apply"] == ["A"]
 
     def test_remove_from_missing_queue_no_error(self) -> None:
         state = State(issues={}, worker_queues={})
-        remove_from_queue(state, "apply", "A")  # should not raise
+        remove_from_queue(state, "default:apply", "A")  # should not raise

--- a/tests/engine/test_event_log.py
+++ b/tests/engine/test_event_log.py
@@ -13,6 +13,7 @@ from orca.engine.types import (
     State,
     StateDef,
     StateMachineConfig,
+    TypeDef,
     WorkerDef,
     WorkerFailedEvent,
     WorkerResultEvent,
@@ -37,21 +38,26 @@ def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
 def _passive_initial_config() -> StateMachineConfig:
     """Config where initial state 'backlog' is passive (no worker)."""
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial="backlog",
-        states={
-            "backlog": StateDef(),
-            "todo": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
-                    },
-                ),
-                on={},
-            ),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial="backlog",
+                states={
+                    "backlog": StateDef(),
+                    "todo": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                            },
+                        ),
+                        on={},
+                    ),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 
@@ -59,20 +65,29 @@ def _passive_initial_config() -> StateMachineConfig:
 def _active_initial_config() -> StateMachineConfig:
     """Config where initial state 'todo' is active (has worker)."""
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial="todo",
-        states={
-            "todo": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["done"], description="Decision"),
-                    },
-                ),
-                on={"done": __import__("orca.engine.types", fromlist=["OnTransition"]).OnTransition(target="done")},
-            ),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial="todo",
+                states={
+                    "todo": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["done"], description="Decision"),
+                            },
+                        ),
+                        on={
+                            "done": __import__("orca.engine.types", fromlist=["OnTransition"]).OnTransition(
+                                target="done"
+                            )
+                        },
+                    ),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 

--- a/tests/engine/test_formatting.py
+++ b/tests/engine/test_formatting.py
@@ -8,6 +8,7 @@ from orca.engine.types import (
     State,
     StateDef,
     StateMachineConfig,
+    TypeDef,
 )
 
 
@@ -15,13 +16,18 @@ def _make_config(
     states: dict[str, StateDef] | None = None,
 ) -> StateMachineConfig:
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="t")},
-        initial="todo",
-        states=states
-        or {
-            "todo": StateDef(),
-            "work": StateDef(),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="t")},
+                initial="todo",
+                states=states
+                or {
+                    "todo": StateDef(),
+                    "work": StateDef(),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 
@@ -36,6 +42,7 @@ def _make_issue(
     if created_ts is not None:
         event_log.append(EventLogEntry(timestamp=created_ts, type="created", data={}))
     return Issue(
+        type="default",
         fields={"title": "Test"},
         state=state,
         worker_active=False,
@@ -128,10 +135,10 @@ class TestFormatIssues:
                 "I-1": _make_issue(state="work"),
                 "I-2": _make_issue(state="work"),
             },
-            worker_queues={"work": ["I-3", "I-4"]},
+            worker_queues={"default:work": ["I-3", "I-4"]},
         )
         result = format_issues(state, _make_config(), now="2026-01-01T00:00:00Z")
-        assert "Queued in 'work': I-3, I-4" in result
+        assert "Queued in 'default:work': I-3, I-4" in result
 
     def test_no_created_event_shows_question_mark(self) -> None:
         state = State(

--- a/tests/engine/test_reducer_advance.py
+++ b/tests/engine/test_reducer_advance.py
@@ -13,6 +13,7 @@ from orca.engine.types import (
     State,
     StateDef,
     StateMachineConfig,
+    TypeDef,
     WorkerDef,
 )
 
@@ -39,6 +40,7 @@ def _make_issue(
     depends_on: list[str] | None = None,
 ) -> Issue:
     return Issue(
+        type="default",
         fields={"title": "Test"},
         state=state,
         worker_active=worker_active,
@@ -53,32 +55,37 @@ def _make_issue(
 def _config() -> StateMachineConfig:
     """Config with passive 'backlog', active 'todo' and 'implementing', terminal 'done'."""
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial="backlog",
-        states={
-            "backlog": StateDef(),
-            "review": StateDef(),
-            "todo": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
-                    },
-                ),
-                on={},
-            ),
-            "implementing": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["complete"], description="Outcome"),
-                    },
-                ),
-                on={},
-            ),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial="backlog",
+                states={
+                    "backlog": StateDef(),
+                    "review": StateDef(),
+                    "todo": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                            },
+                        ),
+                        on={},
+                    ),
+                    "implementing": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["complete"], description="Outcome"),
+                            },
+                        ),
+                        on={},
+                    ),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 

--- a/tests/engine/test_reducer_create.py
+++ b/tests/engine/test_reducer_create.py
@@ -12,6 +12,7 @@ from orca.engine.types import (
     State,
     StateDef,
     StateMachineConfig,
+    TypeDef,
     WorkerDef,
 )
 
@@ -34,21 +35,26 @@ def _clock(value: str = "2026-01-01T00:00:00Z") -> Callable[[], str]:
 def _passive_initial_config() -> StateMachineConfig:
     """Config where initial state 'backlog' is passive (no worker)."""
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial="backlog",
-        states={
-            "backlog": StateDef(),
-            "todo": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
-                    },
-                ),
-                on={},
-            ),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial="backlog",
+                states={
+                    "backlog": StateDef(),
+                    "todo": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                            },
+                        ),
+                        on={},
+                    ),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 
@@ -56,20 +62,25 @@ def _passive_initial_config() -> StateMachineConfig:
 def _active_initial_config() -> StateMachineConfig:
     """Config where initial state 'todo' is active (has worker)."""
     return StateMachineConfig(
-        issue_fields={"title": FieldDef(type="string", description="Title")},
-        initial="todo",
-        states={
-            "todo": StateDef(
-                worker=WorkerDef(
-                    kind="claude-code",
-                    prompt="prompts/default.md",
-                    result_format={
-                        "outcome": EnumFieldDef(values=["start"], description="Decision"),
-                    },
-                ),
-                on={},
-            ),
-            "done": StateDef(terminal=True),
+        root_type="default",
+        types={
+            "default": TypeDef(
+                fields={"title": FieldDef(type="string", description="Title")},
+                initial="todo",
+                states={
+                    "todo": StateDef(
+                        worker=WorkerDef(
+                            kind="claude-code",
+                            prompt="prompts/default.md",
+                            result_format={
+                                "outcome": EnumFieldDef(values=["start"], description="Decision"),
+                            },
+                        ),
+                        on={},
+                    ),
+                    "done": StateDef(terminal=True),
+                },
+            )
         },
     )
 

--- a/tests/engine/test_reducer_worker_failed.py
+++ b/tests/engine/test_reducer_worker_failed.py
@@ -125,7 +125,7 @@ class TestWorkerFailedRetainsSlot:
         )
         assert state.issues["B"].state == "apply"
         assert state.issues["B"].worker_active is False
-        assert "B" in state.worker_queues.get("apply", [])
+        assert "B" in state.worker_queues.get("default:apply", [])
 
         # A's worker fails — slot is retained, B stays queued
         state, effects = reduce(
@@ -140,7 +140,7 @@ class TestWorkerFailedRetainsSlot:
         assert state.issues["A"].worker_active is True
         # B still queued, not dispatched
         assert state.issues["B"].worker_active is False
-        assert "B" in state.worker_queues.get("apply", [])
+        assert "B" in state.worker_queues.get("default:apply", [])
 
         # Only A gets a retry dispatch, not B
         dispatch_effects = [e for e in effects if isinstance(e, DispatchWorkerEffect)]

--- a/tests/engine/test_reducer_worker_result.py
+++ b/tests/engine/test_reducer_worker_result.py
@@ -353,7 +353,7 @@ class TestDecomposeCreatesChildren:
         for cid in child_ids:
             child = state.issues[cid]
             assert child.decomposed_from == "P"
-            assert child.state == config.initial  # "todo"
+            assert child.state == config.root_type_def.initial  # "todo"
 
 
 class TestDecomposeWithDependsOn:

--- a/tests/engine/test_scenario_pipeline.py
+++ b/tests/engine/test_scenario_pipeline.py
@@ -137,7 +137,7 @@ class TestSerializedMerge4Issues:
             assert state.issues[iid].worker_active is False
 
         # Queue should contain P-2, P-3, P-4
-        assert state.worker_queues.get("apply") == ["P-2", "P-3", "P-4"]
+        assert state.worker_queues.get("default:apply") == ["P-2", "P-3", "P-4"]
 
         # Merge them one by one
         for i, iid in enumerate(ids):
@@ -184,7 +184,7 @@ class TestConflictFreesSlotForNext:
 
         assert state.issues["P-1"].worker_active is True
         assert state.issues["P-2"].worker_active is False
-        assert state.worker_queues.get("apply") == ["P-2"]
+        assert state.worker_queues.get("default:apply") == ["P-2"]
 
         # P-1 conflicts → goes back to implementing, P-2 gets dispatched in apply
         state, effects = reduce(
@@ -219,7 +219,7 @@ class TestConflictReenterAtBackOfQueue:
             state = _advance_to_apply(config, state, iid, gen)
 
         assert state.issues["P-1"].worker_active is True
-        assert state.worker_queues.get("apply") == ["P-2", "P-3"]
+        assert state.worker_queues.get("default:apply") == ["P-2", "P-3"]
 
         # P-1 conflicts → goes back to implementing
         state, effects = reduce(
@@ -236,7 +236,7 @@ class TestConflictReenterAtBackOfQueue:
         assert state.issues["P-2"].state == "apply"
 
         # Queue should now be just P-3
-        assert state.worker_queues.get("apply") == ["P-3"]
+        assert state.worker_queues.get("default:apply") == ["P-3"]
 
         # P-1 goes back through implementing→qa→apply, should end up queued behind P-3
         state, _ = reduce(
@@ -248,7 +248,7 @@ class TestConflictReenterAtBackOfQueue:
 
         assert state.issues["P-1"].state == "apply"
         assert state.issues["P-1"].worker_active is False
-        assert state.worker_queues.get("apply") == ["P-3", "P-1"]
+        assert state.worker_queues.get("default:apply") == ["P-3", "P-1"]
 
 
 class TestWorkerFailedRetainsSlot:
@@ -266,7 +266,7 @@ class TestWorkerFailedRetainsSlot:
             state = _advance_to_apply(config, state, iid, gen)
 
         assert state.issues["P-1"].worker_active is True
-        assert state.worker_queues.get("apply") == ["P-2"]
+        assert state.worker_queues.get("default:apply") == ["P-2"]
 
         # Worker fails on P-1 → slot retained, P-2 stays queued
         state, effects = reduce(
@@ -283,4 +283,4 @@ class TestWorkerFailedRetainsSlot:
 
         # P-2 should still be queued
         assert state.issues["P-2"].worker_active is False
-        assert state.worker_queues.get("apply") == ["P-2"]
+        assert state.worker_queues.get("default:apply") == ["P-2"]

--- a/tests/engine/test_scenario_serialization.py
+++ b/tests/engine/test_scenario_serialization.py
@@ -273,7 +273,7 @@ class TestQueueOrderSurvivesRoundtrip:
         state = _roundtrip(state)
 
         # Verify queue survived
-        assert state.worker_queues.get("work") == ["Q-2", "Q-3", "Q-4", "Q-5"]
+        assert state.worker_queues.get("default:work") == ["Q-2", "Q-3", "Q-4", "Q-5"]
 
         # Complete Q-1 on restored state
         state, effects = reduce(

--- a/tests/engine/test_scenario_typed_decompose.py
+++ b/tests/engine/test_scenario_typed_decompose.py
@@ -1,4 +1,5 @@
 """Typed decomposition scenario: epic -> task with different flows."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -76,10 +77,12 @@ def _clock(value: str = TS) -> Callable[[], str]:
 
 def _counter() -> Callable[[], str]:
     n = 0
+
     def gen() -> str:
         nonlocal n
         n += 1
         return f"GEN-{n}"
+
     return gen
 
 
@@ -91,9 +94,11 @@ class TestTypedDecomposition:
 
         # Create epic — starts in scoping
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="EPIC-1", fields={"title": "Big feature", "scope": "all"}, timestamp=TS),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
         assert state.issues["EPIC-1"].type == "epic"
         assert state.issues["EPIC-1"].state == "scoping"
@@ -103,7 +108,8 @@ class TestTypedDecomposition:
 
         # Epic decomposes into 2 tasks
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="EPIC-1",
                 result={
@@ -115,7 +121,8 @@ class TestTypedDecomposition:
                 },
                 timestamp=TS,
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Epic transitions to done via `then: done`
@@ -137,9 +144,11 @@ class TestTypedDecomposition:
         # Complete both tasks
         for cid in child_ids:
             state, _ = reduce(
-                config, state,
+                config,
+                state,
                 WorkerResultEvent(issue_id=cid, result={"outcome": "done"}, timestamp=TS),
-                gen, _clock(),
+                gen,
+                _clock(),
             )
             assert state.issues[cid].state == "done"
 
@@ -149,14 +158,17 @@ class TestTypedDecomposition:
         state = State(issues={}, worker_queues={})
 
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="EPIC-1", fields={"title": "Feature", "scope": "all"}, timestamp=TS),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         # Worker overrides one child to be an epic (recursive decomposition)
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="EPIC-1",
                 result={
@@ -168,7 +180,8 @@ class TestTypedDecomposition:
                 },
                 timestamp=TS,
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         children = {
@@ -218,19 +231,23 @@ types:
         state = State(issues={}, worker_queues={})
 
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="E1", fields={"title": "X"}, timestamp=TS),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="E1",
                 result={"outcome": "decompose", "sub_issues": [{"key": "a", "fields": {"title": "A"}}]},
                 timestamp=TS,
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
@@ -244,13 +261,16 @@ types:
         state = State(issues={}, worker_queues={})
 
         state, _ = reduce(
-            config, state,
+            config,
+            state,
             CreateEvent(issue_id="E1", fields={"title": "X", "scope": "all"}, timestamp=TS),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         state, effects = reduce(
-            config, state,
+            config,
+            state,
             WorkerResultEvent(
                 issue_id="E1",
                 result={
@@ -259,7 +279,8 @@ types:
                 },
                 timestamp=TS,
             ),
-            gen, _clock(),
+            gen,
+            _clock(),
         )
 
         error_effects = [e for e in effects if isinstance(e, ErrorEffect)]

--- a/tests/engine/test_scenario_typed_decompose.py
+++ b/tests/engine/test_scenario_typed_decompose.py
@@ -1,0 +1,267 @@
+"""Typed decomposition scenario: epic -> task with different flows."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orca.engine.config import parse_config
+from orca.engine.reducer import reduce
+from orca.engine.types import (
+    CreateEvent,
+    DispatchWorkerEffect,
+    ErrorEffect,
+    State,
+    WorkerResultEvent,
+)
+
+TYPED_CONFIG = """\
+root_type: epic
+max_hops: 20
+
+types:
+  epic:
+    fields:
+      title: {type: string, description: Title}
+      scope: {type: string, description: Scope}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: prompts/scope.md
+          result_format:
+            outcome:
+              type: enum
+              values: [ready, decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          ready: done
+          decompose:
+            action: decompose
+            child_type: task
+            then: done
+      done:
+        terminal: true
+
+  task:
+    fields:
+      title: {type: string, description: Title}
+    initial: implementing
+    states:
+      implementing:
+        worker:
+          kind: claude-code
+          prompt: prompts/impl.md
+          result_format:
+            outcome:
+              type: enum
+              values: [done]
+              description: d
+        on:
+          done: done
+      done:
+        terminal: true
+"""
+
+TS = "2026-01-01T00:00:00Z"
+
+
+def _clock(value: str = TS) -> Callable[[], str]:
+    return lambda: value
+
+
+def _counter() -> Callable[[], str]:
+    n = 0
+    def gen() -> str:
+        nonlocal n
+        n += 1
+        return f"GEN-{n}"
+    return gen
+
+
+class TestTypedDecomposition:
+    def test_epic_decomposes_into_tasks_with_different_flow(self) -> None:
+        config = parse_config(TYPED_CONFIG)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        # Create epic — starts in scoping
+        state, effects = reduce(
+            config, state,
+            CreateEvent(issue_id="EPIC-1", fields={"title": "Big feature", "scope": "all"}, timestamp=TS),
+            gen, _clock(),
+        )
+        assert state.issues["EPIC-1"].type == "epic"
+        assert state.issues["EPIC-1"].state == "scoping"
+        dispatches = [e for e in effects if isinstance(e, DispatchWorkerEffect)]
+        assert len(dispatches) == 1
+        assert dispatches[0].issue_type == "epic"
+
+        # Epic decomposes into 2 tasks
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="EPIC-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "api", "fields": {"title": "Build API"}},
+                        {"key": "ui", "fields": {"title": "Build UI"}},
+                    ],
+                },
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        # Epic transitions to done via `then: done`
+        assert state.issues["EPIC-1"].state == "done"
+
+        # Children are TASKS starting at IMPLEMENTING (not scoping!)
+        child_ids = [iid for iid, iss in state.issues.items() if iss.decomposed_from == "EPIC-1"]
+        assert len(child_ids) == 2
+        for cid in child_ids:
+            assert state.issues[cid].type == "task"
+            assert state.issues[cid].state == "implementing"
+            assert state.issues[cid].worker_active is True
+
+        # Dispatch effects should have issue_type="task"
+        task_dispatches = [e for e in effects if isinstance(e, DispatchWorkerEffect) and e.issue_id in child_ids]
+        for d in task_dispatches:
+            assert d.issue_type == "task"
+
+        # Complete both tasks
+        for cid in child_ids:
+            state, _ = reduce(
+                config, state,
+                WorkerResultEvent(issue_id=cid, result={"outcome": "done"}, timestamp=TS),
+                gen, _clock(),
+            )
+            assert state.issues[cid].state == "done"
+
+    def test_worker_overrides_child_type(self) -> None:
+        config = parse_config(TYPED_CONFIG)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="EPIC-1", fields={"title": "Feature", "scope": "all"}, timestamp=TS),
+            gen, _clock(),
+        )
+
+        # Worker overrides one child to be an epic (recursive decomposition)
+        state, _ = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="EPIC-1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [
+                        {"key": "sub-epic", "type": "epic", "fields": {"title": "Sub-epic", "scope": "sub"}},
+                        {"key": "task", "fields": {"title": "Simple task"}},
+                    ],
+                },
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        children = {
+            state.issues[iid].fields["title"]: state.issues[iid]
+            for iid in state.issues
+            if state.issues[iid].decomposed_from == "EPIC-1"
+        }
+        # Sub-epic starts in scoping (epic flow)
+        assert children["Sub-epic"].type == "epic"
+        assert children["Sub-epic"].state == "scoping"
+        # Simple task starts in implementing (task flow)
+        assert children["Simple task"].type == "task"
+        assert children["Simple task"].state == "implementing"
+
+    def test_missing_child_type_errors(self) -> None:
+        """If decompose rule has no child_type and worker doesn't specify, error."""
+        no_child_type_config = """\
+root_type: epic
+types:
+  epic:
+    fields:
+      title: {type: string, description: Title}
+    initial: scoping
+    states:
+      scoping:
+        worker:
+          kind: claude-code
+          prompt: p.md
+          result_format:
+            outcome:
+              type: enum
+              values: [decompose]
+              description: d
+            sub_issues:
+              type: list
+              items: "$issue"
+              required_when: [decompose]
+              description: s
+        on:
+          decompose:
+            action: decompose
+      done:
+        terminal: true
+"""
+        config = parse_config(no_child_type_config)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="E1", fields={"title": "X"}, timestamp=TS),
+            gen, _clock(),
+        )
+
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="E1",
+                result={"outcome": "decompose", "sub_issues": [{"key": "a", "fields": {"title": "A"}}]},
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) >= 1
+        assert "type" in error_effects[0].message.lower() or "child_type" in error_effects[0].message.lower()
+
+    def test_unknown_child_type_errors(self) -> None:
+        """If worker specifies a type that doesn't exist, error."""
+        config = parse_config(TYPED_CONFIG)
+        gen = _counter()
+        state = State(issues={}, worker_queues={})
+
+        state, _ = reduce(
+            config, state,
+            CreateEvent(issue_id="E1", fields={"title": "X", "scope": "all"}, timestamp=TS),
+            gen, _clock(),
+        )
+
+        state, effects = reduce(
+            config, state,
+            WorkerResultEvent(
+                issue_id="E1",
+                result={
+                    "outcome": "decompose",
+                    "sub_issues": [{"key": "a", "type": "nonexistent", "fields": {"title": "A"}}],
+                },
+                timestamp=TS,
+            ),
+            gen, _clock(),
+        )
+
+        error_effects = [e for e in effects if isinstance(e, ErrorEffect)]
+        assert len(error_effects) >= 1
+        assert "nonexistent" in error_effects[0].message

--- a/tests/engine/test_types.py
+++ b/tests/engine/test_types.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from orca.engine.types import (
     AdvanceEvent,
     CreateEvent,
@@ -18,6 +20,7 @@ from orca.engine.types import (
     StateDef,
     StateMachineConfig,
     StringFieldDef,
+    TypeDef,
     WorkerDef,
     WorkerFailedEvent,
     WorkerResultEvent,
@@ -27,6 +30,7 @@ from orca.engine.types import (
 class TestIssueConstruction:
     def test_issue_with_all_dag_fields(self) -> None:
         issue = Issue(
+            type="issue",
             fields={"title": "Fix bug", "priority": "high"},
             state="open",
             worker_active=False,
@@ -47,6 +51,7 @@ class TestIssueConstruction:
 
     def test_issue_without_decomposed_from(self) -> None:
         issue = Issue(
+            type="issue",
             fields={"title": "Root issue"},
             state="open",
             worker_active=False,
@@ -88,6 +93,7 @@ class TestSerializationRoundTrip:
         state = State(
             issues={
                 "ISS-1": Issue(
+                    type="issue",
                     fields={"title": "Do thing"},
                     state="open",
                     worker_active=False,
@@ -113,6 +119,7 @@ class TestSerializationRoundTrip:
         state = State(
             issues={
                 "ISS-1": Issue(
+                    type="issue",
                     fields={"title": "Task"},
                     state="review",
                     worker_active=False,
@@ -160,6 +167,7 @@ class TestSerializationRoundTrip:
         state = State(
             issues={
                 "ISS-1": Issue(
+                    type="issue",
                     fields={},
                     state="blocked",
                     worker_active=False,
@@ -180,6 +188,7 @@ class TestSerializationRoundTrip:
 
     def test_issue_visit_counts_hop_count_round_trip(self) -> None:
         issue = Issue(
+            type="issue",
             fields={"title": "Test"},
             state="review",
             worker_active=False,
@@ -197,6 +206,7 @@ class TestSerializationRoundTrip:
     def test_issue_from_dict_backward_compat(self) -> None:
         """from_dict handles missing visit_counts, hop_count, and event_log."""
         raw = {
+            "type": "issue",
             "fields": {"title": "Old"},
             "state": "open",
             "worker_active": False,
@@ -239,6 +249,7 @@ class TestEffects:
     def test_dispatch_worker_effect(self) -> None:
         e = DispatchWorkerEffect(
             issue_id="ISS-1",
+            issue_type="issue",
             state="triage",
             result_format={"decision": {"type": "enum", "values": ["approve", "reject"]}},
             issue={"title": "Fix bug"},
@@ -345,8 +356,8 @@ class TestConfigTypes:
         assert s.max_visits == 5
 
     def test_state_machine_config(self) -> None:
-        config = StateMachineConfig(
-            issue_fields={
+        td = TypeDef(
+            fields={
                 "title": FieldDef(type="string", description="Title"),
                 "priority": FieldDef(type="enum", description="Priority level"),
             },
@@ -369,17 +380,153 @@ class TestConfigTypes:
                 "closed": StateDef(terminal=True),
             },
         )
-        assert config.initial == "triage"
-        assert len(config.states) == 3
-        assert config.states["closed"].terminal is True
-        assert len(config.issue_fields) == 2
+        config = StateMachineConfig(root_type="issue", types={"issue": td})
+        assert config.root_type_def.initial == "triage"
+        assert len(config.root_type_def.states) == 3
+        assert config.root_type_def.states["closed"].terminal is True
+        assert len(config.root_type_def.fields) == 2
         assert config.max_hops is None
 
     def test_state_machine_config_with_max_hops(self) -> None:
-        config = StateMachineConfig(
-            issue_fields={},
+        td = TypeDef(
+            fields={},
             initial="todo",
             states={"todo": StateDef(terminal=True)},
+        )
+        config = StateMachineConfig(
+            root_type="issue",
+            types={"issue": td},
             max_hops=50,
         )
         assert config.max_hops == 50
+
+
+class TestTypeDef:
+    def test_type_def_holds_fields_initial_states(self) -> None:
+        td = TypeDef(
+            fields={"title": FieldDef(type="string", description="t")},
+            initial="todo",
+            states={"todo": StateDef(terminal=True)},
+        )
+        assert td.initial == "todo"
+        assert "title" in td.fields
+        assert "todo" in td.states
+
+
+class TestStateMachineConfigWithTypes:
+    def test_config_has_root_type_and_types(self) -> None:
+        td = TypeDef(
+            fields={},
+            initial="done",
+            states={"done": StateDef(terminal=True)},
+        )
+        cfg = StateMachineConfig(
+            root_type="epic",
+            types={"epic": td},
+            max_hops=None,
+            max_worker_retries=5,
+        )
+        assert cfg.root_type == "epic"
+        assert "epic" in cfg.types
+
+
+class TestConfigHelpers:
+    def _make_config(self) -> StateMachineConfig:
+        worker = WorkerDef(
+            kind="claude-code",
+            prompt="p.md",
+            result_format={"outcome": EnumFieldDef(values=["done"], description="d")},
+        )
+        epic = TypeDef(
+            fields={"title": FieldDef(type="string", description="t")},
+            initial="todo",
+            states={
+                "todo": StateDef(worker=worker, on={"done": OnTransition(target="done")}),
+                "done": StateDef(terminal=True),
+            },
+        )
+        return StateMachineConfig(root_type="epic", types={"epic": epic})
+
+    def test_get_type_def(self) -> None:
+        cfg = self._make_config()
+        td = cfg.get_type("epic")
+        assert td.initial == "todo"
+
+    def test_get_state_def(self) -> None:
+        cfg = self._make_config()
+        sd = cfg.get_state("epic", "todo")
+        assert sd.worker is not None
+
+    def test_get_state_def_unknown_type_raises(self) -> None:
+        cfg = self._make_config()
+        with pytest.raises(KeyError):
+            cfg.get_state("unknown", "todo")
+
+    def test_root_type_def(self) -> None:
+        cfg = self._make_config()
+        td = cfg.root_type_def
+        assert td.initial == "todo"
+
+
+class TestOnDecomposeChildType:
+    def test_child_type_default_none(self) -> None:
+        rule = OnDecompose()
+        assert rule.child_type is None
+        assert rule.then is None
+
+    def test_child_type_set(self) -> None:
+        rule = OnDecompose(child_type="task", then="done")
+        assert rule.child_type == "task"
+        assert rule.then == "done"
+
+
+class TestIssueType:
+    def test_issue_has_type(self) -> None:
+        issue = Issue(
+            type="epic",
+            fields={"title": "t"},
+            state="todo",
+            worker_active=False,
+            decomposed_from=None,
+            depends_on=[],
+            event_log=[],
+        )
+        assert issue.type == "epic"
+
+    def test_issue_to_dict_includes_type(self) -> None:
+        issue = Issue(
+            type="task",
+            fields={},
+            state="done",
+            worker_active=False,
+            decomposed_from=None,
+            depends_on=[],
+            event_log=[],
+        )
+        d = issue.to_dict()
+        assert d["type"] == "task"
+
+    def test_issue_from_dict_reads_type(self) -> None:
+        d = {
+            "type": "subtask",
+            "fields": {},
+            "state": "coding",
+            "worker_active": False,
+            "decomposed_from": None,
+            "depends_on": [],
+            "event_log": [],
+        }
+        issue = Issue.from_dict(d)
+        assert issue.type == "subtask"
+
+
+class TestDispatchWorkerEffectIssueType:
+    def test_effect_has_issue_type(self) -> None:
+        e = DispatchWorkerEffect(
+            issue_id="I1",
+            issue_type="task",
+            state="implementing",
+            result_format={},
+            issue={},
+        )
+        assert e.issue_type == "task"

--- a/tests/orchestrator/test_worker.py
+++ b/tests/orchestrator/test_worker.py
@@ -14,6 +14,7 @@ from orca.orchestrator.worker import KIND_REGISTRY, CliAgentWorker, KindConfig, 
 def _make_effect(state: str = "implementing") -> DispatchWorkerEffect:
     return DispatchWorkerEffect(
         issue_id="issue-1",
+        issue_type="default",
         state=state,
         result_format={
             "outcome": {"type": "enum", "values": ["done"], "description": "Outcome"},

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -15,6 +15,7 @@ def _make_state(title: str = "Root Task", state_name: str = "triage") -> State:
     return State(
         issues={
             "root-1": Issue(
+                type="default",
                 fields={"title": title, "description": "Root description"},
                 state=state_name,
                 worker_active=False,

--- a/tests/tui/test_header.py
+++ b/tests/tui/test_header.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 
-from orca.engine.types import Issue, State, StateDef, StateMachineConfig, WorkerDef
+from orca.engine.types import Issue, State, StateDef, StateMachineConfig, TypeDef, WorkerDef
 from orca.tui.widgets.header import OrcaHeader, _format_elapsed
 
 
@@ -14,7 +14,10 @@ def _make_config(states: dict[str, StateDef] | None = None) -> StateMachineConfi
             "review": StateDef(worker=WorkerDef(kind="claude-code", prompt="r.j2", result_format={})),
             "done": StateDef(terminal=True),
         }
-    return StateMachineConfig(issue_fields={}, initial="triage", states=states)
+    return StateMachineConfig(
+        root_type="default",
+        types={"default": TypeDef(fields={}, initial="triage", states=states)},
+    )
 
 
 def _make_issue(
@@ -25,6 +28,7 @@ def _make_issue(
     failure_count: int = 0,
 ) -> Issue:
     return Issue(
+        type="default",
         fields={},
         state=state,
         worker_active=worker_active,

--- a/tests/tui/test_issue_detail.py
+++ b/tests/tui/test_issue_detail.py
@@ -9,6 +9,7 @@ from orca.tui.widgets.issue_detail import IssueDetail
 
 def _make_issue(title: str = "Test", description: str = "Some description") -> Issue:
     return Issue(
+        type="default",
         fields={"title": title, "description": description},
         state="triage",
         worker_active=False,

--- a/tests/tui/test_issue_tree.py
+++ b/tests/tui/test_issue_tree.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from textual.app import App, ComposeResult
 
-from orca.engine.types import EventLogEntry, Issue, State, StateDef, StateMachineConfig
+from orca.engine.types import EventLogEntry, Issue, State, StateDef, StateMachineConfig, TypeDef
 from orca.tui.widgets.issue_tree import (
     IssueTree,
     _compute_failed_states,
@@ -27,6 +27,7 @@ def _make_issue(
     event_log: list[EventLogEntry] | None = None,
 ) -> Issue:
     return Issue(
+        type="default",
         fields={"title": title, "description": "desc"},
         state=state,
         worker_active=worker_active,
@@ -50,9 +51,8 @@ def _make_config(
             "done": StateDef(terminal=True),
         }
     return StateMachineConfig(
-        issue_fields={},
-        initial=initial,
-        states=states,
+        root_type="default",
+        types={"default": TypeDef(fields={}, initial=initial, states=states)},
     )
 
 

--- a/tests/tui/test_state_reader.py
+++ b/tests/tui/test_state_reader.py
@@ -12,6 +12,7 @@ def _make_state(title: str = "Test Issue") -> State:
     return State(
         issues={
             "issue-1": Issue(
+                type="default",
                 fields={"title": title, "description": "A test issue"},
                 state="triage",
                 worker_active=False,

--- a/tests/tui/test_status_history.py
+++ b/tests/tui/test_status_history.py
@@ -9,6 +9,7 @@ from orca.tui.widgets.status_history import StatusHistory, build_timeline
 
 def _make_issue_with_log(entries: list[EventLogEntry], current_state: str = "review") -> Issue:
     return Issue(
+        type="default",
         fields={"title": "Test", "description": "desc"},
         state=current_state,
         worker_active=False,


### PR DESCRIPTION
## Summary

- Introduces **issue types** so decomposed children can follow different state machine flows than their parent
- Each type defines its own fields schema, initial state, and state machine in `orca.yml`
- `OnDecompose` rules specify a default `child_type`; workers can override per-child
- Legacy single-type configs auto-wrapped as type `"default"` for backward compatibility
- Queue keys scoped to `(type, state)` to prevent cross-type interference

## Test plan

- [x] 372 tests passing (209 engine + 148 orchestrator/TUI + 15 other)
- [x] New `test_scenario_typed_decompose.py` covers: epic→task decomposition, worker type override, missing type error, unknown type error
- [x] All existing decomposition/pipeline/kanban/queuing scenarios pass with legacy compat
- [x] ruff lint clean, ruff format clean, mypy strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)