### PR TITLE
fix(debug): orchestrator no longer deadlocks on modify_restart (0.5.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.5.11"
+version = "0.5.12"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -927,6 +927,15 @@ class Orchestrator:
                 retried = self._process_retry_signals(pending)
                 if retried:
                     continue
+                # modify_restart in debug mode leaves the issue with
+                # modify_pending=true and no in-flight worker. The host (CC
+                # via MCP) is expected to rewrite the prompt and call
+                # orca_restart_state, which spawns a fresh worker directly
+                # into _in_flight. Until that happens, sit idle — this is
+                # not a deadlock, it's an external-unblock wait.
+                if any(i.modify_pending for i in self._state.issues.values()):
+                    await asyncio.sleep(0.5)
+                    continue
                 logger.warning(
                     "Deadlock detected: no tasks in flight and no pending effects. Stopping.",
                     extra={"event": "deadlock_detected"},

--- a/tests/orchestrator/test_debug_e2e.py
+++ b/tests/orchestrator/test_debug_e2e.py
@@ -7,6 +7,7 @@ restart and modify_restart variants are skipped pending fuller harness wiring
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -223,3 +224,79 @@ async def test_debug_modify_restart_path(tmp_path: Path) -> None:
         "E2E harness wiring TBD — exercises modify_restart + orca_restart_state path; "
         "needs WorktreeManager.reset_to with real git branching."
     )
+
+
+@pytest.mark.asyncio()
+async def test_debug_modify_restart_does_not_deadlock(tmp_path: Path) -> None:
+    """After modify_restart, the run loop must wait (not raise DeadlockError).
+
+    Regression for 0.5.11: the user clicked "Modify prompt + restart" in the
+    web UI and the daemon flipped the run to FAILED status because the
+    orchestrator's deadlock check saw empty _in_flight + no pending effects
+    and bailed out. modify_pending is an external-unblock waiting state —
+    the host calls orca_restart_state which spawns the worker directly.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    config = parse_config(SIMPLE_DEBUG_CONFIG)
+    state = State(issues={}, worker_queues={})
+
+    create_event = CreateEvent(issue_id="issue-1", fields={"title": "Test task"}, timestamp=_now())
+    state, initial_effects = reduce(config, state, create_event, _counter(), _now)
+
+    persistence = Persistence(repo, "main")
+    persistence.save(state)
+    branches = BranchMap(repo, "main")
+
+    worker = MockWorker(outcome=WorkerSuccess(result={"outcome": "done"}))
+    workers = {"claude-code": worker}
+
+    orch = Orchestrator(
+        config=config,
+        state=state,
+        root_branch="main",
+        persistence=persistence,
+        branches=branches,
+        workers=workers,
+        generate_id=_counter(),
+        now=_now,
+        worktree_mgr=GitWorktreeManager(repo),
+        repo_root=repo,
+    )
+    orch.debug = True
+
+    fake_snapshot = _make_fake_snapshot()
+    with patch(
+        "orca.orchestrator.snapshot.build_snapshot",
+        new=AsyncMock(return_value=fake_snapshot),
+    ):
+        run_task = asyncio.create_task(orch.run("issue-1", initial_effects))
+
+        for _ in range(100):
+            if orch.is_debug_pending("issue-1"):
+                break
+            await asyncio.sleep(0.1)
+
+        assert orch.is_debug_pending("issue-1"), "Orchestrator never paused for debug review"
+
+        orch.submit_debug_decision("issue-1", "modify_restart", [])
+
+        # The run loop should NOT crash after the modify_restart decision —
+        # it should sit idle waiting for orca_restart_state. Give it 2s to
+        # demonstrate that. Pre-fix, this raised DeadlockError immediately.
+        await asyncio.sleep(2.0)
+        assert not run_task.done(), (
+            "Run task ended after modify_restart — orchestrator should wait for restart_state. "
+            f"Exception: {run_task.exception() if run_task.done() else None}"
+        )
+
+        issue = orch.state.issues["issue-1"]
+        assert issue.modify_pending, "Issue should be in modify_pending state"
+        assert not issue.debug_pending, "debug_pending should be cleared after modify_restart"
+
+        # Cancel the run cleanly so the test exits.
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_task

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.5.11"
+version = "0.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

**Bug:** clicking *"Modify prompt + config & restart"* in the debug review UI flipped the run's status to `FAILED` and dropped the orchestrator's run task.

**Cause:** the run loop's deadlock check in \`orchestrator.py:919-934\` treated \`modify_pending\` as an unrecoverable \"no work in flight, no pending effects\" condition and raised \`DeadlockError\`. The flag is actually an *external-unblock* wait: the host (Claude Code via MCP) is expected to rewrite the prompt + config slice and call \`orca_restart_state\`, which spawns a fresh worker directly into \`_in_flight\`.

**Fix:** if any issue has \`modify_pending=true\`, sleep briefly and re-check the loop conditions instead of raising. Restart-state then drops the flag and adds the new worker to \`_in_flight\`, and the existing main loop picks it up on the next iteration.

## Test plan
- [x] New regression test \`tests/orchestrator/test_debug_e2e.py::test_debug_modify_restart_does_not_deadlock\` — asserts the run task stays alive 2s after \`submit_debug_decision(\"modify_restart\")\` and that the reducer leaves the issue in \`modify_pending\` with \`debug_pending\` cleared
- [x] Full suite: 625 passed, 2 skipped (\`uv run pytest -x\`)
- [ ] Smoke-test in a real debug run: hit \"Modify + restart\", confirm the daemon's run status stays \`RUNNING\`, then call \`orca_restart_state\` and watch the worker re-dispatch

## Out of scope (decided during review)

A pane-output heartbeat was prototyped to catch hung workers (tmux-alive but agent-wedged) but dropped — the test-plan-execute workflow legitimately runs 33+ min with no tmux output, so any time-based stall threshold would false-positive. Future option if needed: a user-driven \`orca kill-worker <issue>\` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)