### PR TITLE
feat(debug): auto-open review URL in browser on pause (0.5.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.5.7"
+version = "0.5.8"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -644,7 +644,52 @@ class Orchestrator:
             issue.state,
             extra={"event": "debug_review_pause", "issue_id": issue_id, "state": issue.state},
         )
+
+        # Auto-open the review URL in the user's default browser. Opt out by
+        # setting ORCA_NO_AUTO_OPEN=1 in the daemon's environment. The user
+        # already chose --debug so we assume they want the UI.
+        self._auto_open_review_url(issue_id)
+
         await decision_event.wait()
+
+    def _auto_open_review_url(self, issue_id: str) -> None:
+        """Best-effort: open the debug-review URL in the user's default browser.
+
+        Runs in a detached thread so a slow `open` / `xdg-open` doesn't block
+        the orchestrator. Silently no-ops in headless environments, when the
+        daemon's browser TCP listener isn't bound, when the user opted out via
+        ORCA_NO_AUTO_OPEN=1, or when webbrowser.open raises (rare on macOS,
+        more common on remote Linux without DISPLAY).
+        """
+        import os
+        import threading
+        import webbrowser
+
+        if os.environ.get("ORCA_NO_AUTO_OPEN"):
+            return
+        if self.repo_root is None:
+            return
+        from orca.daemon.lifecycle import read_browser_port
+
+        port = read_browser_port(self.repo_root)
+        if port is None:
+            return
+
+        # Derive run_id from the persistence layout: state_path is
+        # <repo>/.orca-state/runs/<branch>/<workflow>/state.json
+        run_dir = self.persistence.state_path.parent
+        workflow = run_dir.name
+        branch = run_dir.parent.name
+        run_id = f"{branch}:{workflow}"
+        url = f"http://localhost:{port}/debug/{run_id}/{issue_id}"
+
+        def _open() -> None:
+            try:
+                webbrowser.open(url, new=2)  # new=2 → new tab if possible
+            except Exception:
+                return
+
+        threading.Thread(target=_open, daemon=True).start()
 
     async def _reset_worktree_for_issue(self, issue_id: str) -> None:
         """Reset the worktree branch back to its state_base_commit.

--- a/tests/orchestrator/test_auto_open_review.py
+++ b/tests/orchestrator/test_auto_open_review.py
@@ -1,0 +1,116 @@
+"""Tests for the auto-open-review-URL behavior on debug pause."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from orca.orchestrator.orchestrator import Orchestrator
+
+
+def _make_orchestrator(tmp_path: Path) -> Orchestrator:
+    """Build a bare-minimum Orchestrator instance for testing _auto_open_review_url.
+
+    We don't drive the run loop here — only need the instance method available.
+    """
+    repo_root = tmp_path
+    persistence = MagicMock()
+    # state.json under <repo>/.orca-state/runs/<branch>/<workflow>/state.json
+    run_dir = repo_root / ".orca-state" / "runs" / "main" / "default"
+    run_dir.mkdir(parents=True)
+    persistence.state_path = run_dir / "state.json"
+
+    orch = Orchestrator(
+        config=MagicMock(),
+        state=MagicMock(),
+        root_branch="main",
+        persistence=persistence,
+        branches=MagicMock(),
+        workers={},
+        generate_id=lambda: "id",
+        now=lambda: "now",
+        worktree_mgr=MagicMock(),
+        repo_root=repo_root,
+    )
+    return orch
+
+
+def test_opt_out_via_env_var(tmp_path: Path) -> None:
+    """ORCA_NO_AUTO_OPEN=1 short-circuits the helper before any browser call."""
+    orch = _make_orchestrator(tmp_path)
+    with (
+        patch.dict(os.environ, {"ORCA_NO_AUTO_OPEN": "1"}),
+        patch("webbrowser.open") as wb_open,
+    ):
+        orch._auto_open_review_url("issue-1")
+        # Give the (would-be) thread a beat — should never run
+        import time
+
+        time.sleep(0.05)
+        wb_open.assert_not_called()
+
+
+def test_no_browser_port_no_open(tmp_path: Path) -> None:
+    """If the daemon hasn't bound a browser port, the helper bails silently."""
+    orch = _make_orchestrator(tmp_path)
+    os.environ.pop("ORCA_NO_AUTO_OPEN", None)
+    with (
+        patch("orca.daemon.lifecycle.read_browser_port", return_value=None),
+        patch("webbrowser.open") as wb_open,
+    ):
+        orch._auto_open_review_url("issue-1")
+        import time
+
+        time.sleep(0.05)
+        wb_open.assert_not_called()
+
+
+def test_opens_url_with_correct_components(tmp_path: Path) -> None:
+    """When a port is available, the helper opens the well-formed URL."""
+    orch = _make_orchestrator(tmp_path)
+    os.environ.pop("ORCA_NO_AUTO_OPEN", None)
+
+    opened_urls: list[str] = []
+
+    def fake_open(url: str, new: int = 0) -> bool:
+        opened_urls.append(url)
+        return True
+
+    with (
+        patch("orca.daemon.lifecycle.read_browser_port", return_value=7891),
+        patch("webbrowser.open", side_effect=fake_open),
+    ):
+        orch._auto_open_review_url("a51c63f2-6d4c")
+        # Let the detached thread run
+        import time
+
+        time.sleep(0.2)
+
+    assert len(opened_urls) == 1, f"expected one open call, got {opened_urls!r}"
+    url = opened_urls[0]
+    # URL built from run layout: <branch>:<workflow> + /<issue_id>
+    assert url == "http://localhost:7891/debug/main:default/a51c63f2-6d4c"
+
+
+def test_does_not_block(tmp_path: Path) -> None:
+    """The helper returns immediately even if webbrowser.open is slow."""
+    orch = _make_orchestrator(tmp_path)
+    os.environ.pop("ORCA_NO_AUTO_OPEN", None)
+
+    def slow_open(url: str, new: int = 0) -> bool:
+        import time
+
+        time.sleep(2.0)
+        return True
+
+    with (
+        patch("orca.daemon.lifecycle.read_browser_port", return_value=7891),
+        patch("webbrowser.open", side_effect=slow_open),
+    ):
+        import time
+
+        t0 = time.time()
+        orch._auto_open_review_url("issue-1")
+        elapsed = time.time() - t0
+    assert elapsed < 0.5, f"helper blocked for {elapsed:.2f}s — should run in a daemon thread"

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

