### PR TITLE
feat(workflow): runtime per-state worker overrides + effort field (0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "orca",
       "source": "./plugin/orca",
       "description": "Coding agent orchestrator — MCP server + slash commands for setup, workflow authoring, and run supervision",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "homepage": "https://github.com/gutnikov/orca",
       "license": "MIT",
       "keywords": ["orchestrator", "mcp", "claude-code", "codex", "opencode", "agents", "workflow"]

--- a/plugin/orca/.claude-plugin/plugin.json
+++ b/plugin/orca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Coding agent orchestrator. Spawns Claude Code / Codex / OpenCode workers in git worktrees, drives state machines, exposes MCP tools.",
   "author": {
     "name": "Alex Gutnikov",

--- a/plugins/orca/.codex-plugin/plugin.json
+++ b/plugins/orca/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Coding agent orchestrator with MCP tools, workflow setup, and run supervision for Codex.",
   "author": {
     "name": "Alex Gutnikov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orca"
-version = "0.6.1"
+version = "0.7.0"
 description = ""
 requires-python = ">=3.12"
 dependencies = [

--- a/src/orca/cli/main.py
+++ b/src/orca/cli/main.py
@@ -74,6 +74,18 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--run-id", type=str, default=None)
     run_parser.add_argument("--max-hops", type=int, default=10)
     run_parser.add_argument("--max-retries", type=int, default=3)
+    run_parser.add_argument(
+        "--override",
+        action="append",
+        default=None,
+        metavar="STATE.FIELD=VALUE",
+        help=(
+            "Override a worker field for one state at run time. Repeatable. "
+            "FIELD is one of kind / model / effort. Example: "
+            "--override preflight.kind=codex --override preflight.model=gpt-5.5 "
+            "--override preflight.effort=high"
+        ),
+    )
 
     # orca tui
     sub.add_parser("tui", help="Attach TUI to daemon")

--- a/src/orca/cli/run_cmd.py
+++ b/src/orca/cli/run_cmd.py
@@ -10,6 +10,34 @@ from pathlib import Path
 import aiohttp
 
 
+def parse_worker_overrides(raw: list[str] | None) -> dict[str, dict[str, str]]:
+    """Parse repeated --override values like 'state.field=value'.
+
+    Returns a nested dict {state: {field: value}}. Repeated flags accumulate;
+    the same (state, field) pair specified twice keeps the last value.
+    Raises ValueError on malformed entries — caller prints the message.
+    """
+    overrides: dict[str, dict[str, str]] = {}
+    if not raw:
+        return overrides
+    for entry in raw:
+        if "=" not in entry:
+            raise ValueError(f"override {entry!r}: expected '<state>.<field>=<value>'")
+        key, value = entry.split("=", 1)
+        if "." not in key:
+            raise ValueError(f"override {entry!r}: key part must be '<state>.<field>' (got {key!r})")
+        state_name, field = key.split(".", 1)
+        state_name = state_name.strip()
+        field = field.strip()
+        value = value.strip()
+        if not state_name or not field or not value:
+            raise ValueError(f"override {entry!r}: empty state, field, or value")
+        if field not in ("kind", "model", "effort"):
+            raise ValueError(f"override {entry!r}: field {field!r} not allowed (use kind / model / effort)")
+        overrides.setdefault(state_name, {})[field] = value
+    return overrides
+
+
 def run_command(args: Namespace) -> None:
     """Check daemon running, POST /api/runs/start, print run_id or error."""
     import asyncio
@@ -27,11 +55,17 @@ def run_command(args: Namespace) -> None:
         print(f"Error: task file not found: {task_file}", file=sys.stderr)
         raise SystemExit(1)
 
+    try:
+        worker_overrides = parse_worker_overrides(getattr(args, "override", None))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+
     sock = socket_path(repo)
 
     async def _submit() -> None:
         connector = aiohttp.UnixConnector(path=str(sock))
-        payload = {
+        payload: dict[str, object] = {
             "task_file": str(task_file.resolve()),
             "workflow": args.workflow,
             "branch": args.branch,
@@ -43,6 +77,8 @@ def run_command(args: Namespace) -> None:
             "max_retries": args.max_retries,
             "debug": args.debug,
         }
+        if worker_overrides:
+            payload["worker_overrides"] = worker_overrides
         async with (
             aiohttp.ClientSession(connector=connector) as session,
             session.post("http://localhost/api/runs/start", json=payload) as resp,

--- a/src/orca/daemon/client.py
+++ b/src/orca/daemon/client.py
@@ -67,17 +67,18 @@ class DaemonClient:
         branch: str | None = None,
         run_id: str | None = None,
         debug: bool = False,
+        worker_overrides: dict[str, dict[str, str]] | None = None,
     ) -> dict[str, Any]:
-        return await self._post_json(
-            "/api/runs/start",
-            {
-                "task_file": task_file,
-                "workflow": workflow,
-                "branch": branch,
-                "run_id": run_id,
-                "debug": debug,
-            },
-        )
+        body: dict[str, Any] = {
+            "task_file": task_file,
+            "workflow": workflow,
+            "branch": branch,
+            "run_id": run_id,
+            "debug": debug,
+        }
+        if worker_overrides:
+            body["worker_overrides"] = worker_overrides
+        return await self._post_json("/api/runs/start", body)
 
     async def stop_run(self, run_id: str) -> dict[str, Any]:
         return await self._post_json(f"/api/runs/{run_id}/stop")

--- a/src/orca/daemon/http_api.py
+++ b/src/orca/daemon/http_api.py
@@ -58,6 +58,20 @@ async def _start_run(request: Request) -> JSONResponse:
     if not task_file.is_absolute():
         task_file = manager.repo_root / task_file
 
+    raw_overrides = body.get("worker_overrides")
+    worker_overrides: dict[str, dict[str, str]] | None = None
+    if raw_overrides is not None:
+        if not isinstance(raw_overrides, dict):
+            return JSONResponse({"error": "worker_overrides must be an object"}, status_code=400)
+        worker_overrides = {}
+        for state_name, fields in raw_overrides.items():
+            if not isinstance(fields, dict):
+                return JSONResponse(
+                    {"error": f"worker_overrides[{state_name!r}] must be an object"},
+                    status_code=400,
+                )
+            worker_overrides[str(state_name)] = {str(k): str(v) for k, v in fields.items()}
+
     try:
         run_id = await manager.start_run(
             task_file=task_file,
@@ -69,6 +83,7 @@ async def _start_run(request: Request) -> JSONResponse:
             max_retries=body.get("max_retries"),
             insights=bool(body.get("insights", False)),
             debug=bool(body.get("debug", False)),
+            worker_overrides=worker_overrides,
         )
     except Exception as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)

--- a/src/orca/daemon/manager.py
+++ b/src/orca/daemon/manager.py
@@ -180,6 +180,7 @@ class RunManager:
         *,
         insights: bool = False,
         debug: bool = False,
+        worker_overrides: dict[str, dict[str, str]] | None = None,
     ) -> str:
         """Start a new orchestrator run. Returns run_id.
 
@@ -190,6 +191,29 @@ class RunManager:
         config_path = resolve_config_path(self.repo_root, workflow)
         config = parse_config(config_path.read_text())
         flow_root = config_path.parent
+
+        # Validate worker overrides: every state name must exist in the
+        # workflow's state graph, and any `kind` value must be a registered
+        # CLI kind. We don't validate `model`/`effort` strings — the agent
+        # CLI itself will reject unknown values at spawn time.
+        if worker_overrides:
+            known_states: set[str] = set()
+            for type_def in config.types.values():
+                known_states.update(type_def.states.keys())
+            for state_name, fields in worker_overrides.items():
+                if state_name not in known_states:
+                    msg = f"override references unknown state {state_name!r}"
+                    raise ValueError(msg)
+                if "kind" in fields and fields["kind"] not in KIND_REGISTRY:
+                    msg = (
+                        f"override for state {state_name!r}: unknown kind {fields['kind']!r} "
+                        f"(known: {sorted(KIND_REGISTRY)})"
+                    )
+                    raise ValueError(msg)
+                for key in fields:
+                    if key not in ("kind", "model", "effort"):
+                        msg = f"override for state {state_name!r}: unknown field {key!r} (allowed: kind, model, effort)"
+                        raise ValueError(msg)
 
         # Derive effective_workflow name (short name for run directory)
         if workflow and ("/" in workflow or workflow.endswith(".yml")):
@@ -293,6 +317,7 @@ class RunManager:
             flow_root=flow_root,
             session_sync=session_sync,
             insights_enabled=insights,
+            worker_overrides=worker_overrides,
         )
         orchestrator.debug = debug
 

--- a/src/orca/daemon/mcp_tools.py
+++ b/src/orca/daemon/mcp_tools.py
@@ -81,6 +81,7 @@ def create_mcp_server() -> FastMCP:
         branch: str | None = None,
         run_id: str | None = None,
         debug: bool = False,
+        worker_overrides: dict[str, dict[str, str]] | None = None,
     ) -> str:
         """Start a new orca workflow run.
 
@@ -91,10 +92,27 @@ def create_mcp_server() -> FastMCP:
             branch: Optional git branch name (auto-detected if omitted).
             run_id: Optional custom run identifier (defaults to 'branch:workflow').
             debug: If True, the run pauses after every worker completion for review.
+            worker_overrides: Optional per-state, per-field worker overrides
+                applied at dispatch time. Keys are state names (e.g. "preflight");
+                values are objects with any of `kind`, `model`, `effort`.
+                Example:
+                    {"preflight": {"kind": "codex", "model": "gpt-5.5",
+                                    "effort": "high"}}
+                The state must exist in the workflow; `kind` must be a
+                registered agent kind (claude-code / codex / opencode);
+                `effort` is silently dropped for kinds that don't expose a
+                reasoning-effort flag (currently only codex does).
 
         Returns JSON with run_id and status, or an error message.
         """
-        result = await _get_client(root).start_run(task_file, workflow, branch, run_id, debug=debug)
+        result = await _get_client(root).start_run(
+            task_file,
+            workflow,
+            branch,
+            run_id,
+            debug=debug,
+            worker_overrides=worker_overrides,
+        )
         return json.dumps(result)
 
     async def orca_list_runs(root: str) -> str:

--- a/src/orca/engine/config.py
+++ b/src/orca/engine/config.py
@@ -142,6 +142,8 @@ def _parse_state(name: str, raw_data: dict[str, Any] | None) -> StateDef:
         raw_args = worker_data.get("args")
         args: tuple[str, ...] | None = tuple(str(a) for a in raw_args) if raw_args is not None else None
         progress: bool = bool(worker_data.get("progress", False))
+        effort_raw = worker_data.get("effort")
+        effort: str | None = str(effort_raw) if effort_raw is not None else None
         worker = WorkerDef(
             kind=kind,
             prompt=prompt,
@@ -152,6 +154,7 @@ def _parse_state(name: str, raw_data: dict[str, Any] | None) -> StateDef:
             args=args,
             progress=progress,
             prompt_inline=prompt_inline,
+            effort=effort,
         )
 
     on: dict[str, OnRule] = {}

--- a/src/orca/engine/types.py
+++ b/src/orca/engine/types.py
@@ -48,6 +48,11 @@ class WorkerDef:
     # When True, `prompt` holds inline Jinja template source.
     # When False (default), `prompt` is a path (relative to flow_root) to a template file.
     prompt_inline: bool = False
+    # Reasoning-effort hint passed to the agent CLI when its kind supports
+    # one (e.g. codex → `--reasoning-effort <effort>`). Silently dropped for
+    # kinds that don't expose an effort flag. Typical values: low / medium /
+    # high / xhigh.
+    effort: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/orca/orchestrator/orchestrator.py
+++ b/src/orca/orchestrator/orchestrator.py
@@ -69,6 +69,7 @@ class Orchestrator:
         hot_sessions: set[str] | None = None,
         session_log_paths: dict[str, str] | None = None,
         insights_state: dict[str, str] | None = None,
+        worker_overrides: dict[str, dict[str, str]] | None = None,
     ) -> None:
         self._config = config
         self._state = state
@@ -109,6 +110,10 @@ class Orchestrator:
         self._used_slugs: set[str] = set()
         for branch in self.branches.values():
             self._used_slugs.add(branch)
+        # Per-state, per-field worker overrides applied at dispatch time. Keyed
+        # by state name; each entry may carry `kind` / `model` / `effort`.
+        # State names not present here keep their workflow-config defaults.
+        self._worker_overrides: dict[str, dict[str, str]] = worker_overrides or {}
 
     async def stop(self) -> None:
         """Cancel in-flight workers and kill all tmux sessions."""
@@ -392,7 +397,14 @@ class Orchestrator:
             )
             return
 
-        worker_kind = state_def.worker.kind
+        # Resolve effective worker config = workflow YAML defaults overlaid
+        # with any run-time overrides registered for this state. Overrides
+        # let the user retarget kind/model/effort per state when invoking the
+        # run, without editing the workflow.
+        override = self._worker_overrides.get(effect.state, {})
+        worker_kind = override.get("kind") or state_def.worker.kind
+        effective_model = override.get("model") or state_def.worker.model
+        effective_effort = override.get("effort") or state_def.worker.effort
         worker = self.workers.get(worker_kind)
         if worker is None:
             logger.warning(
@@ -434,9 +446,10 @@ class Orchestrator:
                 state_def.worker.prompt,
                 backoff,
                 tracking_id,
-                model=state_def.worker.model,
+                model=effective_model,
                 extra_args=state_def.worker.args,
                 prompt_inline=state_def.worker.prompt_inline,
+                effort=effective_effort,
             )
         )
         self._in_flight[task] = (effect.issue_id, tracking_id)
@@ -471,6 +484,7 @@ class Orchestrator:
         model: str | None = None,
         extra_args: tuple[str, ...] | None = None,
         prompt_inline: bool = False,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         """Wait for backoff delay, then run the worker."""
         if backoff > 0:
@@ -489,6 +503,7 @@ class Orchestrator:
             model=model,
             extra_args=extra_args,
             prompt_inline=prompt_inline,
+            effort=effort,
         )
 
     async def _run_worker(
@@ -500,6 +515,7 @@ class Orchestrator:
         model: str | None = None,
         extra_args: tuple[str, ...] | None = None,
         prompt_inline: bool = False,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         """Create worktree if needed, then execute the worker."""
         workdir = await self._ensure_worktree(effect.issue_id)
@@ -633,6 +649,7 @@ class Orchestrator:
                 on_blocked=_on_blocked,
                 on_unblocked=_on_unblocked,
                 prompt_text=prompt_text,
+                effort=effort,
             )
         finally:
             self._waiting_workers.pop(effect.issue_id, None)

--- a/src/orca/orchestrator/worker.py
+++ b/src/orca/orchestrator/worker.py
@@ -80,6 +80,7 @@ class Worker(Protocol):
         on_blocked: Callable[[str], None] | None = None,
         on_unblocked: Callable[[str], None] | None = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome: ...
 
 
@@ -91,6 +92,11 @@ class KindConfig:
     prompt_via: str  # "stdin" or "arg"
     subcommand: str | None = None
     default_args: tuple[str, ...] = ()
+    # CLI flag this kind uses for a reasoning-effort hint. None means the
+    # kind doesn't expose one — worker silently drops any configured /
+    # overridden `effort` for that kind instead of passing an unrecognised
+    # flag.
+    effort_flag: str | None = None
 
 
 KIND_REGISTRY: dict[str, KindConfig] = {
@@ -98,18 +104,23 @@ KIND_REGISTRY: dict[str, KindConfig] = {
         bin="claude",
         prompt_via="stdin",
         default_args=("--dangerously-skip-permissions", "--max-turns", "50"),
+        # claude code: effort is implicit in the model choice (opus / sonnet /
+        # haiku), no separate flag.
+        effort_flag=None,
     ),
     "opencode": KindConfig(
         bin="opencode",
         prompt_via="arg",
         subcommand="run",
         default_args=(),
+        effort_flag=None,
     ),
     "codex": KindConfig(
         bin="codex",
         prompt_via="arg",
         subcommand="exec",
         default_args=(),
+        effort_flag="--reasoning-effort",
     ),
 }
 
@@ -151,6 +162,7 @@ class CliAgentWorker:
         on_blocked: Callable[[str], None] | None = None,
         on_unblocked: Callable[[str], None] | None = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         assert pty_session is not None, "pty_session is required"
 
@@ -204,6 +216,12 @@ class CliAgentWorker:
             cmd_parts.extend(extra_args)
         if model:
             cmd_parts.extend(["--model", model])
+        # Reasoning-effort hint, only if this kind knows the flag. Kinds
+        # without `effort_flag` (e.g. claude-code) silently drop the value
+        # so workflows can declare effort once and have it apply only
+        # where it's meaningful.
+        if effort and self._kind_config.effort_flag:
+            cmd_parts.extend([self._kind_config.effort_flag, effort])
 
         # d. Spawn in tmux session
         await pty_session.spawn(

--- a/tests/cli/test_run_overrides.py
+++ b/tests/cli/test_run_overrides.py
@@ -1,0 +1,70 @@
+"""Tests for the `orca run --override` flag parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from orca.cli.run_cmd import parse_worker_overrides
+
+
+def test_no_overrides_returns_empty_dict() -> None:
+    assert parse_worker_overrides(None) == {}
+    assert parse_worker_overrides([]) == {}
+
+
+def test_single_override_parses_nested() -> None:
+    result = parse_worker_overrides(["preflight.kind=codex"])
+    assert result == {"preflight": {"kind": "codex"}}
+
+
+def test_multiple_overrides_merge_under_same_state() -> None:
+    result = parse_worker_overrides(
+        [
+            "preflight.kind=codex",
+            "preflight.model=gpt-5.5",
+            "preflight.effort=high",
+        ]
+    )
+    assert result == {
+        "preflight": {"kind": "codex", "model": "gpt-5.5", "effort": "high"},
+    }
+
+
+def test_overrides_across_multiple_states() -> None:
+    result = parse_worker_overrides(["preflight.kind=codex", "implementing.model=claude-opus-4-7"])
+    assert result == {
+        "preflight": {"kind": "codex"},
+        "implementing": {"model": "claude-opus-4-7"},
+    }
+
+
+def test_later_override_wins_for_same_field() -> None:
+    result = parse_worker_overrides(["preflight.kind=codex", "preflight.kind=claude-code"])
+    assert result == {"preflight": {"kind": "claude-code"}}
+
+
+def test_missing_equals_raises() -> None:
+    with pytest.raises(ValueError, match="<state>.<field>=<value>"):
+        parse_worker_overrides(["preflight.kind"])
+
+
+def test_missing_dot_raises() -> None:
+    with pytest.raises(ValueError, match="<state>.<field>"):
+        parse_worker_overrides(["preflight=codex"])
+
+
+def test_unknown_field_rejected() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        parse_worker_overrides(["preflight.cooldown=10"])
+
+
+def test_empty_value_rejected() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        parse_worker_overrides(["preflight.kind="])
+
+
+def test_value_can_contain_equals() -> None:
+    """Model names sometimes carry version suffixes that don't contain '=',
+    but if someone passes an unusual value the parser shouldn't choke on it."""
+    result = parse_worker_overrides(["preflight.model=foo=bar"])
+    assert result == {"preflight": {"model": "foo=bar"}}

--- a/tests/daemon/test_manager.py
+++ b/tests/daemon/test_manager.py
@@ -70,6 +70,7 @@ class MockWorker:
         on_blocked: Any = None,
         on_unblocked: Any = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         self.calls.append((effect.issue_id, effect.state))
         return self.outcomes.get(effect.state, WorkerSuccess(result={"outcome": "start"}))

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -940,3 +940,49 @@ initial: todo
         rule = cfg.types["default"].states["todo"].on["fail"]
         assert isinstance(rule, OnTransition)
         assert rule.target == "failed"
+
+
+class TestParseEffort:
+    def test_effort_field_round_trips(self) -> None:
+        yaml_str = """\
+issue:
+  fields:
+    title: { type: string, description: t }
+states:
+  preflight:
+    worker:
+      kind: codex
+      prompt: p.md
+      model: gpt-5.5
+      effort: high
+      result_format:
+        outcome: { type: enum, values: [done], description: o }
+    on:
+      done: done
+initial: preflight
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.types["default"].states["preflight"].worker
+        assert worker is not None
+        assert worker.effort == "high"
+
+    def test_effort_absent_defaults_to_none(self) -> None:
+        yaml_str = """\
+issue:
+  fields:
+    title: { type: string, description: t }
+states:
+  preflight:
+    worker:
+      kind: claude-code
+      prompt: p.md
+      result_format:
+        outcome: { type: enum, values: [done], description: o }
+    on:
+      done: done
+initial: preflight
+"""
+        cfg = parse_config(yaml_str)
+        worker = cfg.types["default"].states["preflight"].worker
+        assert worker is not None
+        assert worker.effort is None

--- a/tests/orchestrator/test_debug_e2e.py
+++ b/tests/orchestrator/test_debug_e2e.py
@@ -102,6 +102,7 @@ class MockWorker:
         on_blocked: Any = None,
         on_unblocked: Any = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         self.call_count += 1
         return self.outcome

--- a/tests/orchestrator/test_integration.py
+++ b/tests/orchestrator/test_integration.py
@@ -52,6 +52,7 @@ class ScriptedWorker:
         on_blocked: Any = None,
         on_unblocked: Any = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         key = (effect.issue_id, effect.state)
         self.calls.append(key)

--- a/tests/orchestrator/test_orchestrator.py
+++ b/tests/orchestrator/test_orchestrator.py
@@ -52,6 +52,7 @@ class MockWorker:
         on_blocked: Any = None,
         on_unblocked: Any = None,
         prompt_text: str | None = None,
+        effort: str | None = None,
     ) -> WorkerOutcome:
         self.calls.append((effect.issue_id, effect.state))
         return self.outcomes.get(effect.state, WorkerFailure(error="no mock"))
@@ -232,6 +233,7 @@ class TestOrchestrator:
                 on_blocked: Any = None,
                 on_unblocked: Any = None,
                 prompt_text: str | None = None,
+                effort: str | None = None,
             ) -> WorkerOutcome:
                 self.calls.append((effect.issue_id, effect.state))
                 count = call_count.get(effect.state, 0)

--- a/tests/orchestrator/test_worker.py
+++ b/tests/orchestrator/test_worker.py
@@ -108,6 +108,7 @@ class TestCommandAssembly:
         tmp_path: Path,
         model: str | None = None,
         extra_args: list[str] | None = None,
+        effort: str | None = None,
     ) -> tuple[str, list[str], bytes | None]:
         """Run worker with a mock pty that captures spawn args. Returns (cmd, args, stdin_data)."""
         effect = _make_effect()
@@ -126,6 +127,7 @@ class TestCommandAssembly:
             pty_session=pty,
             model=model,
             extra_args=extra_args,
+            effort=effort,
         )
         call_args = pty.spawn.call_args
         return call_args[0][0], list(call_args[0][1]), call_args[1].get("stdin_data")
@@ -179,6 +181,22 @@ class TestCommandAssembly:
         kind_config = KIND_REGISTRY["claude-code"]
         cmd, args, stdin_data = await self._spawn_and_capture(kind_config, tmp_path, model=None)
         assert "--model" not in args
+
+    async def test_codex_appends_reasoning_effort_flag(self, tmp_path: Path) -> None:
+        """codex's kind has effort_flag=--reasoning-effort; the value flows through."""
+        kind_config = KIND_REGISTRY["codex"]
+        _cmd, args, _stdin = await self._spawn_and_capture(kind_config, tmp_path, effort="high")
+        assert "--reasoning-effort" in args
+        # The value immediately follows the flag.
+        idx = args.index("--reasoning-effort")
+        assert args[idx + 1] == "high"
+
+    async def test_claude_code_drops_effort_silently(self, tmp_path: Path) -> None:
+        """claude-code has effort_flag=None — passing effort should be a no-op."""
+        kind_config = KIND_REGISTRY["claude-code"]
+        _cmd, args, _stdin = await self._spawn_and_capture(kind_config, tmp_path, effort="high")
+        assert "--reasoning-effort" not in args
+        assert "high" not in args
 
 
 @pytest.mark.asyncio()

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "orca"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Run-time per-state worker overrides — both CLI and MCP can retarget a workflow's `kind` / `model` / `effort` per state without editing the YAML.

### CLI
```
orca run task.md \
  --override preflight.kind=codex \
  --override preflight.model=gpt-5.5 \
  --override preflight.effort=high
```

### MCP \`orca_start_run\`
```
worker_overrides = {
  "preflight": {"kind": "codex", "model": "gpt-5.5", "effort": "high"},
  "implementing": {"model": "claude-opus-4-7"}
}
```

### New \`effort\` field
- Lives on \`WorkerDef\` (workflow YAML) and is overridable at runtime.
- Each \`KindConfig\` declares an optional \`effort_flag\`. Codex maps to \`--reasoning-effort\`; claude-code and opencode declare no flag, so the worker silently drops the value for those kinds.
- Workflows can declare \`effort\` once and have it apply only where it makes sense.

## Validation (at run start)
- State name in overrides must exist in the workflow's state graph
- \`kind\` value, if overridden, must be a registered agent kind
- Only \`kind\` / \`model\` / \`effort\` are accepted; unknown fields error early

## Test plan
- [x] 10 new CLI parser tests (\`tests/cli/test_run_overrides.py\`) cover single/multi-state, merging fields, later-wins, malformed entries, unknown fields, empty values, value-with-equals
- [x] 2 new config tests verify \`effort\` round-trips through YAML
- [x] 2 new worker tests confirm codex appends \`--reasoning-effort\`, claude-code drops it
- [x] Targeted suite (engine/cli/orchestrator/daemon): 437 passed, 2 skipped

## Behaviour notes
- Overrides are per-invocation, not stored on the run state. A retry / resume keeps them because they live on the in-memory orchestrator instance.
- Workers spawned by decomposition use the same workflow YAML defaults; overrides apply by state name, so all instances of a given state get the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)