### PR TITLE
feat(tui): surface debug-mode pauses in header, tree, and detail (0.5.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.5.3"
+version = "0.5.4"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/src/orca/tui/app.py
+++ b/src/orca/tui/app.py
@@ -159,12 +159,41 @@ class OrcaApp(App[None]):
             self._daemon_session = None
 
     def on_mount(self) -> None:
+        # Push run context (id + browser port) into the detail widget so the
+        # debug-review URL can be constructed when an issue is paused.
+        try:
+            detail = self.query_one(IssueDetail)
+        except Exception:
+            detail = None
+        if detail is not None:
+            run_id = getattr(self, "_daemon_run_id", "") or self._derive_run_id_from_run_dir()
+            detail.set_run_context(run_id, self._read_browser_port())
+
         if self._daemon_mode:
             self._setup_daemon_polling()
         else:
             self._poll_state()
             self.set_interval(1.5, self._poll_state)
         self.set_interval(0.15, self._tick_spinners)
+
+    def _read_browser_port(self) -> int | None:
+        """Best-effort read of the daemon's browser TCP port for URL surfacing."""
+        try:
+            from orca.daemon.lifecycle import read_browser_port
+
+            repo_root = self._run_dir.parent.parent.parent
+            return read_browser_port(repo_root)
+        except Exception:
+            return None
+
+    def _derive_run_id_from_run_dir(self) -> str:
+        """Disk-mode fallback for run_id. Layout: <repo>/.orca-state/runs/<branch>/<workflow>."""
+        try:
+            workflow = self._run_dir.name
+            branch = self._run_dir.parent.name
+            return f"{branch}:{workflow}"
+        except Exception:
+            return ""
 
     def _setup_daemon_polling(self) -> None:
         """Set up async polling via DaemonStateReader."""

--- a/src/orca/tui/widgets/header.py
+++ b/src/orca/tui/widgets/header.py
@@ -50,6 +50,7 @@ class OrcaHeader(Static):
         self._state: State | None = None
         self._sessions: list[dict[str, Any]] = []
         self._active_workers: int = 0
+        self._paused_workers: int = 0
 
     def on_mount(self) -> None:
         self.update(self.render_text())
@@ -67,6 +68,10 @@ class OrcaHeader(Static):
             self._active_workers = active_workers
         else:
             self._active_workers = sum(1 for issue in state.issues.values() if issue.worker_active)
+        # Debug-mode pauses: worker completed and is waiting for human review
+        # before transitioning. Counted distinctly from active workers so the
+        # user sees "step finished, your move" rather than mistaking it for idle.
+        self._paused_workers = sum(1 for issue in state.issues.values() if getattr(issue, "debug_pending", False))
         self.update(self.render_text())
 
     def render_text(self) -> str:
@@ -81,13 +86,24 @@ class OrcaHeader(Static):
         if all_terminal:
             left = f"  \u2713 {self._branch_name} \u2502 completed"
         else:
-            # Status dot + branch name
-            dot = "[red]\u25cf[/red]" if has_failures else "[green]\u25cf[/green]"
+            # Status dot: red if failures, amber if paused for debug review,
+            # green otherwise. Paused is between healthy and broken \u2014 the run
+            # IS healthy, it just needs the user's attention.
+            if has_failures:
+                dot = "[red]\u25cf[/red]"
+            elif self._paused_workers > 0:
+                dot = "[#d4a064]\u25cf[/#d4a064]"
+            else:
+                dot = "[green]\u25cf[/green]"
 
             parts: list[str] = [f"  {dot} {self._branch_name}"]
 
-            # Workers N
-            parts.append(f"Workers {self._active_workers}")
+            # Workers N \u00b7 \u23f8 M paused (debug)
+            workers_text = f"Workers {self._active_workers}"
+            if self._paused_workers > 0:
+                paused_label = "paused" if self._paused_workers == 1 else "paused"
+                workers_text += f" \u00b7 [#d4a064]\u23f8 {self._paused_workers} {paused_label} (debug)[/#d4a064]"
+            parts.append(workers_text)
 
             # Failures (conditional)
             total_failures = sum(issue.failure_count for issue in self._state.issues.values())

--- a/src/orca/tui/widgets/issue_detail.py
+++ b/src/orca/tui/widgets/issue_detail.py
@@ -24,9 +24,17 @@ class IssueDetail(VerticalScroll):
     def __init__(self) -> None:
         super().__init__(id="issue-detail")
         self._markdown = Markdown(_PLACEHOLDER)
+        # Wired by app.py — used to construct the debug review URL
+        self._run_id: str = ""
+        self._browser_port: int | None = None
 
     def compose(self) -> Generator[Widget, None, None]:
         yield self._markdown
+
+    def set_run_context(self, run_id: str, browser_port: int | None) -> None:
+        """Inject the run id + browser port so debug-review URLs can be rendered."""
+        self._run_id = run_id
+        self._browser_port = browser_port
 
     def show_issue(self, issue_id: str, state: State) -> None:
         issue = state.issues.get(issue_id)
@@ -35,16 +43,42 @@ class IssueDetail(VerticalScroll):
             return
         title = issue.fields.get("title", "Untitled")
         description = issue.fields.get("description", "")
-        content = f"# {title}\n\n{description}"
+
+        parts: list[str] = []
+
+        # Debug-review pause banner — surfaced at the TOP so it's the first
+        # thing the user sees when selecting a paused issue.
+        if getattr(issue, "debug_pending", False):
+            parts.append(self._debug_review_banner(issue_id, issue.state))
+
+        parts.append(f"# {title}\n\n{description}")
 
         # Show failure info if retries exhausted
         if issue.failure_count > 0 and not issue.worker_active:
             last_error = self._last_failure_error(issue)
-            content += f"\n\n---\n\n**Worker failed {issue.failure_count} time(s) — retries exhausted**"
+            parts.append(f"---\n\n**Worker failed {issue.failure_count} time(s) — retries exhausted**")
             if last_error:
-                content += f"\n\n```\n{last_error}\n```"
+                parts.append(f"```\n{last_error}\n```")
 
-        self._markdown.update(content)
+        self._markdown.update("\n\n".join(parts))
+
+    def _debug_review_banner(self, issue_id: str, state_name: str) -> str:
+        """Markdown callout shown above the issue body when paused for review."""
+        if self._browser_port is not None and self._run_id:
+            url = f"http://localhost:{self._browser_port}/debug/{self._run_id}/{issue_id}"
+            url_block = f"`{url}`"
+        else:
+            url_block = "*(browser-port unavailable — start the daemon to surface a review URL)*"
+        return (
+            "> ⏸ **Paused for debug review**\n"
+            f">\n"
+            f"> State `{state_name}` finished. Pick an action in the browser:\n"
+            f">\n"
+            f"> {url_block}\n"
+            f">\n"
+            "> **Modify prompt + config & restart** · **Restart without changes** "
+            "· **Accept & continue** · **Stop run**"
+        )
 
     @staticmethod
     def _last_failure_error(issue: object) -> str:

--- a/src/orca/tui/widgets/issue_tree.py
+++ b/src/orca/tui/widgets/issue_tree.py
@@ -162,6 +162,7 @@ class IssueTree(Tree[str]):
 
     def _issue_label(self, issue: Issue, failed_states: set[str] | None = None) -> Text:
         title = str(issue.fields.get("title", "untitled"))
+        debug_paused = getattr(issue, "debug_pending", False)
         label = Text()
         if issue.failure_count > 0 and not issue.worker_active:
             label.append("• ", style="bold red")
@@ -169,6 +170,13 @@ class IssueTree(Tree[str]):
         elif issue.state == "done":
             label.append("• ", style="bold green")
             label.append(title)
+        elif debug_paused:
+            # Distinct amber pause indicator + state tag so user sees the step
+            # finished and is awaiting their review (not idle).
+            label.append("⏸ ", style=f"bold {_COLOR_ACTIVE}")
+            label.append(title)
+            label.append(f" [{issue.state}]", style=_COLOR_ACTIVE)
+            label.append(" paused for review", style=f"italic {_COLOR_ACTIVE}")
         else:
             label.append("• ", style="dim")
             label.append(title)

--- a/tests/tui/test_header.py
+++ b/tests/tui/test_header.py
@@ -215,3 +215,50 @@ class TestOrcaHeaderActiveWorkersOverride:
         header.update_state(state, [], active_workers=5)
         text = header.render_text()
         assert "Workers 5" in text
+
+
+class TestOrcaHeaderDebugPaused:
+    def test_paused_issue_shows_paused_indicator_and_amber_dot(self) -> None:
+        config = _make_config()
+        header = OrcaHeader(branch_name="b", config=config)
+        issue = _make_issue(state="triage", worker_active=False, visit_counts={"triage": 1})
+        issue.debug_pending = True
+        state = _make_state({"root-1": issue})
+        header.update_state(state, [])
+        text = header.render_text()
+        assert "Workers 0" in text
+        assert "paused" in text and "1" in text
+        # Amber dot color used for paused (no failures)
+        assert "#d4a064" in text
+
+    def test_multiple_paused_pluralisation(self) -> None:
+        config = _make_config()
+        header = OrcaHeader(branch_name="b", config=config)
+        i1 = _make_issue(state="triage", worker_active=False, visit_counts={"triage": 1})
+        i1.debug_pending = True
+        i2 = _make_issue(state="implement", worker_active=False, visit_counts={"implement": 1})
+        i2.debug_pending = True
+        state = _make_state({"root-1": i1, "root-2": i2})
+        header.update_state(state, [])
+        text = header.render_text()
+        assert "2 paused" in text
+
+    def test_no_paused_keeps_green_dot(self) -> None:
+        config = _make_config()
+        header = OrcaHeader(branch_name="b", config=config)
+        state = _make_state({"root-1": _make_issue(state="triage", worker_active=True, visit_counts={"triage": 1})})
+        header.update_state(state, [])
+        text = header.render_text()
+        assert "paused" not in text
+        assert "[green]" in text
+
+    def test_failures_override_amber(self) -> None:
+        # A failure outranks a debug pause in the dot color (red beats amber)
+        config = _make_config()
+        header = OrcaHeader(branch_name="b", config=config)
+        issue = _make_issue(state="triage", worker_active=False, failure_count=2)
+        issue.debug_pending = True
+        state = _make_state({"root-1": issue})
+        header.update_state(state, [])
+        text = header.render_text()
+        assert "[red]" in text

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

The TUI previously conflated "no active worker" with "idle". A step finishing in debug mode showed as `Workers 0` with no other indication that human review was pending — users had to ask the agent why the step appeared finished while the run still said `running`.

This PR adds three coordinated paused-state surfaces:

### Header
- New `_paused_workers` count alongside `_active_workers`.
- Workers cell now reads `Workers 0 · ⏸ 1 paused (debug)` when any issue has `debug_pending: true`.
- Status dot goes amber (`#d4a064`) on a pure pause; red still beats amber when both are present.

### Issue tree
- Paused issues render with a distinct amber label:
  - `⏸ <title> [<state>] paused for review`
- Replaces the dim default that made paused issues look idle.

### Issue detail
- Selected paused issue shows a callout above the title:
  > ⏸ Paused for debug review
  >
  > State `<name>` finished. Pick an action in the browser:
  >
  > `http://localhost:<port>/debug/<run>/<issue>`
  >
  > Modify prompt + config & restart · Restart without changes · Accept & continue · Stop run
- Browser port read from `<repo>/.orca-state/daemon/browser-port` via `lifecycle.read_browser_port`; falls back gracefully if daemon TCP listener isn't bound.

### Wiring
- `app.py` injects `(run_id, browser_port)` into `IssueDetail` on mount via new `set_run_context()`.
- Disk-mode fallback derives `run_id` from `run_dir` layout.

## Test plan

- [x] `uv run pytest tests/tui` — 78 passing
- [x] `uv run pytest` — 612 passing + 2 skipped (no regressions)
- [x] 4 new tests on `OrcaHeader` cover the paused indicator, pluralisation, green-dot default, and red-beats-amber priority
- [x] All four version manifests at 0.5.4
- [x] Web bundle rebuilt and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)