### PR TITLE
fix(debug): include raw diff text per file in snapshot (0.5.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.5.8"
+version = "0.5.9"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -343,12 +343,22 @@ class DiffFile:
     path: str
     status: str  # "added" | "modified" | "deleted" | "renamed"
     hunks: list[Hunk]
+    # Raw unified-diff text for this file (the `diff --git ...` block including
+    # `+++/---` headers and `@@` hunks). The web review UI's DiffView re-parses
+    # this string to render the side-by-side / inline view; pre-parsed `hunks`
+    # are kept for any consumer that wants a typed structure without re-parsing.
+    raw_diff: str = ""
+    additions: int = 0
+    deletions: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "path": self.path,
             "status": self.status,
             "hunks": [h.to_dict() for h in self.hunks],
+            "diff": self.raw_diff,
+            "additions": self.additions,
+            "deletions": self.deletions,
         }
 
     @classmethod
@@ -357,6 +367,9 @@ class DiffFile:
             path=data["path"],
             status=data["status"],
             hunks=[Hunk.from_dict(h) for h in data["hunks"]],
+            raw_diff=data.get("diff", ""),
+            additions=data.get("additions", 0),
+            deletions=data.get("deletions", 0),
         )
 
 

--- a/src/orca/orchestrator/snapshot.py
+++ b/src/orca/orchestrator/snapshot.py
@@ -44,7 +44,12 @@ _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
 def parse_unified_diff(diff_text: str) -> list[DiffFile]:
-    """Parse unified diff text into a list of DiffFile."""
+    """Parse unified diff text into a list of DiffFile.
+
+    Each DiffFile also carries the original raw diff-text slice for its own
+    `diff --git` block (so the web UI's DiffView can re-parse exactly what
+    the daemon saw) plus additions/deletions counters for summary chips.
+    """
     if not diff_text.strip():
         return []
 
@@ -56,6 +61,7 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
         if not line.startswith("diff --git "):
             i += 1
             continue
+        block_start = i  # remember where this file's diff block begins
         parts = line.split(" ", 3)
         path = "?"
         if len(parts) >= 4:
@@ -69,6 +75,8 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
                 path = after
         status = "modified"
         hunks: list[Hunk] = []
+        additions = 0
+        deletions = 0
         i += 1
         while i < len(lines) and not lines[i].startswith("@@") and not lines[i].startswith("diff --git "):
             if lines[i].startswith("new file mode"):
@@ -92,6 +100,10 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
             while i < len(lines) and not lines[i].startswith("@@") and not lines[i].startswith("diff --git "):
                 if lines[i].startswith((" ", "+", "-", "\\")):
                     hunk_lines.append(lines[i])
+                    if lines[i].startswith("+") and not lines[i].startswith("+++"):
+                        additions += 1
+                    elif lines[i].startswith("-") and not lines[i].startswith("---"):
+                        deletions += 1
                 i += 1
             hunks.append(
                 Hunk(
@@ -102,7 +114,18 @@ def parse_unified_diff(diff_text: str) -> list[DiffFile]:
                     lines=hunk_lines,
                 )
             )
-        files.append(DiffFile(path=path, status=status, hunks=hunks))
+        block_end = i  # exclusive — points at the next 'diff --git' or end-of-text
+        raw_diff = "\n".join(lines[block_start:block_end])
+        files.append(
+            DiffFile(
+                path=path,
+                status=status,
+                hunks=hunks,
+                raw_diff=raw_diff,
+                additions=additions,
+                deletions=deletions,
+            )
+        )
     return files
 
 

--- a/tests/orchestrator/test_snapshot.py
+++ b/tests/orchestrator/test_snapshot.py
@@ -158,3 +158,67 @@ def test_build_snapshot_missing_rendered_prompt_returns_empty_string(tmp_path: P
         )
     )
     assert snapshot.rendered_prompt == ""
+
+
+def test_parse_unified_diff_captures_raw_text_and_counters() -> None:
+    """Each DiffFile gets its own raw diff-text slice + addition/deletion counters.
+
+    Without these the web UI's DiffView re-parses an empty string and shows
+    'diff not available' — exactly the bug the user hit on a newly-added file.
+    """
+    diff = """diff --git a/new.md b/new.md
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/new.md
+@@ -0,0 +1,3 @@
++# Title
++
++Body
+diff --git a/edited.py b/edited.py
+index aaa..bbb 100644
+--- a/edited.py
++++ b/edited.py
+@@ -1,3 +1,3 @@
+ line1
+-old line
++new line
+ line3
+"""
+    files = parse_unified_diff(diff)
+    assert len(files) == 2
+
+    added = files[0]
+    assert added.path == "new.md"
+    assert added.status == "added"
+    assert added.additions == 3
+    assert added.deletions == 0
+    assert "diff --git a/new.md b/new.md" in added.raw_diff
+    assert "+# Title" in added.raw_diff
+    assert "edited.py" not in added.raw_diff
+
+    edited = files[1]
+    assert edited.path == "edited.py"
+    assert edited.status == "modified"
+    assert edited.additions == 1
+    assert edited.deletions == 1
+    assert "diff --git a/edited.py b/edited.py" in edited.raw_diff
+    assert "new.md" not in edited.raw_diff
+
+
+def test_diff_file_round_trip_preserves_raw_diff() -> None:
+    """to_dict / from_dict carry the raw diff text and counters."""
+    from orca.engine.types import DiffFile, Hunk
+
+    f = DiffFile(
+        path="x.py",
+        status="modified",
+        hunks=[Hunk(1, 1, 1, 1, [" a", "-b", "+c"])],
+        raw_diff="diff --git a/x.py b/x.py\n--- a/x.py\n+++ b/x.py\n@@ -1,1 +1,1 @@\n-b\n+c\n",
+        additions=1,
+        deletions=1,
+    )
+    f2 = DiffFile.from_dict(f.to_dict())
+    assert f2.raw_diff == f.raw_diff
+    assert f2.additions == 1
+    assert f2.deletions == 1

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Newly-added files (and any other file in the changeset) rendered as **"diff not available"** in the debug review UI. The web `DiffView` component re-parses a unified-diff string (`file.diff`) — but the daemon was only sending pre-parsed `hunks`, no raw text. So `DiffView.parseUnifiedDiff("")` returned 0 hunks → empty body.

## Fix

`DiffFile` now carries:
- `raw_diff: str` — the unified-diff text for this file's `diff --git` block only (DiffView's expected input)
- `additions: int`, `deletions: int` — for the `+adds/-dels` header chip

`parse_unified_diff` in `orchestrator/snapshot.py` now tracks the start/end line index of each block and slices out the raw text per file. `+/-` counts come from walking the hunk body. Serialized in `to_dict()` as `{diff, additions, deletions}` — the frontend already expects these field names.

## Tests

- `test_parse_unified_diff_captures_raw_text_and_counters` covers the user's exact case (a newly-added file alongside an edited file): asserts each file's `raw_diff` is non-empty, contains the file's own header, and doesn't leak the other file's content.
- `test_diff_file_round_trip_preserves_raw_diff` covers `to_dict`/`from_dict`.

## Test plan

- [x] `uv run pytest` — 623 passing + 2 skipped (2 new)
- [x] All four version manifests at 0.5.9
- [x] Web bundle rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)