When the daemon pauses for a debug review, it now opens the review URL in the user's default browser automatically. The user already opted into `--debug`, so we assume they want the UI.

## Behavior

- Runs in a detached thread — daemon doesn't block on the `open` call.
- **Silently no-ops** when:
  - `ORCA_NO_AUTO_OPEN=1` is set in the daemon's environment (opt-out)
  - The daemon's browser TCP listener isn't bound (`read_browser_port` returns `None`)
  - `webbrowser.open` raises (headless Linux, no DISPLAY, etc.)
- The agent-side chat message still prints the URL verbatim (rule #0 of `orca-workflow-run`), so the URL is also copy-paste-able if the browser open fails.

## Implementation

`Orchestrator._auto_open_review_url` is called from `_pause_for_debug_review` after the `decision_event` is registered. Derives the URL from:
- `repo_root` (passed at construction)
- `browser_port` via `lifecycle.read_browser_port`
- `run_id` constructed as `<branch>:<workflow>` from the `state_path` layout
- `issue_id` from the caller

## Tests

4 new tests in `tests/orchestrator/test_auto_open_review.py`:
- Opt-out env var (`ORCA_NO_AUTO_OPEN=1`)
- No browser port → no `webbrowser.open` call
- Well-formed URL construction
- Non-blocking (slow `webbrowser.open` doesn't block the orchestrator)

## Test plan

- [x] `uv run pytest` — 621 passing + 2 skipped (4 new tests)
- [x] All four version manifests at 0.5.8
- [x] Web bundle rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)