### PR TITLE
feat(skill): faster poll cadence while waiting for debug-review decision (0.5.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugin/orca/skills/orca-workflow-run/SKILL.md
+++ b/plugin/orca/skills/orca-workflow-run/SKILL.md
@@ -23,6 +23,7 @@ You are not expected to understand what each state in the workflow means. Trust 
 | Name | Value | Description |
 |---|---|---|
 | `POLL_INTERVAL_SECONDS` | 45 | Seconds to wait between health-check polls during the watch loop |
+| `DEBUG_PAUSE_POLL_INTERVAL_SECONDS` | 10 | Faster poll interval while waiting for a debug-review decision — once the URL is surfaced, the user is actively reviewing and the round-trip should feel responsive |
 
 **Insights:** `--insights` and the matching `orca_get_insights` MCP tool are a CLI-side opt-in for a separate insights agent — not surfaced by this supervisor SKILL. If a user mentions insights, point them at the CLI (`orca run … --insights`) and at the `orca_get_insights` tool to read the resulting log.
 
@@ -80,7 +81,7 @@ If multiple runs exist (shouldn't happen under serial execution), handle in prio
 
 A run is `running`. Enter a polling loop. Each iteration:
 
-1. Sleep `POLL_INTERVAL_SECONDS` (skip the sleep on the very first poll).
+1. Sleep `POLL_INTERVAL_SECONDS` — **except** when you've already surfaced a debug-review URL on a previous poll and the pause is still unresolved. In that case sleep `DEBUG_PAUSE_POLL_INTERVAL_SECONDS` (10 s) so the round-trip after the user clicks an action feels responsive. Skip the sleep on the very first poll.
 2. Call `orca_get_run(root, run_id, compact=true)` and `orca_get_worker_log(root, run_id, issue_id, tail=50)`.
 3. Print a brief 1-line status update including the current state name as reported by orca, e.g., `[poll 3] state=<state-name> — worker active (hop 4, failures 0)`.
 4. Assess health and decide.

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/skills/orca-workflow-run/SKILL.md
+++ b/plugins/orca/skills/orca-workflow-run/SKILL.md
@@ -23,6 +23,7 @@ You are not expected to understand what each state in the workflow means. Trust 
 | Name | Value | Description |
 |---|---|---|
 | `POLL_INTERVAL_SECONDS` | 45 | Seconds to wait between health-check polls during the watch loop |
+| `DEBUG_PAUSE_POLL_INTERVAL_SECONDS` | 10 | Faster poll interval while waiting for a debug-review decision — once the URL is surfaced, the user is actively reviewing and the round-trip should feel responsive |
 
 **Insights:** `--insights` and the matching `orca_get_insights` MCP tool are a CLI-side opt-in for a separate insights agent — not surfaced by this supervisor SKILL. If a user mentions insights, point them at the CLI (`orca run … --insights`) and at the `orca_get_insights` tool to read the resulting log.
 
@@ -80,7 +81,7 @@ If multiple runs exist (shouldn't happen under serial execution), handle in prio
 
 A run is `running`. Enter a polling loop. Each iteration:
 
-1. Sleep `POLL_INTERVAL_SECONDS` (skip the sleep on the very first poll).
+1. Sleep `POLL_INTERVAL_SECONDS` — **except** when you've already surfaced a debug-review URL on a previous poll and the pause is still unresolved. In that case sleep `DEBUG_PAUSE_POLL_INTERVAL_SECONDS` (10 s) so the round-trip after the user clicks an action feels responsive. Skip the sleep on the very first poll.
 2. Call `orca_get_run(root, run_id, compact=true)` and `orca_get_worker_log(root, run_id, issue_id, tail=50)`.
 3. Print a brief 1-line status update including the current state name as reported by orca, e.g., `[poll 3] state=<state-name> — worker active (hop 4, failures 0)`.
 4. Assess health and decide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.5.9"
+version = "0.5.10"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Once the host agent has surfaced a debug-review URL, the user is actively in the browser deciding what to do. The default 45 s health-check poll cadence makes the round-trip after they click an action feel sluggish.

## Change

Add `DEBUG_PAUSE_POLL_INTERVAL_SECONDS = 10` to the `orca-workflow-run` SKILL constants table. The poll loop step #1 now branches:

- **45 s** for normal health checks.
- **10 s** while a previously-surfaced debug pause is still unresolved.

Applied to both the Claude Code and Codex plugin variants.

No code changes — the SKILL is the policy.

## Test plan

- [x] All four version manifests at 0.5.10
- [x] `python3 tools/check_playbooks.py` passes (pre-commit hook)
- [x] Web bundle rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)